### PR TITLE
feat(settings): add toggle for prompt input panel

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -14,6 +14,7 @@ import {
   setThemePreset,
   setAutoTrustFolders,
   setShowPlans,
+  setShowPromptInput,
   setDesktopNotificationsEnabled,
   setInactiveColumnOpacity,
   setEditorCommand,
@@ -213,6 +214,33 @@ export function SettingsDialog(props: SettingsDialogProps) {
             <span style={{ 'font-size': '13px', color: theme.fg }}>Desktop notifications</span>
             <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
               Show native notifications when tasks finish or need attention
+            </span>
+          </div>
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            'align-items': 'center',
+            gap: '10px',
+            cursor: 'pointer',
+            padding: '8px 12px',
+            'border-radius': '8px',
+            background: theme.bgInput,
+            border: `1px solid ${theme.border}`,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={store.showPromptInput}
+            onChange={(e) => setShowPromptInput(e.currentTarget.checked)}
+            style={{ 'accent-color': theme.accent, cursor: 'pointer' }}
+          />
+          <div style={{ display: 'flex', 'flex-direction': 'column', gap: '2px' }}>
+            <span style={{ 'font-size': '13px', color: theme.fg }}>
+              Show prompt input box below terminal
+            </span>
+            <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
+              When hidden, the terminal occupies the full panel and auto-focuses on activation
             </span>
           </div>
         </label>

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -86,7 +86,12 @@ export function TaskPanel(props: TaskPanelProps) {
       autoFocusTimer = setTimeout(() => {
         autoFocusTimer = undefined;
         if (!store.focusedPanel[id] && !panelRef.contains(document.activeElement)) {
-          promptRef?.focus();
+          if (store.showPromptInput) {
+            promptRef?.focus();
+          } else {
+            setTaskFocusedPanel(id, 'ai-terminal');
+            triggerFocus(`${id}:ai-terminal`);
+          }
         }
       }, 0);
     }
@@ -243,7 +248,7 @@ export function TaskPanel(props: TaskPanelProps) {
           notesAndFiles(),
           shellSection(),
           aiTerminal(),
-          promptInput(),
+          ...(store.showPromptInput ? [promptInput()] : []),
         ]}
       />
       <CloseTaskDialog

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -38,6 +38,7 @@ export const [store, setStore] = createStore<AppStore>({
   mergedLinesRemoved: 0,
   terminalFont: DEFAULT_TERMINAL_FONT,
   themePreset: 'minimal',
+  showPromptInput: true,
   windowState: null,
   autoTrustFolders: false,
   showPlans: true,

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -48,6 +48,7 @@ export async function saveState(): Promise<void> {
     mergedLinesRemoved: store.mergedLinesRemoved,
     terminalFont: store.terminalFont,
     themePreset: store.themePreset,
+    showPromptInput: store.showPromptInput,
     windowState: store.windowState ? { ...store.windowState } : undefined,
     autoTrustFolders: store.autoTrustFolders,
     showPlans: store.showPlans,
@@ -187,6 +188,7 @@ interface LegacyPersistedState {
   mergedLinesRemoved?: unknown;
   terminalFont?: unknown;
   themePreset?: unknown;
+  showPromptInput?: unknown;
   windowState?: unknown;
   autoTrustFolders?: unknown;
   showPlans?: unknown;
@@ -297,6 +299,7 @@ export async function loadState(): Promise<void> {
           ? raw.terminalFont
           : DEFAULT_TERMINAL_FONT;
       s.themePreset = isLookPreset(raw.themePreset) ? raw.themePreset : 'minimal';
+      s.showPromptInput = typeof raw.showPromptInput === 'boolean' ? raw.showPromptInput : true;
       s.windowState = parsePersistedWindowState(raw.windowState);
       s.autoTrustFolders = typeof raw.autoTrustFolders === 'boolean' ? raw.autoTrustFolders : false;
       s.showPlans = typeof raw.showPlans === 'boolean' ? raw.showPlans : true;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -96,6 +96,7 @@ export {
   setThemePreset,
   setAutoTrustFolders,
   setShowPlans,
+  setShowPromptInput,
   setDesktopNotificationsEnabled,
   setInactiveColumnOpacity,
   setEditorCommand,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -119,6 +119,7 @@ export interface PersistedState {
   mergedLinesRemoved?: number;
   terminalFont?: string;
   themePreset?: LookPreset;
+  showPromptInput?: boolean;
   windowState?: PersistedWindowState;
   autoTrustFolders?: boolean;
   showPlans?: boolean;
@@ -183,6 +184,7 @@ export interface AppStore {
   mergedLinesRemoved: number;
   terminalFont: string;
   themePreset: LookPreset;
+  showPromptInput: boolean;
   windowState: PersistedWindowState | null;
   autoTrustFolders: boolean;
   showPlans: boolean;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -86,6 +86,10 @@ export function setShowPlans(showPlans: boolean): void {
   setStore('showPlans', showPlans);
 }
 
+export function setShowPromptInput(show: boolean): void {
+  setStore('showPromptInput', show);
+}
+
 export function setDesktopNotificationsEnabled(enabled: boolean): void {
   setStore('desktopNotificationsEnabled', enabled);
 }


### PR DESCRIPTION
## Summary
New setting to show/hide the prompt input box below the terminal. Found in Settings > Behavior.

## Motivation
The prompt input box restricts terminal-native interactions: voice input, image paste, Esc to cancel, up-arrow for history. Power users who prefer typing directly in the terminal can hide it to get more screen space and direct access to all terminal features.

## Details
- New \`showPromptInput\` boolean in store (persisted, defaults to \`true\`)
- When hidden: terminal occupies full panel, auto-focuses on task activation
- When shown: existing behavior (prompt input below terminal)
- Auto-send of initial prompts still works regardless of this setting

## Test plan
- [ ] Default: prompt input box is shown (existing behavior)
- [ ] Uncheck setting: prompt input disappears, terminal gets full space
- [ ] Terminal auto-focuses when switching to a task with prompt hidden
- [ ] Setting persists across restarts
- [ ] Creating a task with an initial prompt still auto-sends it