### PR TITLE
perf: optimize xterm.js rendering for Linux

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -388,7 +388,7 @@ export function TerminalView(props: TerminalViewProps) {
   return (
     <div
       ref={containerRef}
-      style={{ width: "100%", height: "100%", overflow: "hidden", padding: "4px 0 0 4px" }}
+      style={{ width: "100%", height: "100%", overflow: "hidden", padding: "4px 0 0 4px", contain: "strict" }}
     />
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -571,14 +571,17 @@ textarea::placeholder {
   left: 0 !important;
 }
 
-/* Transparent terminal layers */
-.xterm,
-.xterm-viewport,
-.xterm-screen,
-.xterm-rows,
-.xterm .xterm-screen canvas {
-  background: transparent !important;
-  background-color: transparent !important;
+/* Terminal rendering performance: let xterm use its own opaque background
+   (set via theme in TerminalView) instead of forcing transparency.
+   Opaque backgrounds enable the WebGL renderer's fast path and avoid
+   per-frame alpha blending — a major win on Linux. */
+
+/* Disable ligatures in the terminal — complex text shaping (especially
+   JetBrains Mono / Fira Code ligatures) is expensive on Linux. */
+.xterm {
+  font-variant-ligatures: none;
+  -webkit-font-variant-ligatures: none;
+  text-rendering: optimizeSpeed;
 }
 
 .drop-indicator {
@@ -654,13 +657,12 @@ body.dragging-task * {
 }
 
 .shell-terminal-container .xterm {
-  opacity: 0.7;
-  transition: opacity 0.15s ease;
+  filter: opacity(0.7);
+  will-change: filter;
 }
 
 .shell-terminal-container:focus-within .xterm {
-  opacity: 1;
-  transition: opacity 0.15s ease;
+  filter: none;
 }
 
 .prompt-textarea {


### PR DESCRIPTION
- Remove blanket CSS transparency on all xterm layers — this was
  forcing alpha blending every frame and defeating the WebGL
  renderer's opaque fast path. The terminal theme already provides
  matching background colors per preset.
- Disable font ligatures (font-variant-ligatures: none) and use
  text-rendering: optimizeSpeed — ligature shaping in JetBrains Mono
  and Fira Code is expensive on Linux font stacks.
- Add CSS contain: strict to the terminal container for layout
  isolation (skips layout/paint work outside the terminal).
- Switch shell terminal dimming from CSS opacity + transition to
  filter: opacity() with will-change hint — avoids triggering a full
  compositor layer blend on every repaint.

https://claude.ai/code/session_01FtXB5R8qjM54WqwE1FLCYJ