### PR TITLE
feat(tasks): add configurable base branch for worktree creation and m…

### DIFF
--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -337,6 +337,7 @@ export async function createWorktree(
   branchName: string,
   symlinkDirs: string[],
   forceClean = false,
+  startPoint?: string,
 ): Promise<{ path: string; branch: string }> {
   const worktreePath = `${repoRoot}/.worktrees/${branchName}`;
 
@@ -362,7 +363,11 @@ export async function createWorktree(
   }
 
   // Create fresh worktree with new branch
-  await exec('git', ['worktree', 'add', '-b', branchName, worktreePath], { cwd: repoRoot });
+  await exec(
+    'git',
+    ['worktree', 'add', '-b', branchName, worktreePath, ...(startPoint ? [startPoint] : [])],
+    { cwd: repoRoot },
+  );
 
   // Symlink selected directories
   for (const name of symlinkDirs) {
@@ -863,11 +868,12 @@ export async function mergeTask(
   squash: boolean,
   message: string | null,
   cleanup: boolean,
+  targetBranch?: string,
 ): Promise<{ main_branch: string; lines_added: number; lines_removed: number }> {
   const lockKey = await detectRepoLockKey(projectRoot).catch(() => projectRoot);
 
   return withWorktreeLock(lockKey, async () => {
-    const mainBranch = await detectMainBranch(projectRoot);
+    const mainBranch = targetBranch ?? (await detectMainBranch(projectRoot));
     const { linesAdded, linesRemoved } = await computeBranchDiffStats(
       projectRoot,
       mainBranch,

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -131,7 +131,14 @@ export function registerAllHandlers(win: BrowserWindow): void {
     validatePath(args.projectRoot, 'projectRoot');
     assertStringArray(args.symlinkDirs, 'symlinkDirs');
     assertOptionalString(args.branchPrefix, 'branchPrefix');
-    const result = createTask(args.name, args.projectRoot, args.symlinkDirs, args.branchPrefix);
+    assertOptionalString(args.baseBranch, 'baseBranch');
+    const result = createTask(
+      args.name,
+      args.projectRoot,
+      args.symlinkDirs,
+      args.branchPrefix,
+      args.baseBranch,
+    );
     result.then((r: { id: string }) => taskNames.set(r.id, args.name)).catch(() => {});
     return result;
   });
@@ -200,7 +207,15 @@ export function registerAllHandlers(win: BrowserWindow): void {
     assertBoolean(args.squash, 'squash');
     assertOptionalString(args.message, 'message');
     assertOptionalBoolean(args.cleanup, 'cleanup');
-    return mergeTask(args.projectRoot, args.branchName, args.squash, args.message, args.cleanup);
+    assertOptionalString(args.targetBranch, 'targetBranch');
+    return mergeTask(
+      args.projectRoot,
+      args.branchName,
+      args.squash,
+      args.message,
+      args.cleanup,
+      args.targetBranch,
+    );
   });
   ipcMain.handle(IPC.GetBranchLog, (_e, args) => {
     validatePath(args.worktreePath, 'worktreePath');

--- a/electron/ipc/tasks.ts
+++ b/electron/ipc/tasks.ts
@@ -33,10 +33,11 @@ export async function createTask(
   projectRoot: string,
   symlinkDirs: string[],
   branchPrefix: string,
+  baseBranch?: string,
 ): Promise<{ id: string; branch_name: string; worktree_path: string }> {
   const prefix = sanitizeBranchPrefix(branchPrefix);
   const branchName = `${prefix}/${slug(name)}`;
-  const worktree = await createWorktree(projectRoot, branchName, symlinkDirs);
+  const worktree = await createWorktree(projectRoot, branchName, symlinkDirs, false, baseBranch);
   return {
     id: randomUUID(),
     branch_name: worktree.branch,

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -43,6 +43,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const [directMode, setDirectMode] = createSignal(false);
   const [skipPermissions, setSkipPermissions] = createSignal(false);
   const [branchPrefix, setBranchPrefix] = createSignal('');
+  const [baseBranch, setBaseBranch] = createSignal('');
   let promptRef!: HTMLTextAreaElement;
   let formRef!: HTMLFormElement;
 
@@ -105,6 +106,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     setLoading(false);
     setDirectMode(false);
     setSkipPermissions(false);
+    setBaseBranch('');
 
     void (async () => {
       if (store.availableAgents.length === 0) {
@@ -192,6 +194,32 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   createEffect(() => {
     const pid = selectedProjectId();
     setBranchPrefix(pid ? getProjectBranchPrefix(pid) : 'task');
+  });
+
+  // Auto-detect base branch when project changes
+  createEffect(() => {
+    const pid = selectedProjectId();
+    const path = pid ? getProjectPath(pid) : undefined;
+    let cancelled = false;
+
+    if (!path) {
+      setBaseBranch('');
+      return;
+    }
+
+    void (async () => {
+      try {
+        const detected = await invoke<string>(IPC.GetMainBranch, { projectRoot: path });
+        if (cancelled) return;
+        setBaseBranch((prev) => (prev === '' ? detected : prev));
+      } catch {
+        /* ignore */
+      }
+    })();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
   });
 
   // Pre-check direct mode based on project setting
@@ -298,6 +326,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
           skipPermissions: agentSupportsSkipPermissions() && skipPermissions(),
         });
       } else {
+        const bb = baseBranch().trim() || undefined;
         taskId = await createTask({
           name: n,
           agentDef: agent,
@@ -307,6 +336,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
           branchPrefixOverride: prefix,
           githubUrl: ghUrl,
           skipPermissions: agentSupportsSkipPermissions() && skipPermissions(),
+          baseBranch: bb,
         });
       }
       // Drop flow: prefill prompt without auto-sending
@@ -493,6 +523,45 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
             projectPath={selectedProjectPath()}
             onPrefixChange={setBranchPrefix}
           />
+        </Show>
+
+        <Show when={!directMode()}>
+          <div
+            data-nav-field="base-branch"
+            style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}
+          >
+            <label
+              style={{
+                'font-size': '11px',
+                color: theme.fgMuted,
+                'text-transform': 'uppercase',
+                'letter-spacing': '0.05em',
+              }}
+            >
+              Base branch{' '}
+              <span style={{ opacity: '0.5', 'text-transform': 'none' }}>(merge target)</span>
+            </label>
+            <input
+              class="input-field"
+              type="text"
+              value={baseBranch()}
+              onInput={(e) => setBaseBranch(e.currentTarget.value)}
+              placeholder="main"
+              style={{
+                background: theme.bgInput,
+                border: `1px solid ${theme.border}`,
+                'border-radius': '8px',
+                padding: '10px 14px',
+                color: theme.fg,
+                'font-size': '13px',
+                'font-family': "'JetBrains Mono', monospace",
+                outline: 'none',
+              }}
+            />
+            <span style={{ 'font-size': '11px', color: theme.fgSubtle, padding: '0 2px' }}>
+              Worktree branches from and merges back into this branch.
+            </span>
+          </div>
         </Show>
 
         <AgentSelector

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -66,6 +66,7 @@ export async function saveState(): Promise<void> {
       githubUrl: task.githubUrl,
       savedInitialPrompt: task.savedInitialPrompt,
       planFileName: task.planFileName,
+      baseBranch: task.baseBranch,
     };
   }
 
@@ -91,6 +92,7 @@ export async function saveState(): Promise<void> {
       savedInitialPrompt: task.savedInitialPrompt,
       planFileName: task.planFileName,
       collapsed: true,
+      baseBranch: task.baseBranch,
     };
   }
 
@@ -337,6 +339,7 @@ export async function loadState(): Promise<void> {
           githubUrl: pt.githubUrl,
           savedInitialPrompt: pt.savedInitialPrompt,
           planFileName: pt.planFileName,
+          baseBranch: pt.baseBranch,
         };
 
         s.tasks[taskId] = task;
@@ -404,6 +407,7 @@ export async function loadState(): Promise<void> {
           planFileName: pt.planFileName,
           collapsed: true,
           savedAgentDef: agentDef ?? undefined,
+          baseBranch: pt.baseBranch,
         };
 
         s.tasks[taskId] = task;

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -57,6 +57,7 @@ export interface CreateTaskOptions {
   branchPrefixOverride?: string;
   githubUrl?: string;
   skipPermissions?: boolean;
+  baseBranch?: string;
 }
 
 export async function createTask(opts: CreateTaskOptions): Promise<string> {
@@ -68,6 +69,7 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
     initialPrompt,
     githubUrl,
     skipPermissions,
+    baseBranch,
   } = opts;
   const projectRoot = getProjectPath(projectId);
   if (!projectRoot) throw new Error('Project not found');
@@ -79,6 +81,7 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
     projectRoot,
     symlinkDirs,
     branchPrefix,
+    baseBranch,
   });
 
   const agentId = crypto.randomUUID();
@@ -96,6 +99,7 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
     skipPermissions: skipPermissions || undefined,
     githubUrl,
     savedInitialPrompt: initialPrompt || undefined,
+    baseBranch: baseBranch || undefined,
   };
 
   const agent: Agent = {
@@ -327,6 +331,7 @@ export async function mergeTask(
     squash: options?.squash ?? false,
     message: options?.message,
     cleanup,
+    targetBranch: task.baseBranch,
   });
   recordMergedLines(mergeResult.lines_added, mergeResult.lines_removed);
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -52,6 +52,7 @@ export interface Task {
   savedAgentDef?: AgentDef;
   planContent?: string;
   planFileName?: string;
+  baseBranch?: string;
 }
 
 export interface Terminal {
@@ -77,6 +78,7 @@ export interface PersistedTask {
   savedInitialPrompt?: string;
   collapsed?: boolean;
   planFileName?: string;
+  baseBranch?: string;
 }
 
 export interface PersistedTerminal {


### PR DESCRIPTION
I wanted the ability to create worktrees from my develop branch, instead of the main branch, added this on starting the task so the merge goes back to the branch of your choice (from where you had checked it out) instead of main branch. 

- Add optional baseBranch parameter to createTask and mergeTask flows
- Add base branch input field in NewTaskDialog with auto-detection
- Pass baseBranch as startPoint to git worktree add command
- Use baseBranch as merge target instead of auto-detected main branch
- Persist baseBranch in Task and PersistedTask types
- Add validation for baseBranch parameter in IPC handlers


