### PR TITLE
Refactor TaskPanel into smaller focused components

### DIFF
--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -1,0 +1,277 @@
+import { Show, For, createSignal, onMount, onCleanup } from 'solid-js';
+import {
+  store,
+  markAgentExited,
+  restartAgent,
+  switchAgent,
+  setLastPrompt,
+  markAgentOutput,
+  getFontScale,
+  registerFocusFn,
+  setTaskFocusedPanel,
+} from '../store/store';
+import { ScalablePanel } from './ScalablePanel';
+import { InfoBar } from './InfoBar';
+import { TerminalView } from './TerminalView';
+import { theme } from '../lib/theme';
+import { sf } from '../lib/fontScale';
+import type { Task } from '../store/types';
+import type { PromptInputHandle } from './PromptInput';
+
+interface TaskAITerminalProps {
+  task: Task;
+  isActive: boolean;
+  promptHandle: PromptInputHandle | undefined;
+}
+
+export function TaskAITerminal(props: TaskAITerminalProps) {
+  const firstAgent = () => {
+    const ids = props.task.agentIds;
+    return ids.length > 0 ? store.agents[ids[0]] : undefined;
+  };
+
+  return (
+    <ScalablePanel panelId={`${props.task.id}:ai-terminal`}>
+      <div
+        class="focusable-panel shell-terminal-container"
+        data-shell-focused={
+          store.focusedPanel[props.task.id] === 'ai-terminal' ? 'true' : 'false'
+        }
+        style={{
+          height: '100%',
+          position: 'relative',
+          background: theme.taskPanelBg,
+          display: 'flex',
+          'flex-direction': 'column',
+        }}
+        onClick={() => setTaskFocusedPanel(props.task.id, 'ai-terminal')}
+      >
+        <InfoBar
+          title={
+            props.task.lastPrompt ||
+            (props.task.initialPrompt ? 'Waiting to send prompt…' : 'No prompts sent yet')
+          }
+          onDblClick={() => {
+            if (props.task.lastPrompt && props.promptHandle && !props.promptHandle.getText())
+              props.promptHandle.setText(props.task.lastPrompt);
+          }}
+        >
+          <span style={{ opacity: props.task.lastPrompt ? 1 : 0.4 }}>
+            {props.task.lastPrompt
+              ? `> ${props.task.lastPrompt}`
+              : props.task.initialPrompt
+                ? '⏳ Waiting to send prompt…'
+                : 'No prompts sent'}
+          </span>
+        </InfoBar>
+        <div style={{ flex: '1', position: 'relative', overflow: 'hidden' }}>
+          <Show when={firstAgent()}>
+            {(a) => (
+              <>
+                <Show when={a().status === 'exited'}>
+                  <div
+                    class="exit-badge"
+                    title={a().lastOutput.length ? a().lastOutput.join('\n') : undefined}
+                    style={{
+                      position: 'absolute',
+                      top: '8px',
+                      right: '12px',
+                      'z-index': '10',
+                      'font-size': sf(11),
+                      color: a().exitCode === 0 ? theme.success : theme.error,
+                      background: 'color-mix(in srgb, var(--island-bg) 80%, transparent)',
+                      padding: '4px 12px',
+                      'border-radius': '8px',
+                      border: `1px solid ${theme.border}`,
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '8px',
+                    }}
+                  >
+                    <span>
+                      {a().signal === 'spawn_failed'
+                        ? 'Failed to start'
+                        : `Process exited (${a().exitCode ?? '?'})`}
+                    </span>
+                    <AgentRestartMenu agentId={a().id} agentDefId={a().def.id} />
+                    <Show when={a().def.resume_args?.length}>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          restartAgent(a().id, true);
+                        }}
+                        style={{
+                          background: theme.bgElevated,
+                          border: `1px solid ${theme.border}`,
+                          color: theme.fg,
+                          padding: '2px 8px',
+                          'border-radius': '4px',
+                          cursor: 'pointer',
+                          'font-size': sf(10),
+                        }}
+                      >
+                        Resume
+                      </button>
+                    </Show>
+                  </div>
+                </Show>
+                <Show when={`${a().id}:${a().generation}`} keyed>
+                  <TerminalView
+                    taskId={props.task.id}
+                    agentId={a().id}
+                    isFocused={
+                      props.isActive && store.focusedPanel[props.task.id] === 'ai-terminal'
+                    }
+                    command={a().def.command}
+                    args={[
+                      ...(a().resumed && a().def.resume_args?.length
+                        ? (a().def.resume_args ?? [])
+                        : a().def.args),
+                      ...(props.task.skipPermissions && a().def.skip_permissions_args?.length
+                        ? (a().def.skip_permissions_args ?? [])
+                        : []),
+                    ]}
+                    cwd={props.task.worktreePath}
+                    dockerMode={props.task.dockerMode}
+                    dockerImage={props.task.dockerImage}
+                    onExit={(code) => markAgentExited(a().id, code)}
+                    onData={(data) => markAgentOutput(a().id, data, props.task.id)}
+                    onPromptDetected={(text) => setLastPrompt(props.task.id, text)}
+                    onReady={(focusFn) =>
+                      registerFocusFn(`${props.task.id}:ai-terminal`, focusFn)
+                    }
+                    fontSize={Math.round(13 * getFontScale(`${props.task.id}:ai-terminal`))}
+                  />
+                </Show>
+              </>
+            )}
+          </Show>
+        </div>
+      </div>
+    </ScalablePanel>
+  );
+}
+
+/** Restart/switch-agent dropdown menu shown on the exit badge. */
+function AgentRestartMenu(props: { agentId: string; agentDefId: string }) {
+  const [showAgentMenu, setShowAgentMenu] = createSignal(false);
+  let menuRef: HTMLSpanElement | undefined;
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (menuRef && !menuRef.contains(e.target as Node)) {
+      setShowAgentMenu(false);
+    }
+  };
+
+  onMount(() => document.addEventListener('mousedown', handleClickOutside));
+  onCleanup(() => document.removeEventListener('mousedown', handleClickOutside));
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex' }} ref={(el) => (menuRef = el)}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          restartAgent(props.agentId, false);
+        }}
+        style={{
+          background: theme.bgElevated,
+          border: `1px solid ${theme.border}`,
+          color: theme.fg,
+          padding: '2px 8px',
+          'border-radius': '4px 0 0 4px',
+          'border-right': 'none',
+          cursor: 'pointer',
+          'font-size': sf(10),
+        }}
+      >
+        Restart
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowAgentMenu(!showAgentMenu());
+        }}
+        style={{
+          background: theme.bgElevated,
+          border: `1px solid ${theme.border}`,
+          color: theme.fg,
+          padding: '2px 4px',
+          'border-radius': '0 4px 4px 0',
+          cursor: 'pointer',
+          'font-size': sf(10),
+        }}
+      >
+        ▾
+      </button>
+      <Show when={showAgentMenu()}>
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: '0',
+            'margin-top': '4px',
+            background: theme.bgElevated,
+            border: `1px solid ${theme.border}`,
+            'border-radius': '6px',
+            padding: '4px 0',
+            'z-index': '20',
+            'min-width': '160px',
+            'box-shadow': '0 4px 12px rgba(0,0,0,0.3)',
+          }}
+        >
+          <div
+            style={{
+              padding: '4px 10px',
+              'font-size': sf(9),
+              color: theme.fgMuted,
+            }}
+          >
+            Restart with…
+          </div>
+          <For each={store.availableAgents.filter((ag) => ag.available !== false)}>
+            {(agentDef) => (
+              <button
+                title={agentDef.description}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowAgentMenu(false);
+                  if (agentDef.id === props.agentDefId) {
+                    restartAgent(props.agentId, false);
+                  } else {
+                    switchAgent(props.agentId, agentDef);
+                  }
+                }}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  background:
+                    agentDef.id === props.agentDefId ? theme.bgSelected : 'transparent',
+                  border: 'none',
+                  color: theme.fg,
+                  padding: '5px 10px',
+                  cursor: 'pointer',
+                  'font-size': sf(10),
+                  'text-align': 'left',
+                }}
+                onMouseEnter={(e) => {
+                  if (agentDef.id !== props.agentDefId)
+                    e.currentTarget.style.background = theme.bgHover;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background =
+                    agentDef.id === props.agentDefId ? theme.bgSelected : 'transparent';
+                }}
+              >
+                {agentDef.name}
+                <Show when={agentDef.id === props.agentDefId}>
+                  {' '}
+                  <span style={{ opacity: 0.5 }}>(current)</span>
+                </Show>
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </span>
+  );
+}

