### PR TITLE
feat(settings): add toggle for dialog backdrop blur

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -668,7 +668,7 @@ textarea::placeholder {
 .dialog-overlay {
   animation: fadeIn 0.16s ease;
   background: color-mix(in srgb, #000 44%, transparent);
-  backdrop-filter: blur(6px) saturate(1.15);
+  backdrop-filter: saturate(1.15);
 }
 
 .dialog-overlay > form,


### PR DESCRIPTION
## Summary
New setting to enable/disable the backdrop blur effect when dialogs are open. Found in Settings > Behavior.

## Motivation
The blur effect can be distracting when monitoring terminal output behind a dialog. This lets users disable it while keeping the dark overlay for focus.

## Details
- New `dialogBlur` boolean in store (persisted, defaults to `true`)
- CSS split: `.dialog-overlay` has no blur, `.dialog-overlay.dialog-blur` adds it
- `Dialog.tsx` conditionally applies the blur class based on the setting

## Test plan
- [ ] Default: dialogs blur the background (existing behavior)
- [ ] Uncheck setting: dialogs show dark overlay without blur
- [ ] Setting persists across restarts