### PR TITLE
Fix task creation reload in dev

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -51,7 +51,9 @@ function verifyPreloadAllowlist(): void {
     const preloadPath = path.join(__dirname, '..', 'electron', 'preload.cjs');
     const preloadSrc = fs.readFileSync(preloadPath, 'utf8');
     const enumValues = new Set(Object.values(IPC));
-    const missing = [...enumValues].filter((v) => !preloadSrc.includes(`"${v}"`));
+    const hasChannel = (channel: string) =>
+      preloadSrc.includes(`'${channel}'`) || preloadSrc.includes(`"${channel}"`);
+    const missing = [...enumValues].filter((v) => !hasChannel(v));
     if (missing.length > 0) {
       console.warn(
         `[preload-sync] IPC channels missing from preload.cjs ALLOWED_CHANNELS: ${missing.join(', ')}`,

--- a/electron/vite.config.electron.ts
+++ b/electron/vite.config.electron.ts
@@ -1,5 +1,9 @@
+import path from 'path';
 import { defineConfig } from 'vite';
 import solid from 'vite-plugin-solid';
+
+const rootDir = path.resolve(process.cwd());
+const parentDir = path.resolve(rootDir, '..');
 
 export default defineConfig({
   base: './',
@@ -8,5 +12,11 @@ export default defineConfig({
   server: {
     port: 1421,
     strictPort: true,
+    watch: {
+      ignored: (watchedPath) => {
+        const resolvedPath = path.resolve(watchedPath);
+        return resolvedPath.startsWith(parentDir) && !resolvedPath.startsWith(rootDir);
+      },
+    },
   },
 });

--- a/src/components/TaskStepsSection.tsx
+++ b/src/components/TaskStepsSection.tsx
@@ -303,7 +303,11 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                                 {truncate(step.detail ?? '', 280)}
                               </div>
                             </Show>
-                            <Show when={step.files_touched && step.files_touched.length > 0}>
+                            <Show
+                              when={
+                                Array.isArray(step.files_touched) && step.files_touched.length > 0
+                              }
+                            >
                               <div
                                 style={{
                                   display: 'flex',

--- a/src/components/TaskStepsSection.tsx
+++ b/src/components/TaskStepsSection.tsx
@@ -284,7 +284,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                               flex: '1',
                             }}
                           >
-                            {truncate(step.summary, 140)}
+                            {truncate(step.summary ?? '', 140)}
                           </span>
                         </div>
 
@@ -355,7 +355,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                         flex: '1',
                       }}
                     >
-                      {truncate(step().summary, 140)}
+                      {truncate(step().summary ?? '', 140)}
                     </span>
                     <Show when={step().timestamp}>
                       <span

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -2,6 +2,7 @@ import { produce } from 'solid-js/store';
 import { invoke, Channel } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { store, setStore, cleanupPanelEntries } from './core';
+import { saveState } from './persistence';
 import { setTaskFocusedPanel } from './focus';
 import { getProject, getProjectPath, getProjectBranchPrefix, isProjectMissing } from './projects';
 import { setPendingShellCommand } from '../lib/bookmarks';
@@ -181,6 +182,7 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
   };
 
   initTaskInStore(taskId, task, agent, projectId, agentDef);
+  saveState(); // fire-and-forget — errors handled internally
   return taskId;
 }
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -609,12 +609,10 @@ export function setPlanContent(
 }
 
 export function setStepsContent(taskId: string, steps: unknown[] | null): void {
-  setStore(
-    'tasks',
-    taskId,
-    'stepsContent',
-    steps && steps.length > 0 ? (steps as StepEntry[]) : undefined,
-  );
+  const valid = steps
+    ? (steps.filter((s) => s !== null && typeof s === 'object' && !Array.isArray(s)) as StepEntry[])
+    : [];
+  setStore('tasks', taskId, 'stepsContent', valid.length > 0 ? valid : undefined);
 }
 
 export function setTaskLastInputAt(taskId: string): void {


### PR DESCRIPTION
## Summary
- preserve task creation behavior during Electron dev reloads
- include the needed dev config handling in the main process and Electron Vite setup

## Testing
- not run here