--- a/src/components/TaskBranchInfoBar.tsx
+++ b/src/components/TaskBranchInfoBar.tsx
@@ -1,0 +1,188 @@
+import { Show } from 'solid-js';
+import { store, getProject, showNotification } from '../store/store';
+import { revealItemInDir, openInEditor } from '../lib/shell';
+import { InfoBar } from './InfoBar';
+import { theme } from '../lib/theme';
+import { isMac } from '../lib/platform';
+import type { Task } from '../store/types';
+
+interface TaskBranchInfoBarProps {
+  task: Task;
+  onEditProject: (projectId: string) => void;
+}
+
+export function TaskBranchInfoBar(props: TaskBranchInfoBarProps) {
+  const editorTitle = () =>
+    store.editorCommand
+      ? `Click to open in ${store.editorCommand} · ${isMac ? 'Cmd' : 'Ctrl'}+Click to reveal in file manager`
+      : 'Click to reveal in file manager';
+
+  const handleOpenInEditor = (e: MouseEvent) => {
+    if (store.editorCommand && !e.ctrlKey && !e.metaKey) {
+      openInEditor(store.editorCommand, props.task.worktreePath).catch((err) =>
+        showNotification(
+          `Editor failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+        ),
+      );
+    } else {
+      revealItemInDir(props.task.worktreePath).catch((err) =>
+        showNotification(
+          `Could not open folder: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+  };
+
+  return (
+    <InfoBar>
+      {(() => {
+        const project = getProject(props.task.projectId);
+        return (
+          <Show when={project}>
+            {(p) => (
+              <button
+                type="button"
+                onClick={() => props.onEditProject(p().id)}
+                title="Project settings"
+                style={{
+                  display: 'inline-flex',
+                  'align-items': 'center',
+                  gap: '4px',
+                  background: 'transparent',
+                  border: 'none',
+                  padding: '0 4px',
+                  margin: '0 8px 0 0',
+                  'align-self': 'stretch',
+                  color: 'inherit',
+                  cursor: 'pointer',
+                  'font-family': 'inherit',
+                  'font-size': 'inherit',
+                }}
+              >
+                <div
+                  style={{
+                    width: '7px',
+                    height: '7px',
+                    'border-radius': '50%',
+                    background: p().color,
+                    'flex-shrink': '0',
+                  }}
+                />
+                {p().name}
+              </button>
+            )}
+          </Show>
+        );
+      })()}
+      <Show when={props.task.githubUrl}>
+        {(url) => (
+          <button
+            type="button"
+            onClick={() => window.open(url(), '_blank')}
+            title={url()}
+            style={{
+              display: 'inline-flex',
+              'align-items': 'center',
+              gap: '4px',
+              'margin-right': '8px',
+              background: 'transparent',
+              border: 'none',
+              padding: '0 4px',
+              'align-self': 'stretch',
+              color: theme.accent,
+              cursor: 'pointer',
+              'font-family': 'inherit',
+              'font-size': 'inherit',
+            }}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              style={{ 'flex-shrink': '0' }}
+            >
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+            </svg>
+            {url().replace(/^https?:\/\/(www\.)?github\.com\//, '')}
+          </button>
+        )}
+      </Show>
+      <button
+        type="button"
+        title={editorTitle()}
+        onClick={handleOpenInEditor}
+        style={{
+          display: 'inline-flex',
+          'align-items': 'center',
+          gap: '4px',
+          'margin-right': '12px',
+          'align-self': 'stretch',
+          background: 'transparent',
+          border: 'none',
+          padding: '0 4px',
+          color: 'inherit',
+          cursor: 'pointer',
+          'font-family': 'inherit',
+          'font-size': 'inherit',
+        }}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          style={{ 'flex-shrink': '0' }}
+        >
+          <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
+        </svg>
+        <Show when={!props.task.directMode}>{props.task.branchName}</Show>
+        <Show when={props.task.directMode}>
+          <span
+            style={{
+              'font-size': '10px',
+              'font-weight': '600',
+              padding: '1px 6px',
+              'border-radius': '4px',
+              background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
+              color: theme.warning,
+              border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
+            }}
+          >
+            {props.task.branchName}
+          </span>
+        </Show>
+      </button>
+      <button
+        type="button"
+        title={editorTitle()}
+        onClick={handleOpenInEditor}
+        style={{
+          display: 'inline-flex',
+          'align-items': 'center',
+          gap: '4px',
+          'align-self': 'stretch',
+          background: 'transparent',
+          border: 'none',
+          padding: '0 4px',
+          color: 'inherit',
+          cursor: 'pointer',
+          opacity: 0.6,
+          'font-family': 'inherit',
+          'font-size': 'inherit',
+        }}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          style={{ 'flex-shrink': '0' }}
+        >
+          <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
+        </svg>
+        {props.task.worktreePath}
+      </button>
+    </InfoBar>
+  );
+}

--- a/src/components/TaskNotesPanel.tsx
+++ b/src/components/TaskNotesPanel.tsx
@@ -1,0 +1,261 @@
+import { Show, type Accessor } from 'solid-js';
+import { store, updateTaskNotes, setTaskFocusedPanel } from '../store/store';
+import { ResizablePanel } from './ResizablePanel';
+import { ScalablePanel } from './ScalablePanel';
+import { ChangedFilesList } from './ChangedFilesList';
+import { theme } from '../lib/theme';
+import { sf } from '../lib/fontScale';
+import type { Task } from '../store/types';
+
+interface TaskNotesPanelProps {
+  task: Task;
+  isActive: boolean;
+  notesTab: Accessor<'notes' | 'plan'>;
+  setNotesTab: (tab: 'notes' | 'plan') => void;
+  planHtml: Accessor<string>;
+  onPlanFullscreen: () => void;
+  onDiffFileClick: (path: string) => void;
+  notesRef: (el: HTMLTextAreaElement) => void;
+  planScrollRef: (el: HTMLDivElement) => void;
+  changedFilesRef: (el: HTMLDivElement) => void;
+}
+
+export function TaskNotesPanel(props: TaskNotesPanelProps) {
+  let planScrollEl: HTMLDivElement | undefined;
+
+  return (
+    <ResizablePanel
+      direction="horizontal"
+      persistKey={`task:${props.task.id}:notes-split`}
+      children={[
+        {
+          id: 'notes',
+          initialSize: 200,
+          minSize: 100,
+          content: () => (
+            <ScalablePanel panelId={`${props.task.id}:notes`}>
+              <div
+                class="focusable-panel"
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  'flex-direction': 'column',
+                }}
+                onClick={() => setTaskFocusedPanel(props.task.id, 'notes')}
+              >
+                <Show when={store.showPlans && props.task.planContent}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      'border-bottom': `1px solid ${theme.border}`,
+                      'flex-shrink': '0',
+                    }}
+                  >
+                    <button
+                      style={{
+                        padding: '2px 8px',
+                        'font-size': sf(10),
+                        background:
+                          props.notesTab() === 'notes' ? theme.taskPanelBg : 'transparent',
+                        color: props.notesTab() === 'notes' ? theme.fg : theme.fgMuted,
+                        border: 'none',
+                        'border-bottom':
+                          props.notesTab() === 'notes'
+                            ? `2px solid ${theme.accent}`
+                            : '2px solid transparent',
+                        cursor: 'pointer',
+                        'font-family': "'JetBrains Mono', monospace",
+                      }}
+                      onClick={() => props.setNotesTab('notes')}
+                    >
+                      Notes
+                    </button>
+                    <button
+                      style={{
+                        padding: '2px 8px',
+                        'font-size': sf(10),
+                        background:
+                          props.notesTab() === 'plan' ? theme.taskPanelBg : 'transparent',
+                        color: props.notesTab() === 'plan' ? theme.fg : theme.fgMuted,
+                        border: 'none',
+                        'border-bottom':
+                          props.notesTab() === 'plan'
+                            ? `2px solid ${theme.accent}`
+                            : '2px solid transparent',
+                        cursor: 'pointer',
+                        'font-family': "'JetBrains Mono', monospace",
+                      }}
+                      onClick={() => props.setNotesTab('plan')}
+                    >
+                      Plan
+                    </button>
+                  </div>
+                </Show>
+
+                <Show
+                  when={
+                    props.notesTab() === 'notes' || !store.showPlans || !props.task.planContent
+                  }
+                >
+                  <textarea
+                    ref={(el) => props.notesRef(el)}
+                    value={props.task.notes}
+                    onInput={(e) => updateTaskNotes(props.task.id, e.currentTarget.value)}
+                    placeholder="Notes..."
+                    style={{
+                      width: '100%',
+                      flex: '1',
+                      background: theme.taskPanelBg,
+                      border: 'none',
+                      padding: '6px 8px',
+                      color: theme.fg,
+                      'font-size': sf(11),
+                      'font-family': "'JetBrains Mono', monospace",
+                      resize: 'none',
+                      outline: 'none',
+                    }}
+                  />
+                </Show>
+
+                <Show
+                  when={
+                    props.notesTab() === 'plan' && store.showPlans && props.task.planContent
+                  }
+                >
+                  <div
+                    style={{
+                      flex: '1',
+                      overflow: 'hidden',
+                      display: 'flex',
+                      'flex-direction': 'column',
+                      position: 'relative',
+                    }}
+                  >
+                    <div
+                      ref={(el) => {
+                        planScrollEl = el;
+                        props.planScrollRef(el);
+                      }}
+                      tabIndex={0}
+                      class="plan-markdown"
+                      style={{
+                        flex: '1',
+                        overflow: 'auto',
+                        padding: '6px 8px',
+                        background: theme.taskPanelBg,
+                        color: theme.fg,
+                        'font-size': sf(11),
+                        'font-family': "'JetBrains Mono', monospace",
+                        outline: 'none',
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          props.onPlanFullscreen();
+                          return;
+                        }
+                        if (!planScrollEl) return;
+                        const step = 40;
+                        const page = Math.max(100, planScrollEl.clientHeight - 40);
+                        switch (e.key) {
+                          case 'ArrowDown':
+                            e.preventDefault();
+                            planScrollEl.scrollTop += step;
+                            break;
+                          case 'ArrowUp':
+                            e.preventDefault();
+                            planScrollEl.scrollTop -= step;
+                            break;
+                          case 'PageDown':
+                            e.preventDefault();
+                            planScrollEl.scrollTop += page;
+                            break;
+                          case 'PageUp':
+                            e.preventDefault();
+                            planScrollEl.scrollTop -= page;
+                            break;
+                          case 'Home':
+                            e.preventDefault();
+                            planScrollEl.scrollTop = 0;
+                            break;
+                          case 'End':
+                            e.preventDefault();
+                            planScrollEl.scrollTop = planScrollEl.scrollHeight;
+                            break;
+                        }
+                      }}
+                      // eslint-disable-next-line solid/no-innerhtml -- plan files are local, written by Claude Code in the worktree
+                      innerHTML={props.planHtml()}
+                    />
+                    <button
+                      class="btn-secondary review-plan-btn"
+                      style={{
+                        position: 'absolute',
+                        bottom: '8px',
+                        right: '8px',
+                        padding: '4px 16px',
+                        'font-size': sf(11),
+                        'font-family': "'JetBrains Mono', monospace",
+                        background: `color-mix(in srgb, ${theme.accent} 12%, ${theme.bgInput})`,
+                        color: theme.fg,
+                        border: `1px solid color-mix(in srgb, ${theme.accent} 25%, ${theme.border})`,
+                        'border-radius': '6px',
+                        cursor: 'pointer',
+                        'z-index': '1',
+                      }}
+                      onClick={() => props.onPlanFullscreen()}
+                    >
+                      Review Plan
+                    </button>
+                  </div>
+                </Show>
+              </div>
+            </ScalablePanel>
+          ),
+        },
+        {
+          id: 'changed-files',
+          initialSize: 200,
+          minSize: 100,
+          content: () => (
+            <ScalablePanel panelId={`${props.task.id}:changed-files`}>
+              <div
+                style={{
+                  height: '100%',
+                  background: theme.taskPanelBg,
+                  display: 'flex',
+                  'flex-direction': 'column',
+                }}
+                onClick={() => setTaskFocusedPanel(props.task.id, 'changed-files')}
+              >
+                <div
+                  style={{
+                    padding: '4px 8px',
+                    'font-size': sf(10),
+                    'font-weight': '600',
+                    color: theme.fgMuted,
+                    'text-transform': 'uppercase',
+                    'letter-spacing': '0.05em',
+                    'border-bottom': `1px solid ${theme.border}`,
+                    'flex-shrink': '0',
+                  }}
+                >
+                  Changed Files
+                </div>
+                <div style={{ flex: '1', overflow: 'hidden' }}>
+                  <ChangedFilesList
+                    worktreePath={props.task.worktreePath}
+                    isActive={props.isActive}
+                    onFileClick={(file) => props.onDiffFileClick(file.path)}
+                    ref={(el) => props.changedFilesRef(el)}
+                  />
+                </div>
+              </div>
+            </ScalablePanel>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -1,42 +1,21 @@
-import { Show, For, createSignal, createEffect, onMount, onCleanup } from 'solid-js';
-import { createStore } from 'solid-js/store';
-import { revealItemInDir, openInEditor } from '../lib/shell';
+import { Show, createSignal, createEffect, onMount, onCleanup } from 'solid-js';
 import {
   store,
   retryCloseTask,
   setActiveTask,
-  markAgentExited,
-  restartAgent,
-  switchAgent,
-  updateTaskName,
-  updateTaskNotes,
-  spawnShellForTask,
-  runBookmarkInTask,
-  closeShell,
-  setLastPrompt,
   clearInitialPrompt,
   clearPrefillPrompt,
   getProject,
-  reorderTask,
-  getFontScale,
-  getTaskDotStatus,
-  markAgentOutput,
   registerFocusFn,
   unregisterFocusFn,
   setTaskFocusedPanel,
   triggerFocus,
   clearPendingAction,
   showNotification,
-  collapseTask,
 } from '../store/store';
 import { ResizablePanel, type PanelChild } from './ResizablePanel';
-import { EditableText, type EditableTextHandle } from './EditableText';
-import { IconButton } from './IconButton';
-import { InfoBar } from './InfoBar';
+import type { EditableTextHandle } from './EditableText';
 import { PromptInput, type PromptInputHandle } from './PromptInput';
-import { ChangedFilesList } from './ChangedFilesList';
-import { StatusDot } from './StatusDot';
-import { TerminalView } from './TerminalView';
 import { ScalablePanel } from './ScalablePanel';
 import { CloseTaskDialog } from './CloseTaskDialog';
 import { MergeDialog } from './MergeDialog';
@@ -44,11 +23,12 @@ import { PushDialog } from './PushDialog';
 import { DiffViewerDialog } from './DiffViewerDialog';
 import { PlanViewerDialog } from './PlanViewerDialog';
 import { EditProjectDialog } from './EditProjectDialog';
+import { TaskTitleBar } from './TaskTitleBar';
+import { TaskBranchInfoBar } from './TaskBranchInfoBar';
+import { TaskNotesPanel } from './TaskNotesPanel';
+import { TaskShellSection } from './TaskShellSection';
+import { TaskAITerminal } from './TaskAITerminal';
 import { theme } from '../lib/theme';
-import { sf } from '../lib/fontScale';
-import { mod, isMac } from '../lib/platform';
-import { extractLabel, consumePendingShellCommand } from '../lib/bookmarks';
-import { handleDragReorder } from '../lib/dragReorder';
 import { createHighlightedMarkdown } from '../lib/marked-shiki';
 import type { Task } from '../store/types';
 
@@ -83,21 +63,14 @@ export function TaskPanel(props: TaskPanelProps) {
   onCleanup(() => clearTimeout(pushSuccessTimer));
   const [diffScrollTarget, setDiffScrollTarget] = createSignal<string | null>(null);
   const [editingProjectId, setEditingProjectId] = createSignal<string | null>(null);
-  const [shellExits, setShellExits] = createStore<
-    Record<string, { exitCode: number | null; signal: string | null }>
-  >({});
   let panelRef!: HTMLDivElement;
   let promptRef: HTMLTextAreaElement | undefined;
   let notesRef: HTMLTextAreaElement | undefined;
-  let reviewPlanBtnRef: HTMLButtonElement | undefined;
   let planScrollRef: HTMLDivElement | undefined;
   let changedFilesRef: HTMLDivElement | undefined;
-  let shellToolbarRef: HTMLDivElement | undefined;
   let titleEditHandle: EditableTextHandle | undefined;
   let promptHandle: PromptInputHandle | undefined;
-  const [shellToolbarIdx, setShellToolbarIdx] = createSignal(0);
-  const [shellToolbarFocused, setShellToolbarFocused] = createSignal(false);
-  const projectBookmarks = () => getProject(props.task.projectId)?.terminalBookmarks ?? [];
+
   const editingProject = () => {
     const id = editingProjectId();
     return id ? (getProject(id) ?? null) : null;
@@ -119,40 +92,13 @@ export function TaskPanel(props: TaskPanelProps) {
       changedFilesRef?.focus();
     });
     registerFocusFn(`${id}:prompt`, () => promptRef?.focus());
-    // shell-toolbar:N focus fns are registered reactively below
-    // Individual shell:N and ai-terminal focus fns are registered via TerminalView.onReady
 
     onCleanup(() => {
       unregisterFocusFn(`${id}:title`);
       unregisterFocusFn(`${id}:notes`);
       unregisterFocusFn(`${id}:changed-files`);
-      // shell-toolbar:N cleanup is handled by the reactive effect below
-      // Individual shell:N focus fns are cleaned up by their own onCleanup
       unregisterFocusFn(`${id}:ai-terminal`);
       unregisterFocusFn(`${id}:prompt`);
-    });
-  });
-
-  // Reactively register shell-toolbar:N focus fns (count changes with bookmarks)
-  createEffect(() => {
-    const id = props.task.id;
-    const count = 1 + projectBookmarks().length;
-    // Clamp toolbar index when bookmarks are removed
-    if (shellToolbarIdx() >= count) {
-      setShellToolbarIdx(count - 1);
-    }
-    // Register new set
-    for (let n = 0; n < count; n++) {
-      const idx = n; // capture for closure
-      registerFocusFn(`${id}:shell-toolbar:${idx}`, () => {
-        setShellToolbarIdx(idx);
-        shellToolbarRef?.focus();
-      });
-    }
-    onCleanup(() => {
-      for (let i = 0; i < count; i++) {
-        unregisterFocusFn(`${id}:shell-toolbar:${i}`);
-      }
     });
   });
 
@@ -165,7 +111,7 @@ export function TaskPanel(props: TaskPanelProps) {
     }
   });
 
-  // Auto-focus prompt when task first becomes active (if no panel set yet)
+  // Auto-focus prompt when task first becomes active
   let autoFocusTimer: ReturnType<typeof setTimeout> | undefined;
   onCleanup(() => {
     if (autoFocusTimer !== undefined) clearTimeout(autoFocusTimer);
@@ -176,7 +122,6 @@ export function TaskPanel(props: TaskPanelProps) {
       if (autoFocusTimer !== undefined) clearTimeout(autoFocusTimer);
       autoFocusTimer = setTimeout(() => {
         autoFocusTimer = undefined;
-        // Only focus prompt if no panel was set in the meantime
         if (!store.focusedPanel[id] && !panelRef.contains(document.activeElement)) {
           promptRef?.focus();
         }
@@ -202,21 +147,7 @@ export function TaskPanel(props: TaskPanelProps) {
     }
   });
 
-  const firstAgent = () => {
-    const ids = props.task.agentIds;
-    return ids.length > 0 ? store.agents[ids[0]] : undefined;
-  };
-
   const firstAgentId = () => props.task.agentIds[0] ?? '';
-
-  function handleTitleMouseDown(e: MouseEvent) {
-    handleDragReorder(e, {
-      itemId: props.task.id,
-      getTaskOrder: () => store.taskOrder,
-      onReorder: reorderTask,
-      onTap: () => setActiveTask(props.task.id),
-    });
-  }
 
   function titleBar(): PanelChild {
     return {
@@ -224,340 +155,30 @@ export function TaskPanel(props: TaskPanelProps) {
       initialSize: 50,
       fixed: true,
       content: () => (
-        <div
-          class={props.isActive ? 'island-header-active' : ''}
-          style={{
-            display: 'flex',
-            'align-items': 'center',
-            'justify-content': 'space-between',
-            padding: '0 10px',
-            height: '100%',
-            background: 'transparent',
-            'border-bottom': `1px solid ${theme.border}`,
-            'user-select': 'none',
-            cursor: 'grab',
-          }}
-          onMouseDown={handleTitleMouseDown}
-        >
-          <div
-            style={{
-              overflow: 'hidden',
-              flex: '1',
-              'min-width': '0',
-              display: 'flex',
-              'align-items': 'center',
-              gap: '8px',
-            }}
-          >
-            <StatusDot status={getTaskDotStatus(props.task.id)} size="md" />
-            <Show when={props.task.directMode}>
-              <span
-                style={{
-                  'font-size': '11px',
-                  'font-weight': '600',
-                  padding: '2px 8px',
-                  'border-radius': '4px',
-                  background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
-                  color: theme.warning,
-                  border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
-                  'flex-shrink': '0',
-                  'white-space': 'nowrap',
-                }}
-              >
-                {props.task.branchName}
-              </span>
-            </Show>
-            <Show when={props.task.dockerMode}>
-              <span
-                style={{
-                  'font-size': '11px',
-                  'font-weight': '600',
-                  padding: '2px 8px',
-                  'border-radius': '4px',
-                  background: `color-mix(in srgb, ${theme.fgMuted} 15%, transparent)`,
-                  color: theme.fgMuted,
-                  border: `1px solid color-mix(in srgb, ${theme.fgMuted} 25%, transparent)`,
-                  'flex-shrink': '0',
-                  'white-space': 'nowrap',
-                }}
-              >
-                Docker
-              </span>
-            </Show>
-            <EditableText
-              value={props.task.name}
-              onCommit={(v) => updateTaskName(props.task.id, v)}
-              class="editable-text"
-              title={props.task.savedInitialPrompt}
-              ref={(h) => (titleEditHandle = h)}
-            />
-          </div>
-          <div style={{ display: 'flex', gap: '4px', 'margin-left': '8px', 'flex-shrink': '0' }}>
-            <Show when={!props.task.directMode}>
-              <IconButton
-                icon={
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
-                  </svg>
-                }
-                onClick={() => setShowMergeConfirm(true)}
-                title="Merge into main"
-              />
-              <div style={{ position: 'relative', display: 'inline-flex' }}>
-                <Show
-                  when={!pushing()}
-                  fallback={
-                    <div
-                      style={{
-                        display: 'inline-flex',
-                        'align-items': 'center',
-                        'justify-content': 'center',
-                        padding: '4px',
-                        border: `1px solid ${theme.border}`,
-                        'border-radius': '6px',
-                      }}
-                    >
-                      <span class="inline-spinner" style={{ width: '14px', height: '14px' }} />
-                    </div>
-                  }
-                >
-                  <IconButton
-                    icon={
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                        <path
-                          d="M4.75 8a.75.75 0 0 1 .75-.75h5.19L8.22 4.78a.75.75 0 0 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.47-2.47H5.5A.75.75 0 0 1 4.75 8Z"
-                          transform="rotate(-90 8 8)"
-                        />
-                      </svg>
-                    }
-                    onClick={() => setShowPushConfirm(true)}
-                    title="Push to remote"
-                  />
-                </Show>
-                <Show when={pushSuccess()}>
-                  <div
-                    style={{
-                      position: 'absolute',
-                      bottom: '-4px',
-                      right: '-4px',
-                      width: '12px',
-                      height: '12px',
-                      'border-radius': '50%',
-                      background: theme.success,
-                      display: 'flex',
-                      'align-items': 'center',
-                      'justify-content': 'center',
-                      'pointer-events': 'none',
-                    }}
-                  >
-                    <svg width="8" height="8" viewBox="0 0 16 16" fill="white">
-                      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
-                    </svg>
-                  </div>
-                </Show>
-              </div>
-            </Show>
-            <IconButton
-              icon={
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M2 8a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 8Z" />
-                </svg>
-              }
-              onClick={() => collapseTask(props.task.id)}
-              title="Collapse task"
-            />
-            <IconButton
-              icon={
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                </svg>
-              }
-              onClick={() => setShowCloseConfirm(true)}
-              title="Close task"
-            />
-          </div>
-        </div>
+        <TaskTitleBar
+          task={props.task}
+          isActive={props.isActive}
+          onClose={() => setShowCloseConfirm(true)}
+          onMerge={() => setShowMergeConfirm(true)}
+          onPush={() => setShowPushConfirm(true)}
+          pushing={pushing()}
+          pushSuccess={pushSuccess()}
+          onTitleEditRef={(h) => (titleEditHandle = h)}
+        />
       ),
     };
   }
 
   function branchInfoBar(): PanelChild {
-    const editorTitle = () =>
-      store.editorCommand
-        ? `Click to open in ${store.editorCommand} · ${isMac ? 'Cmd' : 'Ctrl'}+Click to reveal in file manager`
-        : 'Click to reveal in file manager';
-
-    const handleOpenInEditor = (e: MouseEvent) => {
-      if (store.editorCommand && !e.ctrlKey && !e.metaKey) {
-        openInEditor(store.editorCommand, props.task.worktreePath).catch((err) =>
-          showNotification(
-            `Editor failed: ${err instanceof Error ? err.message : 'unknown error'}`,
-          ),
-        );
-      } else {
-        revealItemInDir(props.task.worktreePath).catch((err) =>
-          showNotification(
-            `Could not open folder: ${err instanceof Error ? err.message : String(err)}`,
-          ),
-        );
-      }
-    };
-
     return {
       id: 'branch',
       initialSize: 28,
       fixed: true,
       content: () => (
-        <InfoBar>
-          {(() => {
-            const project = getProject(props.task.projectId);
-            return (
-              <Show when={project}>
-                {(p) => (
-                  <button
-                    type="button"
-                    onClick={() => setEditingProjectId(p().id)}
-                    title="Project settings"
-                    style={{
-                      display: 'inline-flex',
-                      'align-items': 'center',
-                      gap: '4px',
-                      background: 'transparent',
-                      border: 'none',
-                      padding: '0 4px',
-                      margin: '0 8px 0 0',
-                      'align-self': 'stretch',
-                      color: 'inherit',
-                      cursor: 'pointer',
-                      'font-family': 'inherit',
-                      'font-size': 'inherit',
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: '7px',
-                        height: '7px',
-                        'border-radius': '50%',
-                        background: p().color,
-                        'flex-shrink': '0',
-                      }}
-                    />
-                    {p().name}
-                  </button>
-                )}
-              </Show>
-            );
-          })()}
-          <Show when={props.task.githubUrl}>
-            {(url) => (
-              <button
-                type="button"
-                onClick={() => window.open(url(), '_blank')}
-                title={url()}
-                style={{
-                  display: 'inline-flex',
-                  'align-items': 'center',
-                  gap: '4px',
-                  'margin-right': '8px',
-                  background: 'transparent',
-                  border: 'none',
-                  padding: '0 4px',
-                  'align-self': 'stretch',
-                  color: theme.accent,
-                  cursor: 'pointer',
-                  'font-family': 'inherit',
-                  'font-size': 'inherit',
-                }}
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 16 16"
-                  fill="currentColor"
-                  style={{ 'flex-shrink': '0' }}
-                >
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
-                </svg>
-                {url().replace(/^https?:\/\/(www\.)?github\.com\//, '')}
-              </button>
-            )}
-          </Show>
-          <button
-            type="button"
-            title={editorTitle()}
-            onClick={handleOpenInEditor}
-            style={{
-              display: 'inline-flex',
-              'align-items': 'center',
-              gap: '4px',
-              'margin-right': '12px',
-              'align-self': 'stretch',
-              background: 'transparent',
-              border: 'none',
-              padding: '0 4px',
-              color: 'inherit',
-              cursor: 'pointer',
-              'font-family': 'inherit',
-              'font-size': 'inherit',
-            }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              style={{ 'flex-shrink': '0' }}
-            >
-              <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
-            </svg>
-            <Show when={!props.task.directMode}>{props.task.branchName}</Show>
-            <Show when={props.task.directMode}>
-              <span
-                style={{
-                  'font-size': '10px',
-                  'font-weight': '600',
-                  padding: '1px 6px',
-                  'border-radius': '4px',
-                  background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
-                  color: theme.warning,
-                  border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
-                }}
-              >
-                {props.task.branchName}
-              </span>
-            </Show>
-          </button>
-          <button
-            type="button"
-            title={editorTitle()}
-            onClick={handleOpenInEditor}
-            style={{
-              display: 'inline-flex',
-              'align-items': 'center',
-              gap: '4px',
-              'align-self': 'stretch',
-              background: 'transparent',
-              border: 'none',
-              padding: '0 4px',
-              color: 'inherit',
-              cursor: 'pointer',
-              opacity: 0.6,
-              'font-family': 'inherit',
-              'font-size': 'inherit',
-            }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              style={{ 'flex-shrink': '0' }}
-            >
-              <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
-            </svg>
-            {props.task.worktreePath}
-          </button>
-        </InfoBar>
+        <TaskBranchInfoBar
+          task={props.task}
+          onEditProject={(id) => setEditingProjectId(id)}
+        />
       ),
     };
   }
@@ -568,228 +189,17 @@ export function TaskPanel(props: TaskPanelProps) {
       initialSize: 150,
       minSize: 60,
       content: () => (
-        <ResizablePanel
-          direction="horizontal"
-          persistKey={`task:${props.task.id}:notes-split`}
-          children={[
-            {
-              id: 'notes',
-              initialSize: 200,
-              minSize: 100,
-              content: () => (
-                <ScalablePanel panelId={`${props.task.id}:notes`}>
-                  <div
-                    class="focusable-panel"
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      display: 'flex',
-                      'flex-direction': 'column',
-                    }}
-                    onClick={() => setTaskFocusedPanel(props.task.id, 'notes')}
-                  >
-                    <Show when={store.showPlans && props.task.planContent}>
-                      <div
-                        style={{
-                          display: 'flex',
-                          'border-bottom': `1px solid ${theme.border}`,
-                          'flex-shrink': '0',
-                        }}
-                      >
-                        <button
-                          style={{
-                            padding: '2px 8px',
-                            'font-size': sf(10),
-                            background: notesTab() === 'notes' ? theme.taskPanelBg : 'transparent',
-                            color: notesTab() === 'notes' ? theme.fg : theme.fgMuted,
-                            border: 'none',
-                            'border-bottom':
-                              notesTab() === 'notes'
-                                ? `2px solid ${theme.accent}`
-                                : '2px solid transparent',
-                            cursor: 'pointer',
-                            'font-family': "'JetBrains Mono', monospace",
-                          }}
-                          onClick={() => setNotesTab('notes')}
-                        >
-                          Notes
-                        </button>
-                        <button
-                          style={{
-                            padding: '2px 8px',
-                            'font-size': sf(10),
-                            background: notesTab() === 'plan' ? theme.taskPanelBg : 'transparent',
-                            color: notesTab() === 'plan' ? theme.fg : theme.fgMuted,
-                            border: 'none',
-                            'border-bottom':
-                              notesTab() === 'plan'
-                                ? `2px solid ${theme.accent}`
-                                : '2px solid transparent',
-                            cursor: 'pointer',
-                            'font-family': "'JetBrains Mono', monospace",
-                          }}
-                          onClick={() => setNotesTab('plan')}
-                        >
-                          Plan
-                        </button>
-                      </div>
-                    </Show>
-
-                    <Show
-                      when={notesTab() === 'notes' || !store.showPlans || !props.task.planContent}
-                    >
-                      <textarea
-                        ref={notesRef}
-                        value={props.task.notes}
-                        onInput={(e) => updateTaskNotes(props.task.id, e.currentTarget.value)}
-                        placeholder="Notes..."
-                        style={{
-                          width: '100%',
-                          flex: '1',
-                          background: theme.taskPanelBg,
-                          border: 'none',
-                          padding: '6px 8px',
-                          color: theme.fg,
-                          'font-size': sf(11),
-                          'font-family': "'JetBrains Mono', monospace",
-                          resize: 'none',
-                          outline: 'none',
-                        }}
-                      />
-                    </Show>
-
-                    <Show when={notesTab() === 'plan' && store.showPlans && props.task.planContent}>
-                      <div
-                        style={{
-                          flex: '1',
-                          overflow: 'hidden',
-                          display: 'flex',
-                          'flex-direction': 'column',
-                          position: 'relative',
-                        }}
-                      >
-                        <div
-                          ref={planScrollRef}
-                          tabIndex={0}
-                          class="plan-markdown"
-                          style={{
-                            flex: '1',
-                            overflow: 'auto',
-                            padding: '6px 8px',
-                            background: theme.taskPanelBg,
-                            color: theme.fg,
-                            'font-size': sf(11),
-                            'font-family': "'JetBrains Mono', monospace",
-                            outline: 'none',
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              e.preventDefault();
-                              setPlanFullscreen(true);
-                              return;
-                            }
-                            if (!planScrollRef) return;
-                            const step = 40;
-                            const page = Math.max(100, planScrollRef.clientHeight - 40);
-                            switch (e.key) {
-                              case 'ArrowDown':
-                                e.preventDefault();
-                                planScrollRef.scrollTop += step;
-                                break;
-                              case 'ArrowUp':
-                                e.preventDefault();
-                                planScrollRef.scrollTop -= step;
-                                break;
-                              case 'PageDown':
-                                e.preventDefault();
-                                planScrollRef.scrollTop += page;
-                                break;
-                              case 'PageUp':
-                                e.preventDefault();
-                                planScrollRef.scrollTop -= page;
-                                break;
-                              case 'Home':
-                                e.preventDefault();
-                                planScrollRef.scrollTop = 0;
-                                break;
-                              case 'End':
-                                e.preventDefault();
-                                planScrollRef.scrollTop = planScrollRef.scrollHeight;
-                                break;
-                            }
-                          }}
-                          // eslint-disable-next-line solid/no-innerhtml -- plan files are local, written by Claude Code in the worktree
-                          innerHTML={planHtml()}
-                        />
-                        <button
-                          ref={reviewPlanBtnRef}
-                          class="btn-secondary review-plan-btn"
-                          style={{
-                            position: 'absolute',
-                            bottom: '8px',
-                            right: '8px',
-                            padding: '4px 16px',
-                            'font-size': sf(11),
-                            'font-family': "'JetBrains Mono', monospace",
-                            background: `color-mix(in srgb, ${theme.accent} 12%, ${theme.bgInput})`,
-                            color: theme.fg,
-                            border: `1px solid color-mix(in srgb, ${theme.accent} 25%, ${theme.border})`,
-                            'border-radius': '6px',
-                            cursor: 'pointer',
-                            'z-index': '1',
-                          }}
-                          onClick={() => setPlanFullscreen(true)}
-                        >
-                          Review Plan
-                        </button>
-                      </div>
-                    </Show>
-                  </div>
-                </ScalablePanel>
-              ),
-            },
-            {
-              id: 'changed-files',
-              initialSize: 200,
-              minSize: 100,
-              content: () => (
-                <ScalablePanel panelId={`${props.task.id}:changed-files`}>
-                  <div
-                    style={{
-                      height: '100%',
-                      background: theme.taskPanelBg,
-                      display: 'flex',
-                      'flex-direction': 'column',
-                    }}
-                    onClick={() => setTaskFocusedPanel(props.task.id, 'changed-files')}
-                  >
-                    <div
-                      style={{
-                        padding: '4px 8px',
-                        'font-size': sf(10),
-                        'font-weight': '600',
-                        color: theme.fgMuted,
-                        'text-transform': 'uppercase',
-                        'letter-spacing': '0.05em',
-                        'border-bottom': `1px solid ${theme.border}`,
-                        'flex-shrink': '0',
-                      }}
-                    >
-                      Changed Files
-                    </div>
-                    <div style={{ flex: '1', overflow: 'hidden' }}>
-                      <ChangedFilesList
-                        worktreePath={props.task.worktreePath}
-                        isActive={props.isActive}
-                        onFileClick={(file) => setDiffScrollTarget(file.path)}
-                        ref={(el) => (changedFilesRef = el)}
-                      />
-                    </div>
-                  </div>
-                </ScalablePanel>
-              ),
-            },
-          ]}
+        <TaskNotesPanel
+          task={props.task}
+          isActive={props.isActive}
+          notesTab={notesTab}
+          setNotesTab={setNotesTab}
+          planHtml={planHtml}
+          onPlanFullscreen={() => setPlanFullscreen(true)}
+          onDiffFileClick={(path) => setDiffScrollTarget(path)}
+          notesRef={(el) => (notesRef = el)}
+          planScrollRef={(el) => (planScrollRef = el)}
+          changedFilesRef={(el) => (changedFilesRef = el)}
         />
       ),
     };
@@ -805,234 +215,10 @@ export function TaskPanel(props: TaskPanelProps) {
       },
       requestSize: () => (props.task.shellAgentIds.length > 0 ? 200 : 28),
       content: () => (
-        <ScalablePanel panelId={`${props.task.id}:shell`}>
-          <div
-            style={{
-              height: '100%',
-              display: 'flex',
-              'flex-direction': 'column',
-              background: 'transparent',
-            }}
-          >
-            <div
-              ref={shellToolbarRef}
-              class="focusable-panel shell-toolbar-panel"
-              tabIndex={0}
-              onClick={() =>
-                setTaskFocusedPanel(props.task.id, `shell-toolbar:${shellToolbarIdx()}`)
-              }
-              onFocus={() => setShellToolbarFocused(true)}
-              onBlur={() => setShellToolbarFocused(false)}
-              onKeyDown={(e) => {
-                // Alt+Arrow is handled by global shortcuts (grid navigation)
-                if (e.altKey) return;
-                const itemCount = 1 + projectBookmarks().length;
-                if (e.key === 'ArrowRight') {
-                  e.preventDefault();
-                  const next = Math.min(itemCount - 1, shellToolbarIdx() + 1);
-                  setShellToolbarIdx(next);
-                  setTaskFocusedPanel(props.task.id, `shell-toolbar:${next}`);
-                } else if (e.key === 'ArrowLeft') {
-                  e.preventDefault();
-                  const next = Math.max(0, shellToolbarIdx() - 1);
-                  setShellToolbarIdx(next);
-                  setTaskFocusedPanel(props.task.id, `shell-toolbar:${next}`);
-                } else if (e.key === 'Enter') {
-                  e.preventDefault();
-                  const idx = shellToolbarIdx();
-                  if (idx === 0) {
-                    spawnShellForTask(props.task.id);
-                  } else {
-                    const bm = projectBookmarks()[idx - 1];
-                    if (bm) runBookmarkInTask(props.task.id, bm.command);
-                  }
-                }
-              }}
-              style={{
-                height: '28px',
-                'min-height': '28px',
-                display: 'flex',
-                'align-items': 'center',
-                padding: '0 8px',
-                background: 'transparent',
-                gap: '4px',
-                outline: 'none',
-              }}
-            >
-              <button
-                class="icon-btn"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  spawnShellForTask(props.task.id);
-                }}
-                tabIndex={-1}
-                title={`Open terminal (${mod}+Shift+T)`}
-                style={{
-                  background: theme.taskPanelBg,
-                  border: `1px solid ${shellToolbarIdx() === 0 && shellToolbarFocused() ? theme.accent : theme.border}`,
-                  color: theme.fgMuted,
-                  cursor: 'pointer',
-                  'border-radius': '4px',
-                  padding: '4px 12px',
-                  'font-size': sf(13),
-                  'line-height': '1',
-                  display: 'flex',
-                  'align-items': 'center',
-                  gap: '4px',
-                }}
-              >
-                <span style={{ 'font-family': 'monospace', 'font-size': sf(13) }}>&gt;_</span>
-                <span>Terminal</span>
-              </button>
-              <For each={projectBookmarks()}>
-                {(bookmark, i) => (
-                  <button
-                    class="icon-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      runBookmarkInTask(props.task.id, bookmark.command);
-                    }}
-                    tabIndex={-1}
-                    title={bookmark.command}
-                    style={{
-                      background: theme.taskPanelBg,
-                      border: `1px solid ${shellToolbarIdx() === i() + 1 && shellToolbarFocused() ? theme.accent : theme.border}`,
-                      color: theme.fgMuted,
-                      cursor: 'pointer',
-                      'border-radius': '4px',
-                      padding: '4px 12px',
-                      'font-size': sf(13),
-                      'line-height': '1',
-                      display: 'flex',
-                      'align-items': 'center',
-                      gap: '4px',
-                    }}
-                  >
-                    <span>{extractLabel(bookmark.command)}</span>
-                  </button>
-                )}
-              </For>
-            </div>
-            <Show when={props.task.shellAgentIds.length > 0}>
-              <div
-                style={{
-                  flex: '1',
-                  display: 'flex',
-                  overflow: 'hidden',
-                  background: theme.taskContainerBg,
-                  gap: '6px',
-                  'margin-top': '6px',
-                }}
-              >
-                <For each={props.task.shellAgentIds}>
-                  {(shellId, i) => {
-                    const initialCommand = consumePendingShellCommand(shellId);
-                    let shellFocusFn: (() => void) | undefined;
-                    let registeredKey: string | undefined;
-
-                    // Re-register focus fn whenever the index changes (e.g. after a sibling is removed)
-                    createEffect(() => {
-                      const key = `${props.task.id}:shell:${i()}`;
-                      if (registeredKey && registeredKey !== key) unregisterFocusFn(registeredKey);
-                      if (shellFocusFn) registerFocusFn(key, shellFocusFn);
-                      registeredKey = key;
-                    });
-                    onCleanup(() => {
-                      if (registeredKey) unregisterFocusFn(registeredKey);
-                    });
-
-                    const isShellFocused = () =>
-                      store.focusedPanel[props.task.id] === `shell:${i()}`;
-
-                    return (
-                      <div
-                        class="focusable-panel shell-terminal-container"
-                        data-shell-focused={isShellFocused() ? 'true' : 'false'}
-                        style={{
-                          flex: '1',
-                          overflow: 'hidden',
-                          position: 'relative',
-                          background: theme.taskPanelBg,
-                        }}
-                        onClick={() => setTaskFocusedPanel(props.task.id, `shell:${i()}`)}
-                      >
-                        <button
-                          class="shell-terminal-close"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            closeShell(props.task.id, shellId);
-                          }}
-                          title="Close terminal (Ctrl+Shift+Q)"
-                          style={{
-                            background: 'color-mix(in srgb, var(--island-bg) 85%, transparent)',
-                            border: `1px solid ${theme.border}`,
-                            color: theme.fgMuted,
-                            cursor: 'pointer',
-                            'border-radius': '6px',
-                            padding: '2px 6px',
-                            'line-height': '1',
-                            'font-size': '14px',
-                          }}
-                        >
-                          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                          </svg>
-                        </button>
-                        <Show when={shellExits[shellId]}>
-                          <div
-                            class="exit-badge"
-                            style={{
-                              position: 'absolute',
-                              top: '8px',
-                              right: '12px',
-                              'z-index': '10',
-                              'font-size': sf(11),
-                              color:
-                                shellExits[shellId]?.exitCode === 0 ? theme.success : theme.error,
-                              background: 'color-mix(in srgb, var(--island-bg) 80%, transparent)',
-                              padding: '4px 12px',
-                              'border-radius': '8px',
-                              border: `1px solid ${theme.border}`,
-                            }}
-                          >
-                            Process exited ({shellExits[shellId]?.exitCode ?? '?'})
-                          </div>
-                        </Show>
-                        <TerminalView
-                          taskId={props.task.id}
-                          agentId={shellId}
-                          isShell
-                          isFocused={
-                            props.isActive && store.focusedPanel[props.task.id] === `shell:${i()}`
-                          }
-                          command={''}
-                          args={['-l']}
-                          cwd={props.task.worktreePath}
-                          dockerMode={props.task.dockerMode}
-                          dockerImage={props.task.dockerImage}
-                          initialCommand={initialCommand}
-                          onData={(data) => markAgentOutput(shellId, data, props.task.id)}
-                          onExit={(info) =>
-                            setShellExits(shellId, {
-                              exitCode: info.exit_code,
-                              signal: info.signal,
-                            })
-                          }
-                          onReady={(focusFn) => {
-                            shellFocusFn = focusFn;
-                            if (registeredKey) registerFocusFn(registeredKey, focusFn);
-                          }}
-                          fontSize={Math.round(11 * getFontScale(`${props.task.id}:shell`))}
-                          autoFocus
-                        />
-                      </div>
-                    );
-                  }}
-                </For>
-              </div>
-            </Show>
-          </div>
-        </ScalablePanel>
+        <TaskShellSection
+          task={props.task}
+          isActive={props.isActive}
+        />
       ),
     };
   }
