### PR TITLE
fix(terminal): open .md file links in built-in viewer

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -149,8 +149,8 @@ export function TerminalView(props: TerminalViewProps) {
               const filePath = link.text.replace(/:\d+(:\d+)?$/, '');
               // Resolve relative paths against the task's working directory
               const resolved = filePath.startsWith('/') ? filePath : `${props.cwd}/${filePath}`;
-              // Cmd+click always opens externally; otherwise use callback for .md files
-              if (!event.metaKey && /\.md$/i.test(resolved) && props.onFileLink) {
+              // .md files open in viewer; Shift held = open externally instead
+              if (/\.md$/i.test(resolved) && props.onFileLink && !event.shiftKey) {
                 props.onFileLink(resolved);
               } else {
                 invoke(IPC.OpenPath, { filePath: resolved }).catch(console.error);


### PR DESCRIPTION
## Summary
Fixes .md file links always opening externally instead of in the built-in markdown viewer.

## Problem
After #45 was merged and Ctrl+click was added as a requirement in `933931a`, the `.md` viewer check (`!event.metaKey`) was always false on Mac since Cmd is required to activate the link. All `.md` files fell through to the external open path.

## Fix
Use `event.shiftKey` as the "open externally" modifier instead:
- **Cmd/Ctrl+click** on `.md` → opens in built-in viewer
- **Cmd/Ctrl+Shift+click** on `.md` → opens externally
- **Cmd/Ctrl+click** on other files → opens externally (unchanged)

## Test plan
- [ ] Cmd+click a `.md` file path in terminal — opens in viewer dialog
- [ ] Cmd+Shift+click a `.md` file path — opens externally
- [ ] Cmd+click a `.ts` file — opens externally