### PR TITLE
fix(autosave): include branchName in persisted snapshot

### DIFF
--- a/src/store/autosave.ts
+++ b/src/store/autosave.ts
@@ -43,6 +43,7 @@ function persistedSnapshot(): string {
               name: t.name,
               gitIsolation: t.gitIsolation,
               baseBranch: t.baseBranch,
+              branchName: t.branchName,
               savedInitialPrompt: t.savedInitialPrompt,
               collapsed: t.collapsed,
             },


### PR DESCRIPTION
updateTaskBranch (used by MergeDialog's branch mismatch fix) updates
branchName in the store, but the autosave snapshot didn't track it.
If branchName was the only field that changed, the debounced save
would not trigger, potentially losing the update on app restart.

https://claude.ai/code/session_01McqHYwdaCNNXqPQWGBTGS4