@@ -1042,259 +228,11 @@ export function TaskPanel(props: TaskPanelProps) {
       id: 'ai-terminal',
       minSize: 80,
       content: () => (
-        <ScalablePanel panelId={`${props.task.id}:ai-terminal`}>
-          <div
-            class="focusable-panel shell-terminal-container"
-            data-shell-focused={
-              store.focusedPanel[props.task.id] === 'ai-terminal' ? 'true' : 'false'
-            }
-            style={{
-              height: '100%',
-              position: 'relative',
-              background: theme.taskPanelBg,
-              display: 'flex',
-              'flex-direction': 'column',
-            }}
-            onClick={() => setTaskFocusedPanel(props.task.id, 'ai-terminal')}
-          >
-            <InfoBar
-              title={
-                props.task.lastPrompt ||
-                (props.task.initialPrompt ? 'Waiting to send prompt…' : 'No prompts sent yet')
-              }
-              onDblClick={() => {
-                if (props.task.lastPrompt && promptHandle && !promptHandle.getText())
-                  promptHandle.setText(props.task.lastPrompt);
-              }}
-            >
-              <span style={{ opacity: props.task.lastPrompt ? 1 : 0.4 }}>
-                {props.task.lastPrompt
-                  ? `> ${props.task.lastPrompt}`
-                  : props.task.initialPrompt
-                    ? '⏳ Waiting to send prompt…'
-                    : 'No prompts sent'}
-              </span>
-            </InfoBar>
-            <div style={{ flex: '1', position: 'relative', overflow: 'hidden' }}>
-              <Show when={firstAgent()}>
-                {(a) => (
-                  <>
-                    <Show when={a().status === 'exited'}>
-                      <div
-                        class="exit-badge"
-                        title={a().lastOutput.length ? a().lastOutput.join('\n') : undefined}
-                        style={{
-                          position: 'absolute',
-                          top: '8px',
-                          right: '12px',
-                          'z-index': '10',
-                          'font-size': sf(11),
-                          color: a().exitCode === 0 ? theme.success : theme.error,
-                          background: 'color-mix(in srgb, var(--island-bg) 80%, transparent)',
-                          padding: '4px 12px',
-                          'border-radius': '8px',
-                          border: `1px solid ${theme.border}`,
-                          display: 'flex',
-                          'align-items': 'center',
-                          gap: '8px',
-                        }}
-                      >
-                        <span>
-                          {a().signal === 'spawn_failed'
-                            ? 'Failed to start'
-                            : `Process exited (${a().exitCode ?? '?'})`}
-                        </span>
-                        {(() => {
-                          const [showAgentMenu, setShowAgentMenu] = createSignal(false);
-                          let menuRef: HTMLSpanElement | undefined;
-                          const handleClickOutside = (e: MouseEvent) => {
-                            if (menuRef && !menuRef.contains(e.target as Node)) {
-                              setShowAgentMenu(false);
-                            }
-                          };
-                          return (
-                            <span
-                              style={{ position: 'relative', display: 'inline-flex' }}
-                              ref={(el) => {
-                                menuRef = el;
-                                onMount(() =>
-                                  document.addEventListener('mousedown', handleClickOutside),
-                                );
-                                onCleanup(() =>
-                                  document.removeEventListener('mousedown', handleClickOutside),
-                                );
-                              }}
-                            >
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  restartAgent(a().id, false);
-                                }}
-                                style={{
-                                  background: theme.bgElevated,
-                                  border: `1px solid ${theme.border}`,
-                                  color: theme.fg,
-                                  padding: '2px 8px',
-                                  'border-radius': '4px 0 0 4px',
-                                  'border-right': 'none',
-                                  cursor: 'pointer',
-                                  'font-size': sf(10),
-                                }}
-                              >
-                                Restart
-                              </button>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setShowAgentMenu(!showAgentMenu());
-                                }}
-                                style={{
-                                  background: theme.bgElevated,
-                                  border: `1px solid ${theme.border}`,
-                                  color: theme.fg,
-                                  padding: '2px 4px',
-                                  'border-radius': '0 4px 4px 0',
-                                  cursor: 'pointer',
-                                  'font-size': sf(10),
-                                }}
-                              >
-                                ▾
-                              </button>
-                              <Show when={showAgentMenu()}>
-                                <div
-                                  style={{
-                                    position: 'absolute',
-                                    top: '100%',
-                                    right: '0',
-                                    'margin-top': '4px',
-                                    background: theme.bgElevated,
-                                    border: `1px solid ${theme.border}`,
-                                    'border-radius': '6px',
-                                    padding: '4px 0',
-                                    'z-index': '20',
-                                    'min-width': '160px',
-                                    'box-shadow': '0 4px 12px rgba(0,0,0,0.3)',
-                                  }}
-                                >
-                                  <div
-                                    style={{
-                                      padding: '4px 10px',
-                                      'font-size': sf(9),
-                                      color: theme.fgMuted,
-                                    }}
-                                  >
-                                    Restart with…
-                                  </div>
-                                  <For
-                                    each={store.availableAgents.filter(
-                                      (ag) => ag.available !== false,
-                                    )}
-                                  >
-                                    {(agentDef) => (
-                                      <button
-                                        title={agentDef.description}
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          setShowAgentMenu(false);
-                                          if (agentDef.id === a().def.id) {
-                                            restartAgent(a().id, false);
-                                          } else {
-                                            switchAgent(a().id, agentDef);
-                                          }
-                                        }}
-                                        style={{
-                                          display: 'block',
-                                          width: '100%',
-                                          background:
-                                            agentDef.id === a().def.id
-                                              ? theme.bgSelected
-                                              : 'transparent',
-                                          border: 'none',
-                                          color: theme.fg,
-                                          padding: '5px 10px',
-                                          cursor: 'pointer',
-                                          'font-size': sf(10),
-                                          'text-align': 'left',
-                                        }}
-                                        onMouseEnter={(e) => {
-                                          if (agentDef.id !== a().def.id)
-                                            e.currentTarget.style.background = theme.bgHover;
-                                        }}
-                                        onMouseLeave={(e) => {
-                                          e.currentTarget.style.background =
-                                            agentDef.id === a().def.id
-                                              ? theme.bgSelected
-                                              : 'transparent';
-                                        }}
-                                      >
-                                        {agentDef.name}
-                                        <Show when={agentDef.id === a().def.id}>
-                                          {' '}
-                                          <span style={{ opacity: 0.5 }}>(current)</span>
-                                        </Show>
-                                      </button>
-                                    )}
-                                  </For>
-                                </div>
-                              </Show>
-                            </span>
-                          );
-                        })()}
-                        <Show when={a().def.resume_args?.length}>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              restartAgent(a().id, true);
-                            }}
-                            style={{
-                              background: theme.bgElevated,
-                              border: `1px solid ${theme.border}`,
-                              color: theme.fg,
-                              padding: '2px 8px',
-                              'border-radius': '4px',
-                              cursor: 'pointer',
-                              'font-size': sf(10),
-                            }}
-                          >
-                            Resume
-                          </button>
-                        </Show>
-                      </div>
-                    </Show>
-                    <Show when={`${a().id}:${a().generation}`} keyed>
-                      <TerminalView
-                        taskId={props.task.id}
-                        agentId={a().id}
-                        isFocused={
-                          props.isActive && store.focusedPanel[props.task.id] === 'ai-terminal'
-                        }
-                        command={a().def.command}
-                        args={[
-                          ...(a().resumed && a().def.resume_args?.length
-                            ? (a().def.resume_args ?? [])
-                            : a().def.args),
-                          ...(props.task.skipPermissions && a().def.skip_permissions_args?.length
-                            ? (a().def.skip_permissions_args ?? [])
-                            : []),
-                        ]}
-                        cwd={props.task.worktreePath}
-                        dockerMode={props.task.dockerMode}
-                        dockerImage={props.task.dockerImage}
-                        onExit={(code) => markAgentExited(a().id, code)}
-                        onData={(data) => markAgentOutput(a().id, data, props.task.id)}
-                        onPromptDetected={(text) => setLastPrompt(props.task.id, text)}
-                        onReady={(focusFn) =>
-                          registerFocusFn(`${props.task.id}:ai-terminal`, focusFn)
-                        }
-                        fontSize={Math.round(13 * getFontScale(`${props.task.id}:ai-terminal`))}
-                      />
-                    </Show>
-                  </>
-                )}
-              </Show>
-            </div>
-          </div>
-        </ScalablePanel>
+        <TaskAITerminal
+          task={props.task}
+          isActive={props.isActive}
+          promptHandle={promptHandle}
+        />
       ),
     };
   }

