### PR TITLE
fix(ui): wrap agent selector buttons instead of clipping overflow

### DIFF
--- a/src/components/AgentSelector.tsx
+++ b/src/components/AgentSelector.tsx
@@ -22,7 +22,7 @@ export function AgentSelector(props: AgentSelectorProps) {
       >
         Agent
       </label>
-      <div style={{ display: 'flex', gap: '8px' }}>
+      <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '8px' }}>
         <For each={props.agents}>
           {(agent) => {
             const isSelected = () => props.selectedAgent?.id === agent.id;
@@ -32,7 +32,8 @@ export function AgentSelector(props: AgentSelectorProps) {
                 class={`agent-btn ${isSelected() ? 'selected' : ''}`}
                 onClick={() => props.onSelect(agent)}
                 style={{
-                  flex: '1',
+                  flex: '0 1 auto',
+                  'min-width': '70px',
                   padding: '10px 8px',
                   background: isSelected() ? theme.bgSelected : theme.bgInput,
                   border: isSelected() ? `1px solid ${theme.accent}` : `1px solid ${theme.border}`,

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -433,7 +433,12 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   }
 
   return (
-    <Dialog open={props.open} onClose={props.onClose} width="420px" panelStyle={{ gap: '20px' }}>
+    <Dialog
+      open={props.open}
+      onClose={props.onClose}
+      width={store.availableAgents.length > 8 ? '540px' : '420px'}
+      panelStyle={{ gap: '20px' }}
+    >
       <form
         ref={formRef}
         onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary

- Agent buttons in the New Task dialog were rendered in a single non-wrapping flex row with `flex: 1`, causing buttons to shrink and clip when many agents are configured (e.g., 6+ custom agents)
- Buttons now wrap onto multiple lines with content-based sizing (`flex: 0 1 auto`, `min-width: 70px`)
- Dialog widens from 420px to 540px when more than 8 agents are present to avoid excessive rows

## Before / After
<p float="left">
  <img width="320" height="328" alt="CleanShot 2026-03-24 at 11 37 26" src="https://github.com/user-attachments/assets/c3fa3ba8-a3ae-4d22-9284-103e20e7e6cf" />
  <img width="300" height="397" alt="CleanShot 2026-03-24 at 11 24 27" src="https://github.com/user-attachments/assets/38c3e8f8-f7d2-4092-ba55-27b60981a5bf" />
</p>

## Test plan

- [x] Open New Task dialog with default agents (3-5) — buttons should display on a single row as before
- [x] Add custom agents until 6+ are visible — buttons should wrap to a second row
- [x] Add 9+ agents — dialog should widen to 540px
- [x] Verify buttons with short names ("CC") don't collapse below 70px
- [x] Verify buttons with long names render without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)