### PR TITLE
feat(terminal): add Cmd+Arrow and Shift+Enter keyboard shortcuts

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -202,14 +202,14 @@ export function TerminalView(props: TerminalViewProps) {
       }
 
       // Shift+Enter → send as Alt+Enter (newline in CLI agents like Claude Code)
-      if (e.key === 'Enter' && e.shiftKey) {
+      if (e.key === 'Enter' && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
         enqueueInput('\x1b\r');
         return false;
       }
 
       // Cmd+Left/Right → Home/End (macOS only; on Linux Ctrl+Arrow is word-jump)
-      if (isMac && e.metaKey && !e.altKey && !e.ctrlKey) {
+      if (isMac && e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey) {
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
           enqueueInput('\x1b[H'); // Home


### PR DESCRIPTION
## Summary
- **Cmd+Left/Right** sends Home/End escape sequences in the terminal (macOS)
- **Shift+Enter** sends Alt+Enter for multi-line input in CLI agents like Claude Code

## Motivation
On macOS, Cmd+Arrow keys are the standard way to jump to beginning/end of line, but xterm.js doesn't handle them by default. Similarly, Shift+Enter for newlines is expected in modern terminal UIs but isn't sent correctly without explicit handling.

## Test plan
- [ ] Open a terminal, type text, press Cmd+Left — cursor jumps to start of line
- [ ] Press Cmd+Right — cursor jumps to end of line
- [ ] In Claude Code, press Shift+Enter — inserts a newline instead of submitting