--- a/src/components/TaskShellSection.tsx
+++ b/src/components/TaskShellSection.tsx
@@ -1,0 +1,289 @@
+import { Show, For, createSignal, createEffect, onCleanup } from 'solid-js';
+import { createStore } from 'solid-js/store';
+import {
+  store,
+  getProject,
+  spawnShellForTask,
+  runBookmarkInTask,
+  closeShell,
+  markAgentOutput,
+  getFontScale,
+  registerFocusFn,
+  unregisterFocusFn,
+  setTaskFocusedPanel,
+} from '../store/store';
+import { ScalablePanel } from './ScalablePanel';
+import { TerminalView } from './TerminalView';
+import { theme } from '../lib/theme';
+import { sf } from '../lib/fontScale';
+import { mod } from '../lib/platform';
+import { extractLabel, consumePendingShellCommand } from '../lib/bookmarks';
+import type { Task } from '../store/types';
+
+interface TaskShellSectionProps {
+  task: Task;
+  isActive: boolean;
+}
+
+export function TaskShellSection(props: TaskShellSectionProps) {
+  const [shellToolbarIdx, setShellToolbarIdx] = createSignal(0);
+  const [shellToolbarFocused, setShellToolbarFocused] = createSignal(false);
+  const [shellExits, setShellExits] = createStore<
+    Record<string, { exitCode: number | null; signal: string | null }>
+  >({});
+  let shellToolbarEl: HTMLDivElement | undefined;
+
+  const projectBookmarks = () => getProject(props.task.projectId)?.terminalBookmarks ?? [];
+
+  // Reactively register shell-toolbar:N focus fns
+  createEffect(() => {
+    const id = props.task.id;
+    const count = 1 + projectBookmarks().length;
+    if (shellToolbarIdx() >= count) {
+      setShellToolbarIdx(count - 1);
+    }
+    for (let n = 0; n < count; n++) {
+      const idx = n;
+      registerFocusFn(`${id}:shell-toolbar:${idx}`, () => {
+        setShellToolbarIdx(idx);
+        shellToolbarEl?.focus();
+      });
+    }
+    onCleanup(() => {
+      for (let i = 0; i < count; i++) {
+        unregisterFocusFn(`${id}:shell-toolbar:${i}`);
+      }
+    });
+  });
+
+  return (
+    <ScalablePanel panelId={`${props.task.id}:shell`}>
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          'flex-direction': 'column',
+          background: 'transparent',
+        }}
+      >
+        <div
+          ref={(el) => {
+            shellToolbarEl = el;
+          }}
+          class="focusable-panel shell-toolbar-panel"
+          tabIndex={0}
+          onClick={() =>
+            setTaskFocusedPanel(props.task.id, `shell-toolbar:${shellToolbarIdx()}`)
+          }
+          onFocus={() => setShellToolbarFocused(true)}
+          onBlur={() => setShellToolbarFocused(false)}
+          onKeyDown={(e) => {
+            if (e.altKey) return;
+            const itemCount = 1 + projectBookmarks().length;
+            if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              const next = Math.min(itemCount - 1, shellToolbarIdx() + 1);
+              setShellToolbarIdx(next);
+              setTaskFocusedPanel(props.task.id, `shell-toolbar:${next}`);
+            } else if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              const next = Math.max(0, shellToolbarIdx() - 1);
+              setShellToolbarIdx(next);
+              setTaskFocusedPanel(props.task.id, `shell-toolbar:${next}`);
+            } else if (e.key === 'Enter') {
+              e.preventDefault();
+              const idx = shellToolbarIdx();
+              if (idx === 0) {
+                spawnShellForTask(props.task.id);
+              } else {
+                const bm = projectBookmarks()[idx - 1];
+                if (bm) runBookmarkInTask(props.task.id, bm.command);
+              }
+            }
+          }}
+          style={{
+            height: '28px',
+            'min-height': '28px',
+            display: 'flex',
+            'align-items': 'center',
+            padding: '0 8px',
+            background: 'transparent',
+            gap: '4px',
+            outline: 'none',
+          }}
+        >
+          <button
+            class="icon-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              spawnShellForTask(props.task.id);
+            }}
+            tabIndex={-1}
+            title={`Open terminal (${mod}+Shift+T)`}
+            style={{
+              background: theme.taskPanelBg,
+              border: `1px solid ${shellToolbarIdx() === 0 && shellToolbarFocused() ? theme.accent : theme.border}`,
+              color: theme.fgMuted,
+              cursor: 'pointer',
+              'border-radius': '4px',
+              padding: '4px 12px',
+              'font-size': sf(13),
+              'line-height': '1',
+              display: 'flex',
+              'align-items': 'center',
+              gap: '4px',
+            }}
+          >
+            <span style={{ 'font-family': 'monospace', 'font-size': sf(13) }}>&gt;_</span>
+            <span>Terminal</span>
+          </button>
+          <For each={projectBookmarks()}>
+            {(bookmark, i) => (
+              <button
+                class="icon-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  runBookmarkInTask(props.task.id, bookmark.command);
+                }}
+                tabIndex={-1}
+                title={bookmark.command}
+                style={{
+                  background: theme.taskPanelBg,
+                  border: `1px solid ${shellToolbarIdx() === i() + 1 && shellToolbarFocused() ? theme.accent : theme.border}`,
+                  color: theme.fgMuted,
+                  cursor: 'pointer',
+                  'border-radius': '4px',
+                  padding: '4px 12px',
+                  'font-size': sf(13),
+                  'line-height': '1',
+                  display: 'flex',
+                  'align-items': 'center',
+                  gap: '4px',
+                }}
+              >
+                <span>{extractLabel(bookmark.command)}</span>
+              </button>
+            )}
+          </For>
+        </div>
+        <Show when={props.task.shellAgentIds.length > 0}>
+          <div
+            style={{
+              flex: '1',
+              display: 'flex',
+              overflow: 'hidden',
+              background: theme.taskContainerBg,
+              gap: '6px',
+              'margin-top': '6px',
+            }}
+          >
+            <For each={props.task.shellAgentIds}>
+              {(shellId, i) => {
+                const initialCommand = consumePendingShellCommand(shellId);
+                let shellFocusFn: (() => void) | undefined;
+                let registeredKey: string | undefined;
+
+                createEffect(() => {
+                  const key = `${props.task.id}:shell:${i()}`;
+                  if (registeredKey && registeredKey !== key) unregisterFocusFn(registeredKey);
+                  if (shellFocusFn) registerFocusFn(key, shellFocusFn);
+                  registeredKey = key;
+                });
+                onCleanup(() => {
+                  if (registeredKey) unregisterFocusFn(registeredKey);
+                });
+
+                const isShellFocused = () =>
+                  store.focusedPanel[props.task.id] === `shell:${i()}`;
+
+                return (
+                  <div
+                    class="focusable-panel shell-terminal-container"
+                    data-shell-focused={isShellFocused() ? 'true' : 'false'}
+                    style={{
+                      flex: '1',
+                      overflow: 'hidden',
+                      position: 'relative',
+                      background: theme.taskPanelBg,
+                    }}
+                    onClick={() => setTaskFocusedPanel(props.task.id, `shell:${i()}`)}
+                  >
+                    <button
+                      class="shell-terminal-close"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        closeShell(props.task.id, shellId);
+                      }}
+                      title="Close terminal (Ctrl+Shift+Q)"
+                      style={{
+                        background: 'color-mix(in srgb, var(--island-bg) 85%, transparent)',
+                        border: `1px solid ${theme.border}`,
+                        color: theme.fgMuted,
+                        cursor: 'pointer',
+                        'border-radius': '6px',
+                        padding: '2px 6px',
+                        'line-height': '1',
+                        'font-size': '14px',
+                      }}
+                    >
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+                      </svg>
+                    </button>
+                    <Show when={shellExits[shellId]}>
+                      <div
+                        class="exit-badge"
+                        style={{
+                          position: 'absolute',
+                          top: '8px',
+                          right: '12px',
+                          'z-index': '10',
+                          'font-size': sf(11),
+                          color:
+                            shellExits[shellId]?.exitCode === 0 ? theme.success : theme.error,
+                          background: 'color-mix(in srgb, var(--island-bg) 80%, transparent)',
+                          padding: '4px 12px',
+                          'border-radius': '8px',
+                          border: `1px solid ${theme.border}`,
+                        }}
+                      >
+                        Process exited ({shellExits[shellId]?.exitCode ?? '?'})
+                      </div>
+                    </Show>
+                    <TerminalView
+                      taskId={props.task.id}
+                      agentId={shellId}
+                      isShell
+                      isFocused={
+                        props.isActive && store.focusedPanel[props.task.id] === `shell:${i()}`
+                      }
+                      command={''}
+                      args={['-l']}
+                      cwd={props.task.worktreePath}
+                      dockerMode={props.task.dockerMode}
+                      dockerImage={props.task.dockerImage}
+                      initialCommand={initialCommand}
+                      onData={(data) => markAgentOutput(shellId, data, props.task.id)}
+                      onExit={(info) =>
+                        setShellExits(shellId, {
+                          exitCode: info.exit_code,
+                          signal: info.signal,
+                        })
+                      }
+                      onReady={(focusFn) => {
+                        shellFocusFn = focusFn;
+                        if (registeredKey) registerFocusFn(registeredKey, focusFn);
+                      }}
+                      fontSize={Math.round(11 * getFontScale(`${props.task.id}:shell`))}
+                      autoFocus
+                    />
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </ScalablePanel>
+  );
+}

