### PR TITLE
feat(layout): add flex-stretch panels and focus mode

### DIFF
--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -28,6 +28,7 @@ import {
   clearPendingAction,
   showNotification,
   collapseTask,
+  toggleFocusMode,
 } from '../store/store';
 import { ResizablePanel, type PanelChild } from './ResizablePanel';
 import { EditableText, type EditableTextHandle } from './EditableText';
@@ -344,6 +345,24 @@ export function TaskPanel(props: TaskPanelProps) {
                 </Show>
               </div>
             </Show>
+            <IconButton
+              icon={
+                store.focusMode ? (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5.5 2.75A.75.75 0 0 0 4.75 2H2.5a.5.5 0 0 0-.5.5v2.25a.75.75 0 0 0 1.5 0V3.5h1.25a.75.75 0 0 0 .75-.75ZM11.25 2a.75.75 0 0 0 0 1.5H12.5v1.25a.75.75 0 0 0 1.5 0V2.5a.5.5 0 0 0-.5-.5h-2.25ZM3.5 11.25a.75.75 0 0 0-1.5 0V13.5a.5.5 0 0 0 .5.5h2.25a.75.75 0 0 0 0-1.5H3.5v-1.25ZM14 11.25a.75.75 0 0 0-1.5 0v1.25h-1.25a.75.75 0 0 0 0 1.5H13.5a.5.5 0 0 0 .5-.5v-2.25Z" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M2.75 5.5A.75.75 0 0 0 3.5 4.75V3.5h1.25a.75.75 0 0 0 0-1.5H2.5a.5.5 0 0 0-.5.5v2.25c0 .414.336.75.75.75ZM12.5 4.75a.75.75 0 0 0 1.5 0V2.5a.5.5 0 0 0-.5-.5h-2.25a.75.75 0 0 0 0 1.5h1.25v1.25ZM3.5 11.25a.75.75 0 0 0-1.5 0V13.5a.5.5 0 0 0 .5.5h2.25a.75.75 0 0 0 0-1.5H3.5v-1.25ZM13.25 10.5a.75.75 0 0 0-.75.75v1.25h-1.25a.75.75 0 0 0 0 1.5H13.5a.5.5 0 0 0 .5-.5v-2.25a.75.75 0 0 0-.75-.75Z" />
+                  </svg>
+                )
+              }
+              onClick={() => {
+                if (!store.focusMode) setActiveTask(props.task.id);
+                toggleFocusMode();
+              }}
+              title={store.focusMode ? 'Exit focus mode' : 'Focus on this task'}
+            />
             <IconButton
               icon={
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -1,26 +1,16 @@
-import { Show, createMemo, createEffect, onMount, onCleanup, ErrorBoundary } from 'solid-js';
+import { Show, For, createMemo, createEffect, ErrorBoundary } from 'solid-js';
 import { store, pickAndAddProject, closeTerminal } from '../store/store';
 import { closeTask } from '../store/tasks';
-import { ResizablePanel, type PanelChild, type ResizablePanelHandle } from './ResizablePanel';
+import type { PanelChild } from './ResizablePanel';
 import { TaskPanel } from './TaskPanel';
 import { TerminalPanel } from './TerminalPanel';
 import { NewTaskPlaceholder } from './NewTaskPlaceholder';
+import { markDirty } from '../lib/terminalFitManager';
 import { theme } from '../lib/theme';
 import { mod } from '../lib/platform';
-import { createCtrlShiftWheelResizeHandler } from '../lib/wheelZoom';
 
 export function TilingLayout() {
   let containerRef: HTMLDivElement | undefined;
-  let panelHandle: ResizablePanelHandle | undefined;
-
-  onMount(() => {
-    if (!containerRef) return;
-    const handleWheel = createCtrlShiftWheelResizeHandler((deltaPx) => {
-      panelHandle?.resizeAll(deltaPx);
-    });
-    containerRef.addEventListener('wheel', handleWheel, { passive: false });
-    onCleanup(() => containerRef?.removeEventListener('wheel', handleWheel));
-  });
 
   // Scroll the active task panel into view when selection changes
   createEffect(() => {
@@ -28,6 +18,20 @@ export function TilingLayout() {
     if (!activeId || !containerRef) return;
     const el = containerRef.querySelector<HTMLElement>(`[data-task-id="${CSS.escape(activeId)}"]`);
     el?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'instant' });
+  });
+
+  // When switching tasks in focus mode, mark all terminals of the newly active
+  // task as dirty so they re-fit to the correct size.
+  createEffect(() => {
+    const activeId = store.activeTaskId;
+    if (!store.focusMode || !activeId) return;
+    const task = store.tasks[activeId];
+    if (task) {
+      for (const agentId of task.agentIds) markDirty(agentId);
+      for (const shellId of task.shellAgentIds) markDirty(shellId);
+    }
+    const terminal = store.terminals[activeId];
+    if (terminal) markDirty(terminal.agentId);
   });
   // Cache PanelChild objects by ID so <For> sees stable references
   // and doesn't unmount/remount panels when taskOrder changes.
@@ -48,7 +52,7 @@ export function TilingLayout() {
         cached = {
           id: panelId,
           initialSize: 520,
-          minSize: 300,
+          minSize: 520,
           content: () => {
             const task = store.tasks[panelId];
             const terminal = store.terminals[panelId];
@@ -334,15 +338,52 @@ export function TilingLayout() {
           </div>
         }
       >
-        <ResizablePanel
-          direction="horizontal"
-          children={panelChildren()}
-          fitContent
-          persistKey="tiling"
-          onHandle={(h) => {
-            panelHandle = h;
+        <div
+          style={{
+            display: 'flex',
+            'flex-direction': 'row',
+            width: '100%',
+            'min-width': '100%',
+            height: '100%',
+            position: 'relative',
           }}
-        />
+        >
+          <For each={panelChildren()}>
+            {(child) => {
+              const isPlaceholder = child.id === '__placeholder';
+              const hidden = () =>
+                store.focusMode && !isPlaceholder && child.id !== store.activeTaskId;
+              const hidePlaceholder = () => store.focusMode && isPlaceholder;
+              return (
+                <div
+                  style={{
+                    // Focus mode: stack all panels on top of each other at full size
+                    // so terminals always compute correct dimensions.
+                    // Normal mode: standard flex row layout.
+                    ...(store.focusMode && !isPlaceholder
+                      ? {
+                          position: hidden() ? 'absolute' : 'relative',
+                          inset: '0',
+                          width: '100%',
+                          height: '100%',
+                          visibility: hidden() ? 'hidden' : undefined,
+                          'pointer-events': hidden() ? 'none' : undefined,
+                        }
+                      : {
+                          flex: isPlaceholder ? '0 0 54px' : '1 1 0px',
+                          'min-width': isPlaceholder ? undefined : '520px',
+                          height: '100%',
+                          display: hidePlaceholder() ? 'none' : undefined,
+                        }),
+                    overflow: 'hidden',
+                  }}
+                >
+                  {child.content()}
+                </div>
+              );
+            }}
+          </For>
+        </div>
       </Show>
     </div>
   );

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -56,6 +56,7 @@ export const [store, setStore] = createStore<AppStore>({
     connectedClients: 0,
   },
   showArena: false,
+  focusMode: false,
 });
 
 export function updateWindowTitle(_taskName?: string): void {

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -43,6 +43,7 @@ export async function saveState(): Promise<void> {
     inactiveColumnOpacity: store.inactiveColumnOpacity,
     editorCommand: store.editorCommand || undefined,
     customAgents: store.customAgents.length > 0 ? [...store.customAgents] : undefined,
+    focusMode: store.focusMode || undefined,
   };
 
   for (const taskId of store.taskOrder) {
@@ -175,6 +176,7 @@ interface LegacyPersistedState {
   editorCommand?: unknown;
   customAgents?: unknown;
   terminals?: unknown;
+  focusMode?: unknown;
 }
 
 export async function loadState(): Promise<void> {
@@ -280,6 +282,7 @@ export async function loadState(): Promise<void> {
 
       const rawEditorCommand = raw.editorCommand;
       s.editorCommand = typeof rawEditorCommand === 'string' ? rawEditorCommand.trim() : '';
+      s.focusMode = raw.focusMode === true;
 
       // Restore custom agents
       if (Array.isArray(raw.customAgents)) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -92,6 +92,7 @@ export {
   setPanelSizes,
   toggleSidebar,
   toggleArena,
+  toggleFocusMode,
   setTerminalFont,
   setThemePreset,
   setAutoTrustFolders,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -117,6 +117,7 @@ export interface PersistedState {
   inactiveColumnOpacity?: number;
   editorCommand?: string;
   customAgents?: AgentDef[];
+  focusMode?: boolean;
 }
 
 // Panel cell IDs. Shell terminals use "shell:0", "shell:1", etc.
@@ -183,4 +184,5 @@ export interface AppStore {
   missingProjectIds: Record<string, true>;
   remoteAccess: RemoteAccess;
   showArena: boolean;
+  focusMode: boolean;
 }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -99,6 +99,10 @@ export function toggleArena(show?: boolean): void {
   setStore('showArena', show ?? !store.showArena);
 }
 
+export function toggleFocusMode(on?: boolean): void {
+  setStore('focusMode', on ?? !store.focusMode);
+}
+
 export function setWindowState(windowState: PersistedWindowState): void {
   const current = store.windowState;
   if (


### PR DESCRIPTION
## Summary

  Task panels now stretch to fill available width using flex-grow instead of fixed pixel sizes. Added a focus mode toggle button in the task title bar that shows only the active task at full  width.

  ## Description

  ### Flex-stretch layout (default)

  Panels automatically distribute available space — 1 task fills the entire width, 2 tasks split 50/50, etc. Minimum width
  (520px) is preserved; horizontal scroll appears when needed.

  <img width="800" alt="image" src="https://github.com/user-attachments/assets/98e3d67c-3270-4d98-b0cf-0852f18ecac6" />

  Minimum width is still enforced when there are many tasks:

  <img width="800" alt="image" src="https://github.com/user-attachments/assets/7f50ef68-3687-4d50-9192-0418a333d346" />

  ### Focus mode

  A new focus button in the task title bar shows only the active task at full width. Other tasks remain alive in the background  (terminals keep running). Switching tasks via sidebar or keyboard shortcuts works seamlessly while in focus mode.

  <img width="800" alt="image" src="https://github.com/user-attachments/assets/85b408b6-0082-4ab7-b8d7-5a34738fd5f5" />

  - Focus mode state is persisted across app restarts
  - Terminal resize events are fired on task switch to ensure proper redraw

  ## Check List

  - [x] New functionality includes testing. — N/A, manual UI
  testing performed
  - [x] New functionality has been documented in the README if
  applicable. — N/A, internal UI feature