--- a/src/components/TaskTitleBar.tsx
+++ b/src/components/TaskTitleBar.tsx
@@ -1,0 +1,193 @@
+import { Show } from 'solid-js';
+import {
+  store,
+  reorderTask,
+  setActiveTask,
+  updateTaskName,
+  collapseTask,
+  getTaskDotStatus,
+} from '../store/store';
+import { EditableText, type EditableTextHandle } from './EditableText';
+import { IconButton } from './IconButton';
+import { StatusDot } from './StatusDot';
+import { theme } from '../lib/theme';
+import { handleDragReorder } from '../lib/dragReorder';
+import type { Task } from '../store/types';
+
+interface TaskTitleBarProps {
+  task: Task;
+  isActive: boolean;
+  onClose: () => void;
+  onMerge: () => void;
+  onPush: () => void;
+  pushing: boolean;
+  pushSuccess: boolean;
+  onTitleEditRef: (h: EditableTextHandle) => void;
+}
+
+export function TaskTitleBar(props: TaskTitleBarProps) {
+  function handleTitleMouseDown(e: MouseEvent) {
+    handleDragReorder(e, {
+      itemId: props.task.id,
+      getTaskOrder: () => store.taskOrder,
+      onReorder: reorderTask,
+      onTap: () => setActiveTask(props.task.id),
+    });
+  }
+
+  return (
+    <div
+      class={props.isActive ? 'island-header-active' : ''}
+      style={{
+        display: 'flex',
+        'align-items': 'center',
+        'justify-content': 'space-between',
+        padding: '0 10px',
+        height: '100%',
+        background: 'transparent',
+        'border-bottom': `1px solid ${theme.border}`,
+        'user-select': 'none',
+        cursor: 'grab',
+      }}
+      onMouseDown={handleTitleMouseDown}
+    >
+      <div
+        style={{
+          overflow: 'hidden',
+          flex: '1',
+          'min-width': '0',
+          display: 'flex',
+          'align-items': 'center',
+          gap: '8px',
+        }}
+      >
+        <StatusDot status={getTaskDotStatus(props.task.id)} size="md" />
+        <Show when={props.task.directMode}>
+          <span
+            style={{
+              'font-size': '11px',
+              'font-weight': '600',
+              padding: '2px 8px',
+              'border-radius': '4px',
+              background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
+              color: theme.warning,
+              border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
+              'flex-shrink': '0',
+              'white-space': 'nowrap',
+            }}
+          >
+            {props.task.branchName}
+          </span>
+        </Show>
+        <Show when={props.task.dockerMode}>
+          <span
+            style={{
+              'font-size': '11px',
+              'font-weight': '600',
+              padding: '2px 8px',
+              'border-radius': '4px',
+              background: `color-mix(in srgb, ${theme.fgMuted} 15%, transparent)`,
+              color: theme.fgMuted,
+              border: `1px solid color-mix(in srgb, ${theme.fgMuted} 25%, transparent)`,
+              'flex-shrink': '0',
+              'white-space': 'nowrap',
+            }}
+          >
+            Docker
+          </span>
+        </Show>
+        <EditableText
+          value={props.task.name}
+          onCommit={(v) => updateTaskName(props.task.id, v)}
+          class="editable-text"
+          title={props.task.savedInitialPrompt}
+          ref={(h) => props.onTitleEditRef(h)}
+        />
+      </div>
+      <div style={{ display: 'flex', gap: '4px', 'margin-left': '8px', 'flex-shrink': '0' }}>
+        <Show when={!props.task.directMode}>
+          <IconButton
+            icon={
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+              </svg>
+            }
+            onClick={() => props.onMerge()}
+            title="Merge into main"
+          />
+          <div style={{ position: 'relative', display: 'inline-flex' }}>
+            <Show
+              when={!props.pushing}
+              fallback={
+                <div
+                  style={{
+                    display: 'inline-flex',
+                    'align-items': 'center',
+                    'justify-content': 'center',
+                    padding: '4px',
+                    border: `1px solid ${theme.border}`,
+                    'border-radius': '6px',
+                  }}
+                >
+                  <span class="inline-spinner" style={{ width: '14px', height: '14px' }} />
+                </div>
+              }
+            >
+              <IconButton
+                icon={
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path
+                      d="M4.75 8a.75.75 0 0 1 .75-.75h5.19L8.22 4.78a.75.75 0 0 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.47-2.47H5.5A.75.75 0 0 1 4.75 8Z"
+                      transform="rotate(-90 8 8)"
+                    />
+                  </svg>
+                }
+                onClick={() => props.onPush()}
+                title="Push to remote"
+              />
+            </Show>
+            <Show when={props.pushSuccess}>
+              <div
+                style={{
+                  position: 'absolute',
+                  bottom: '-4px',
+                  right: '-4px',
+                  width: '12px',
+                  height: '12px',
+                  'border-radius': '50%',
+                  background: theme.success,
+                  display: 'flex',
+                  'align-items': 'center',
+                  'justify-content': 'center',
+                  'pointer-events': 'none',
+                }}
+              >
+                <svg width="8" height="8" viewBox="0 0 16 16" fill="white">
+                  <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+                </svg>
+              </div>
+            </Show>
+          </div>
+        </Show>
+        <IconButton
+          icon={
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M2 8a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 8Z" />
+            </svg>
+          }
+          onClick={() => collapseTask(props.task.id)}
+          title="Collapse task"
+        />
+        <IconButton
+          icon={
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+          }
+          onClick={() => props.onClose()}
+          title="Close task"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR refactors the monolithic `TaskPanel` component into smaller, more focused and maintainable sub-components. The changes improve code organization and separation of concerns without altering functionality.

## Key Changes

- **Extracted `TaskTitleBar`**: New component handling the task title bar with status dot, mode badges, editable task name, and action buttons (merge, push, close)

- **Extracted `TaskBranchInfoBar`**: New component for displaying branch information, project selector, GitHub link, and file system navigation

- **Extracted `TaskNotesPanel`**: New component managing the notes and plan tabs, including the notes textarea, plan viewer, and changed files list

- **Extracted `TaskShellSection`**: New component handling the shell toolbar and terminal views, including bookmark buttons and shell session management

- **Extracted `TaskAITerminal`**: New component for the AI agent terminal display, including agent status, exit badges, and restart controls

- **Removed unused imports and state**: Cleaned up imports from `TaskPanel` that are now only used in extracted components (e.g., `For`, `createStore`, shell-related store functions)

- **Simplified focus management**: Moved shell-toolbar focus registration logic into `TaskShellSection` where it's more contextually relevant

## Implementation Details

- All extracted components receive necessary props to maintain their functionality
- State management (signals, effects) moved to the components that use them
- Focus function registration and cleanup properly scoped to each component
- Component composition maintains the same visual layout and user interactions
- No changes to store functions or data structures

https://claude.ai/code/session_01QKHMqgf27nEbHkNnegfjHq