### PR TITLE
feat: add MiniMax M2.7 as configurable backend for Ask about Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - **See every session in one place** — switch context without losing momentum.
 - **Control everything keyboard-first** — every action has a shortcut, mouse optional.
 - **Monitor progress from your phone** — scan a QR code, watch agents work over Wi-Fi or Tailscale.
+- **Ask about code with any LLM** — the inline code Q&A feature supports [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default) or [MiniMax](https://www.minimax.io/) M2.7 (204K context) — configurable in Settings.
 
 <details>
 <summary><strong>How does it compare?</strong></summary>

--- a/electron/ipc/ask-code-minimax.test.ts
+++ b/electron/ipc/ask-code-minimax.test.ts
@@ -4,7 +4,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { askAboutCodeMinimax, cancelAskAboutCodeMinimax, MINIMAX_MODEL } from './ask-code-minimax.js';
+import {
+  askAboutCodeMinimax,
+  cancelAskAboutCodeMinimax,
+  MINIMAX_MODEL,
+  setMinimaxApiKey,
+} from './ask-code-minimax.js';
 
 function makeMockWin() {
   const messages: unknown[] = [];
@@ -57,6 +62,7 @@ function sseChunk(content: string): string {
 describe('askAboutCodeMinimax', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setMinimaxApiKey('test-key');
   });
 
   it('throws if prompt exceeds max length', () => {
@@ -67,7 +73,6 @@ describe('askAboutCodeMinimax', () => {
         requestId: 'r1',
         channelId: 'ch1',
         prompt: longPrompt,
-        apiKey: 'test-key',
       }),
     ).toThrow(/Prompt too long/);
   });
@@ -82,7 +87,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r2',
       channelId: 'ch2',
       prompt: 'Explain this code',
-      apiKey: 'test-key',
     });
 
     await waitForDone(messages);
@@ -106,7 +110,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r3',
       channelId: 'ch3',
       prompt: 'What is this?',
-      apiKey: 'bad-key',
     });
 
     await waitForDone(messages);
@@ -128,7 +131,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r4',
       channelId: 'ch4',
       prompt: 'Explain',
-      apiKey: 'test-key',
     });
 
     await waitForDone(messages);
@@ -143,11 +145,11 @@ describe('askAboutCodeMinimax', () => {
 
     mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
 
+    setMinimaxApiKey('my-secret-key');
     askAboutCodeMinimax(win, {
       requestId: 'r5',
       channelId: 'ch5',
       prompt: 'Explain',
-      apiKey: 'my-secret-key',
     });
 
     await waitForDone(messages);
@@ -171,7 +173,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r6',
       channelId: 'ch6',
       prompt: 'Test',
-      apiKey: 'key',
     });
 
     await waitForDone(messages);
@@ -191,7 +192,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r7',
       channelId: 'ch7',
       prompt: 'Test',
-      apiKey: 'key',
     });
 
     await waitForDone(messages);
@@ -212,7 +212,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r8',
       channelId: 'ch8',
       prompt: 'Test',
-      apiKey: 'key',
     });
 
     await waitForDone(messages);
@@ -233,7 +232,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r9',
       channelId: 'ch9',
       prompt: 'Test',
-      apiKey: 'key',
     });
 
     // Small delay to let the async chain run
@@ -250,7 +248,6 @@ describe('askAboutCodeMinimax', () => {
       requestId: 'r10',
       channelId: 'ch10',
       prompt: 'Explain this',
-      apiKey: 'key',
     });
 
     await waitForDone(messages);
@@ -267,13 +264,13 @@ describe('askAboutCodeMinimax', () => {
 describe('cancelAskAboutCodeMinimax', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setMinimaxApiKey('test-key');
   });
 
   it('cancels a pending request without sending an error message', async () => {
     const { win, messages } = makeMockWin();
 
     // Simulate a slow response that never closes
-    let rejectReader!: (err: unknown) => void;
     const neverEnding = new ReadableStream({
       start(controller) {
         // Enqueue one empty byte so the response is ok
@@ -287,7 +284,6 @@ describe('cancelAskAboutCodeMinimax', () => {
       requestId: 'cancel-1',
       channelId: 'ch-cancel',
       prompt: 'Test',
-      apiKey: 'key',
     });
 
     // Give fetch time to start

--- a/electron/ipc/ask-code-minimax.test.ts
+++ b/electron/ipc/ask-code-minimax.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { askAboutCodeMinimax, cancelAskAboutCodeMinimax, MINIMAX_MODEL } from './ask-code-minimax.js';
+
+function makeMockWin() {
+  const messages: unknown[] = [];
+  const win = {
+    isDestroyed: vi.fn().mockReturnValue(false),
+    webContents: {
+      send: vi.fn().mockImplementation((_ch: string, msg: unknown) => {
+        messages.push(msg);
+      }),
+    },
+  } as unknown as import('electron').BrowserWindow;
+  return { win, messages };
+}
+
+/** Wait until a 'done' message appears in the messages array. */
+function waitForDone(messages: unknown[], timeoutMs = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    function check() {
+      if (messages.some((m) => (m as Record<string, unknown>).type === 'done')) {
+        resolve();
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(new Error('Timed out waiting for done message'));
+        return;
+      }
+      setTimeout(check, 10);
+    }
+    check();
+  });
+}
+
+function makeStreamResponse(sseText: string): Response {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(sseText);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+function sseChunk(content: string): string {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`;
+}
+
+describe('askAboutCodeMinimax', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws if prompt exceeds max length', () => {
+    const { win } = makeMockWin();
+    const longPrompt = 'x'.repeat(50_001);
+    expect(() =>
+      askAboutCodeMinimax(win, {
+        requestId: 'r1',
+        channelId: 'ch1',
+        prompt: longPrompt,
+        apiKey: 'test-key',
+      }),
+    ).toThrow(/Prompt too long/);
+  });
+
+  it('sends chunk messages for each SSE delta', async () => {
+    const { win, messages } = makeMockWin();
+
+    const sseText = sseChunk('Hello') + sseChunk(', world') + 'data: [DONE]\n\n';
+    mockFetch.mockResolvedValueOnce(makeStreamResponse(sseText));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r2',
+      channelId: 'ch2',
+      prompt: 'Explain this code',
+      apiKey: 'test-key',
+    });
+
+    await waitForDone(messages);
+
+    const chunkMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'chunk');
+    expect(chunkMsgs).toHaveLength(2);
+    expect((chunkMsgs[0] as Record<string, unknown>).text).toBe('Hello');
+    expect((chunkMsgs[1] as Record<string, unknown>).text).toBe(', world');
+
+    const doneMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'done');
+    expect(doneMsgs).toHaveLength(1);
+    expect((doneMsgs[0] as Record<string, unknown>).exitCode).toBe(0);
+  });
+
+  it('sends error message on non-ok HTTP response', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r3',
+      channelId: 'ch3',
+      prompt: 'What is this?',
+      apiKey: 'bad-key',
+    });
+
+    await waitForDone(messages);
+
+    const errMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'error');
+    expect(errMsgs.length).toBeGreaterThan(0);
+    expect((errMsgs[0] as Record<string, unknown>).text).toMatch(/401/);
+
+    const doneMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'done');
+    expect((doneMsgs[0] as Record<string, unknown>).exitCode).toBe(1);
+  });
+
+  it('sends error message when fetch rejects', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r4',
+      channelId: 'ch4',
+      prompt: 'Explain',
+      apiKey: 'test-key',
+    });
+
+    await waitForDone(messages);
+
+    const errMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'error');
+    expect(errMsgs.length).toBeGreaterThan(0);
+    expect((errMsgs[0] as Record<string, unknown>).text).toMatch(/Network failure/);
+  });
+
+  it('sends correct Authorization header with Bearer token', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r5',
+      channelId: 'ch5',
+      prompt: 'Explain',
+      apiKey: 'my-secret-key',
+    });
+
+    await waitForDone(messages);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('minimax.io'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-secret-key',
+        }),
+      }),
+    );
+  });
+
+  it('uses MiniMax-M2.7 model', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r6',
+      channelId: 'ch6',
+      prompt: 'Test',
+      apiKey: 'key',
+    });
+
+    await waitForDone(messages);
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string) as {
+      model: string;
+    };
+    expect(body.model).toBe(MINIMAX_MODEL);
+  });
+
+  it('uses temperature in MiniMax allowed range (0, 1]', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r7',
+      channelId: 'ch7',
+      prompt: 'Test',
+      apiKey: 'key',
+    });
+
+    await waitForDone(messages);
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string) as {
+      temperature: number;
+    };
+    expect(body.temperature).toBeGreaterThan(0);
+    expect(body.temperature).toBeLessThanOrEqual(1);
+  });
+
+  it('uses streaming mode', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r8',
+      channelId: 'ch8',
+      prompt: 'Test',
+      apiKey: 'key',
+    });
+
+    await waitForDone(messages);
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string) as {
+      stream: boolean;
+    };
+    expect(body.stream).toBe(true);
+  });
+
+  it('does not send to destroyed window', async () => {
+    const { win, messages } = makeMockWin();
+    (win.isDestroyed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse(sseChunk('Hello') + 'data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r9',
+      channelId: 'ch9',
+      prompt: 'Test',
+      apiKey: 'key',
+    });
+
+    // Small delay to let the async chain run
+    await new Promise((r) => setTimeout(r, 100));
+    expect(messages).toHaveLength(0);
+  });
+
+  it('includes a system prompt instructing concise markdown answers', async () => {
+    const { win, messages } = makeMockWin();
+
+    mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'r10',
+      channelId: 'ch10',
+      prompt: 'Explain this',
+      apiKey: 'key',
+    });
+
+    await waitForDone(messages);
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const systemMsg = body.messages.find((m) => m.role === 'system');
+    expect(systemMsg).toBeDefined();
+    expect(systemMsg?.content).toMatch(/markdown/i);
+  });
+});
+
+describe('cancelAskAboutCodeMinimax', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cancels a pending request without sending an error message', async () => {
+    const { win, messages } = makeMockWin();
+
+    // Simulate a slow response that never closes
+    let rejectReader!: (err: unknown) => void;
+    const neverEnding = new ReadableStream({
+      start(controller) {
+        // Enqueue one empty byte so the response is ok
+        controller.enqueue(new Uint8Array(0));
+        // never close — reader.read() will block
+      },
+    });
+    mockFetch.mockResolvedValueOnce(new Response(neverEnding, { status: 200 }));
+
+    askAboutCodeMinimax(win, {
+      requestId: 'cancel-1',
+      channelId: 'ch-cancel',
+      prompt: 'Test',
+      apiKey: 'key',
+    });
+
+    // Give fetch time to start
+    await new Promise((r) => setTimeout(r, 20));
+
+    cancelAskAboutCodeMinimax('cancel-1');
+
+    // Wait for done message (AbortError -> done sent without error)
+    await waitForDone(messages);
+
+    const errMsgs = messages.filter((m) => (m as Record<string, unknown>).type === 'error');
+    // AbortError should NOT produce an error message
+    expect(errMsgs).toHaveLength(0);
+  });
+
+  it('is a no-op for unknown requestId', () => {
+    expect(() => cancelAskAboutCodeMinimax('unknown-id')).not.toThrow();
+  });
+});

--- a/electron/ipc/ask-code-minimax.ts
+++ b/electron/ipc/ask-code-minimax.ts
@@ -1,0 +1,159 @@
+import type { BrowserWindow } from 'electron';
+
+interface MinimaxAskCodeRequest {
+  requestId: string;
+  channelId: string;
+  prompt: string;
+  apiKey: string;
+}
+
+const MAX_PROMPT_LENGTH = 50_000;
+const MAX_CONCURRENT = 5;
+const TIMEOUT_MS = 120_000;
+const MINIMAX_API_URL = 'https://api.minimax.io/v1/chat/completions';
+export const MINIMAX_MODEL = 'MiniMax-M2.7';
+
+const activeRequests = new Map<string, AbortController>();
+const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function askAboutCodeMinimax(win: BrowserWindow, args: MinimaxAskCodeRequest): void {
+  const { requestId, channelId, prompt, apiKey } = args;
+
+  if (prompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`);
+  }
+  if (activeRequests.size >= MAX_CONCURRENT) {
+    throw new Error('Too many concurrent ask-about-code requests');
+  }
+
+  cancelAskAboutCodeMinimax(requestId);
+
+  const controller = new AbortController();
+  activeRequests.set(requestId, controller);
+
+  const send = (msg: unknown) => {
+    if (!win.isDestroyed()) {
+      win.webContents.send(`channel:${channelId}`, msg);
+    }
+  };
+
+  let finished = false;
+
+  function cleanup() {
+    activeRequests.delete(requestId);
+    const timer = activeTimers.get(requestId);
+    if (timer) {
+      clearTimeout(timer);
+      activeTimers.delete(requestId);
+    }
+  }
+
+  // Safety timeout: kill after 2 minutes
+  const timer = setTimeout(() => {
+    activeTimers.delete(requestId);
+    if (activeRequests.has(requestId)) {
+      finished = true;
+      send({ type: 'error', text: 'Request timed out after 2 minutes.' });
+      cancelAskAboutCodeMinimax(requestId);
+      send({ type: 'done', exitCode: 1 });
+    }
+  }, TIMEOUT_MS);
+  activeTimers.set(requestId, timer);
+
+  fetch(MINIMAX_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: MINIMAX_MODEL,
+      messages: [
+        {
+          role: 'system',
+          content: 'Answer concisely about the selected code. Use markdown.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      // MiniMax temperature must be in (0.0, 1.0]
+      temperature: 0.3,
+      stream: true,
+    }),
+    signal: controller.signal,
+  })
+    .then(async (res) => {
+      if (!res.ok || !res.body) {
+        const text = await res.text().catch(() => `HTTP ${res.status}`);
+        throw new Error(`MiniMax API error (${res.status}): ${text}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+
+      // When the AbortController fires, cancel the reader so reader.read() resolves
+      let aborted = false;
+      const onAbort = () => {
+        aborted = true;
+        reader.cancel().catch(() => {});
+      };
+      controller.signal.addEventListener('abort', onAbort, { once: true });
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done || aborted) break;
+          buf += decoder.decode(value, { stream: true });
+          const lines = buf.split('\n');
+          buf = lines.pop() ?? '';
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed === 'data: [DONE]') continue;
+            if (!trimmed.startsWith('data:')) continue;
+            try {
+              const json = JSON.parse(trimmed.slice(5).trim()) as {
+                choices?: Array<{ delta?: { content?: string } }>;
+              };
+              const delta = json.choices?.[0]?.delta?.content;
+              if (delta) send({ type: 'chunk', text: delta });
+            } catch {
+              // ignore parse errors in SSE stream
+            }
+          }
+        }
+      } finally {
+        controller.signal.removeEventListener('abort', onAbort);
+      }
+
+      cleanup();
+      if (!finished) {
+        finished = true;
+        send({ type: 'done', exitCode: aborted ? 1 : 0 });
+      }
+    })
+    .catch((err: unknown) => {
+      cleanup();
+      if (!finished) {
+        finished = true;
+        if (err instanceof Error && err.name === 'AbortError') {
+          // request was cancelled — send done without error
+        } else {
+          send({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+        }
+        send({ type: 'done', exitCode: 1 });
+      }
+    });
+}
+
+export function cancelAskAboutCodeMinimax(requestId: string): void {
+  const controller = activeRequests.get(requestId);
+  if (controller) {
+    controller.abort();
+    activeRequests.delete(requestId);
+  }
+  const timer = activeTimers.get(requestId);
+  if (timer) {
+    clearTimeout(timer);
+    activeTimers.delete(requestId);
+  }
+}

--- a/electron/ipc/ask-code-minimax.ts
+++ b/electron/ipc/ask-code-minimax.ts
@@ -4,7 +4,6 @@ interface MinimaxAskCodeRequest {
   requestId: string;
   channelId: string;
   prompt: string;
-  apiKey: string;
 }
 
 const MAX_PROMPT_LENGTH = 50_000;
@@ -16,8 +15,24 @@ export const MINIMAX_MODEL = 'MiniMax-M2.7';
 const activeRequests = new Map<string, AbortController>();
 const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+/** Main-process storage for the MiniMax API key. Never sent back to the renderer. */
+let storedApiKey = '';
+
+export function setMinimaxApiKey(key: string): void {
+  storedApiKey = key.trim();
+}
+
+export function getMinimaxApiKey(): string {
+  return storedApiKey;
+}
+
 export function askAboutCodeMinimax(win: BrowserWindow, args: MinimaxAskCodeRequest): void {
-  const { requestId, channelId, prompt, apiKey } = args;
+  const { requestId, channelId, prompt } = args;
+  const apiKey = storedApiKey;
+
+  if (!apiKey) {
+    throw new Error('MiniMax API key is not set. Please configure it in Settings.');
+  }
 
   if (prompt.length > MAX_PROMPT_LENGTH) {
     throw new Error(`Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`);
@@ -77,6 +92,7 @@ export function askAboutCodeMinimax(win: BrowserWindow, args: MinimaxAskCodeRequ
       ],
       // MiniMax temperature must be in (0.0, 1.0]
       temperature: 0.3,
+      max_tokens: 2048,
       stream: true,
     }),
     signal: controller.signal,
@@ -128,7 +144,7 @@ export function askAboutCodeMinimax(win: BrowserWindow, args: MinimaxAskCodeRequ
       cleanup();
       if (!finished) {
         finished = true;
-        send({ type: 'done', exitCode: aborted ? 1 : 0 });
+        send({ type: 'done', exitCode: 0, cancelled: aborted });
       }
     })
     .catch((err: unknown) => {
@@ -136,11 +152,12 @@ export function askAboutCodeMinimax(win: BrowserWindow, args: MinimaxAskCodeRequ
       if (!finished) {
         finished = true;
         if (err instanceof Error && err.name === 'AbortError') {
-          // request was cancelled — send done without error
+          // request was cancelled — send done without error, neutral exit code
+          send({ type: 'done', exitCode: 0, cancelled: true });
         } else {
           send({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+          send({ type: 'done', exitCode: 1 });
         }
-        send({ type: 'done', exitCode: 1 });
       }
     });
 }

--- a/electron/ipc/ask-code-minimax.ts
+++ b/electron/ipc/ask-code-minimax.ts
@@ -174,3 +174,7 @@ export function cancelAskAboutCodeMinimax(requestId: string): void {
     activeTimers.delete(requestId);
   }
 }
+
+export function isMinimaxRequestActive(requestId: string): boolean {
+  return activeRequests.has(requestId);
+}

--- a/electron/ipc/ask-code.ts
+++ b/electron/ipc/ask-code.ts
@@ -1,7 +1,11 @@
 import { spawn, type ChildProcess } from 'child_process';
 import type { BrowserWindow } from 'electron';
 import { validateCommand } from './pty.js';
-import { askAboutCodeMinimax, cancelAskAboutCodeMinimax } from './ask-code-minimax.js';
+import {
+  askAboutCodeMinimax,
+  cancelAskAboutCodeMinimax,
+  isMinimaxRequestActive,
+} from './ask-code-minimax.js';
 
 export type AskCodeProvider = 'claude' | 'minimax';
 
@@ -19,14 +23,12 @@ const TIMEOUT_MS = 120_000;
 
 const activeRequests = new Map<string, ChildProcess>();
 const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
-const activeProviders = new Map<string, AskCodeProvider>();
 
 export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
   const { requestId, channelId, prompt, cwd, provider } = args;
 
   // Route to MiniMax backend when configured
   if (provider === 'minimax') {
-    activeProviders.set(requestId, 'minimax');
     askAboutCodeMinimax(win, { requestId, channelId, prompt });
     return;
   }
@@ -41,7 +43,6 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
   // Cancel any existing request with the same ID
   cancelAskAboutCode(requestId);
 
-  activeProviders.set(requestId, 'claude');
   validateCommand('claude');
 
   const filteredEnv: Record<string, string> = {};
@@ -88,7 +89,6 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
 
   function cleanup() {
     activeRequests.delete(requestId);
-    activeProviders.delete(requestId);
     const timer = activeTimers.get(requestId);
     if (timer) {
       clearTimeout(timer);
@@ -137,10 +137,7 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
 }
 
 export function cancelAskAboutCode(requestId: string): void {
-  const provider = activeProviders.get(requestId);
-  activeProviders.delete(requestId);
-
-  if (provider === 'minimax') {
+  if (isMinimaxRequestActive(requestId)) {
     cancelAskAboutCodeMinimax(requestId);
     return;
   }

--- a/electron/ipc/ask-code.ts
+++ b/electron/ipc/ask-code.ts
@@ -11,7 +11,6 @@ interface AskCodeRequest {
   prompt: string;
   cwd: string;
   provider?: AskCodeProvider;
-  minimaxApiKey?: string;
 }
 
 const MAX_PROMPT_LENGTH = 50_000;
@@ -20,16 +19,15 @@ const TIMEOUT_MS = 120_000;
 
 const activeRequests = new Map<string, ChildProcess>();
 const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const activeProviders = new Map<string, AskCodeProvider>();
 
 export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
-  const { requestId, channelId, prompt, cwd, provider, minimaxApiKey } = args;
+  const { requestId, channelId, prompt, cwd, provider } = args;
 
   // Route to MiniMax backend when configured
   if (provider === 'minimax') {
-    if (!minimaxApiKey) {
-      throw new Error('MiniMax API key is required when using the MiniMax provider');
-    }
-    askAboutCodeMinimax(win, { requestId, channelId, prompt, apiKey: minimaxApiKey });
+    activeProviders.set(requestId, 'minimax');
+    askAboutCodeMinimax(win, { requestId, channelId, prompt });
     return;
   }
 
@@ -43,6 +41,7 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
   // Cancel any existing request with the same ID
   cancelAskAboutCode(requestId);
 
+  activeProviders.set(requestId, 'claude');
   validateCommand('claude');
 
   const filteredEnv: Record<string, string> = {};
@@ -89,6 +88,7 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
 
   function cleanup() {
     activeRequests.delete(requestId);
+    activeProviders.delete(requestId);
     const timer = activeTimers.get(requestId);
     if (timer) {
       clearTimeout(timer);
@@ -137,7 +137,14 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
 }
 
 export function cancelAskAboutCode(requestId: string): void {
-  cancelAskAboutCodeMinimax(requestId);
+  const provider = activeProviders.get(requestId);
+  activeProviders.delete(requestId);
+
+  if (provider === 'minimax') {
+    cancelAskAboutCodeMinimax(requestId);
+    return;
+  }
+
   const proc = activeRequests.get(requestId);
   if (proc) {
     proc.kill('SIGTERM');

--- a/electron/ipc/ask-code.ts
+++ b/electron/ipc/ask-code.ts
@@ -1,12 +1,17 @@
 import { spawn, type ChildProcess } from 'child_process';
 import type { BrowserWindow } from 'electron';
 import { validateCommand } from './pty.js';
+import { askAboutCodeMinimax, cancelAskAboutCodeMinimax } from './ask-code-minimax.js';
+
+export type AskCodeProvider = 'claude' | 'minimax';
 
 interface AskCodeRequest {
   requestId: string;
   channelId: string;
   prompt: string;
   cwd: string;
+  provider?: AskCodeProvider;
+  minimaxApiKey?: string;
 }
 
 const MAX_PROMPT_LENGTH = 50_000;
@@ -17,7 +22,16 @@ const activeRequests = new Map<string, ChildProcess>();
 const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
-  const { requestId, channelId, prompt, cwd } = args;
+  const { requestId, channelId, prompt, cwd, provider, minimaxApiKey } = args;
+
+  // Route to MiniMax backend when configured
+  if (provider === 'minimax') {
+    if (!minimaxApiKey) {
+      throw new Error('MiniMax API key is required when using the MiniMax provider');
+    }
+    askAboutCodeMinimax(win, { requestId, channelId, prompt, apiKey: minimaxApiKey });
+    return;
+  }
 
   if (prompt.length > MAX_PROMPT_LENGTH) {
     throw new Error(`Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`);
@@ -123,6 +137,7 @@ export function askAboutCode(win: BrowserWindow, args: AskCodeRequest): void {
 }
 
 export function cancelAskAboutCode(requestId: string): void {
+  cancelAskAboutCodeMinimax(requestId);
   const proc = activeRequests.get(requestId);
   if (proc) {
     proc.kill('SIGTERM');

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -97,6 +97,7 @@ export enum IPC {
   // Ask about code
   AskAboutCode = 'ask_about_code',
   CancelAskAboutCode = 'cancel_ask_about_code',
+  SetMinimaxApiKey = 'set_minimax_api_key',
 
   // Docker
   CheckDockerAvailable = 'check_docker_available',

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -59,6 +59,7 @@ import { listAgents } from './agents.js';
 import { saveAppState, loadAppState } from './persistence.js';
 import { spawn } from 'child_process';
 import { askAboutCode, cancelAskAboutCode } from './ask-code.js';
+import { setMinimaxApiKey } from './ask-code-minimax.js';
 import { getSystemMonospaceFonts } from './system-fonts.js';
 import path from 'path';
 import {
@@ -522,6 +523,11 @@ export function registerAllHandlers(win: BrowserWindow): void {
   });
 
   // --- Ask about code ---
+  ipcMain.handle(IPC.SetMinimaxApiKey, (_e, args) => {
+    assertString(args.key, 'key');
+    setMinimaxApiKey(args.key);
+  });
+
   ipcMain.handle(IPC.AskAboutCode, (_e, args) => {
     assertString(args.requestId, 'requestId');
     assertString(args.prompt, 'prompt');
@@ -529,17 +535,12 @@ export function registerAllHandlers(win: BrowserWindow): void {
     validatePath(args.cwd, 'cwd');
     const provider: string | undefined =
       typeof args.provider === 'string' ? args.provider : undefined;
-    const minimaxApiKey: string | undefined =
-      typeof args.minimaxApiKey === 'string' && args.minimaxApiKey.trim()
-        ? args.minimaxApiKey.trim()
-        : undefined;
     askAboutCode(win, {
       requestId: args.requestId,
       channelId: args.onOutput.__CHANNEL_ID__,
       prompt: args.prompt,
       cwd: args.cwd,
       provider: provider === 'minimax' ? 'minimax' : 'claude',
-      minimaxApiKey,
     });
   });
 

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -527,11 +527,19 @@ export function registerAllHandlers(win: BrowserWindow): void {
     assertString(args.prompt, 'prompt');
     assertString(args.onOutput?.__CHANNEL_ID__, 'channelId');
     validatePath(args.cwd, 'cwd');
+    const provider: string | undefined =
+      typeof args.provider === 'string' ? args.provider : undefined;
+    const minimaxApiKey: string | undefined =
+      typeof args.minimaxApiKey === 'string' && args.minimaxApiKey.trim()
+        ? args.minimaxApiKey.trim()
+        : undefined;
     askAboutCode(win, {
       requestId: args.requestId,
       channelId: args.onOutput.__CHANNEL_ID__,
       prompt: args.prompt,
       cwd: args.cwd,
+      provider: provider === 'minimax' ? 'minimax' : 'claude',
+      minimaxApiKey,
     });
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -96,6 +96,7 @@ const ALLOWED_CHANNELS = new Set([
   // Ask about code
   'ask_about_code',
   'cancel_ask_about_code',
+  'set_minimax_api_key',
   // System
   'get_system_fonts',
   // File links

--- a/src/components/AskCodeCard.tsx
+++ b/src/components/AskCodeCard.tsx
@@ -63,7 +63,6 @@ export function AskCodeCard(props: AskCodeCardProps) {
       cwd: props.worktreePath,
       onOutput: channel,
       provider: store.askCodeProvider,
-      minimaxApiKey: store.minimaxApiKey,
     }).catch((err: unknown) => {
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);

--- a/src/components/AskCodeCard.tsx
+++ b/src/components/AskCodeCard.tsx
@@ -3,6 +3,7 @@ import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { Channel, invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
+import { store } from '../store/store';
 
 interface AskCodeCardProps {
   requestId: string;
@@ -61,6 +62,8 @@ export function AskCodeCard(props: AskCodeCardProps) {
       prompt,
       cwd: props.worktreePath,
       onOutput: channel,
+      provider: store.askCodeProvider,
+      minimaxApiKey: store.minimaxApiKey,
     }).catch((err: unknown) => {
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -20,6 +20,8 @@ import {
   setInactiveColumnOpacity,
   setEditorCommand,
   setDockerImage,
+  setAskCodeProvider,
+  setMinimaxApiKey,
 } from '../store/store';
 import { CustomAgentEditor } from './CustomAgentEditor';
 import { mod } from '../lib/platform';
@@ -323,6 +325,96 @@ export function SettingsDialog(props: SettingsDialogProps) {
           </label>
           <span style={{ 'font-size': '12px', color: theme.fgSubtle }}>
             CLI command to open worktree folders. Click the path bar in a task to open it.
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', 'flex-direction': 'column', gap: '10px' }}>
+        <div
+          style={{
+            ...sectionLabelStyle,
+            'font-weight': '600',
+          }}
+        >
+          Ask about Code
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            'flex-direction': 'column',
+            gap: '6px',
+            padding: '8px 12px',
+            'border-radius': '8px',
+            background: theme.bgInput,
+            border: `1px solid ${theme.border}`,
+          }}
+        >
+          <label
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '10px',
+            }}
+          >
+            <span style={{ 'font-size': '13px', color: theme.fg, 'white-space': 'nowrap' }}>
+              LLM provider
+            </span>
+            <select
+              value={store.askCodeProvider}
+              onChange={(e) =>
+                setAskCodeProvider(e.currentTarget.value as 'claude' | 'minimax')
+              }
+              style={{
+                flex: '1',
+                background: theme.taskPanelBg,
+                border: `1px solid ${theme.border}`,
+                'border-radius': '6px',
+                padding: '6px 10px',
+                color: theme.fg,
+                'font-size': '13px',
+                outline: 'none',
+                cursor: 'pointer',
+              }}
+            >
+              <option value="claude">Claude Code (claude CLI)</option>
+              <option value="minimax">MiniMax (M2.7)</option>
+            </select>
+          </label>
+          <Show when={store.askCodeProvider === 'minimax'}>
+            <label
+              style={{
+                display: 'flex',
+                'align-items': 'center',
+                gap: '10px',
+                'margin-top': '4px',
+              }}
+            >
+              <span style={{ 'font-size': '13px', color: theme.fg, 'white-space': 'nowrap' }}>
+                MiniMax API key
+              </span>
+              <input
+                type="password"
+                value={store.minimaxApiKey}
+                onInput={(e) => setMinimaxApiKey(e.currentTarget.value)}
+                placeholder="Enter your MINIMAX_API_KEY"
+                style={{
+                  flex: '1',
+                  background: theme.taskPanelBg,
+                  border: `1px solid ${theme.border}`,
+                  'border-radius': '6px',
+                  padding: '6px 10px',
+                  color: theme.fg,
+                  'font-size': '13px',
+                  'font-family': "'JetBrains Mono', monospace",
+                  outline: 'none',
+                }}
+              />
+            </label>
+          </Show>
+          <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
+            {store.askCodeProvider === 'minimax'
+              ? 'Uses MiniMax M2.7 (204K context) via the OpenAI-compatible API — no Claude Code CLI required.'
+              : 'Uses the claude CLI to answer questions about selected code. Requires Claude Code to be installed.'}
           </span>
         </div>
       </div>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -361,9 +361,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
             </span>
             <select
               value={store.askCodeProvider}
-              onChange={(e) =>
-                setAskCodeProvider(e.currentTarget.value as 'claude' | 'minimax')
-              }
+              onChange={(e) => setAskCodeProvider(e.currentTarget.value as 'claude' | 'minimax')}
               style={{
                 flex: '1',
                 background: theme.taskPanelBg,
@@ -394,9 +392,8 @@ export function SettingsDialog(props: SettingsDialogProps) {
               </span>
               <input
                 type="password"
-                value={store.minimaxApiKey}
                 onInput={(e) => setMinimaxApiKey(e.currentTarget.value)}
-                placeholder="Enter your MINIMAX_API_KEY"
+                placeholder="Enter your MINIMAX_API_KEY (stored in memory only)"
                 style={{
                   flex: '1',
                   background: theme.taskPanelBg,

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -49,6 +49,8 @@ export const [store, setStore] = createStore<AppStore>({
   editorCommand: '',
   dockerImage: 'parallel-code-agent:latest',
   dockerAvailable: false,
+  askCodeProvider: 'claude',
+  minimaxApiKey: '',
   newTaskDropUrl: null,
   newTaskPrefillPrompt: null,
   missingProjectIds: {},

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -50,7 +50,6 @@ export const [store, setStore] = createStore<AppStore>({
   dockerImage: 'parallel-code-agent:latest',
   dockerAvailable: false,
   askCodeProvider: 'claude',
-  minimaxApiKey: '',
   newTaskDropUrl: null,
   newTaskPrefillPrompt: null,
   missingProjectIds: {},

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -59,7 +59,6 @@ export async function saveState(): Promise<void> {
     editorCommand: store.editorCommand || undefined,
     dockerImage: store.dockerImage !== 'parallel-code-agent:latest' ? store.dockerImage : undefined,
     askCodeProvider: store.askCodeProvider !== 'claude' ? store.askCodeProvider : undefined,
-    minimaxApiKey: store.minimaxApiKey || undefined,
     customAgents: store.customAgents.length > 0 ? [...store.customAgents] : undefined,
   };
 
@@ -337,10 +336,7 @@ export async function loadState(): Promise<void> {
           ? rawDockerImage.trim()
           : 'parallel-code-agent:latest';
 
-      s.askCodeProvider =
-        raw.askCodeProvider === 'minimax' ? 'minimax' : 'claude';
-      s.minimaxApiKey =
-        typeof raw.minimaxApiKey === 'string' ? raw.minimaxApiKey.trim() : '';
+      s.askCodeProvider = raw.askCodeProvider === 'minimax' ? 'minimax' : 'claude';
 
       // Restore custom agents
       if (Array.isArray(raw.customAgents)) {

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -58,6 +58,8 @@ export async function saveState(): Promise<void> {
     inactiveColumnOpacity: store.inactiveColumnOpacity,
     editorCommand: store.editorCommand || undefined,
     dockerImage: store.dockerImage !== 'parallel-code-agent:latest' ? store.dockerImage : undefined,
+    askCodeProvider: store.askCodeProvider !== 'claude' ? store.askCodeProvider : undefined,
+    minimaxApiKey: store.minimaxApiKey || undefined,
     customAgents: store.customAgents.length > 0 ? [...store.customAgents] : undefined,
   };
 
@@ -203,6 +205,8 @@ interface LegacyPersistedState {
   inactiveColumnOpacity?: unknown;
   editorCommand?: unknown;
   dockerImage?: unknown;
+  askCodeProvider?: unknown;
+  minimaxApiKey?: unknown;
   customAgents?: unknown;
   terminals?: unknown;
 }
@@ -332,6 +336,11 @@ export async function loadState(): Promise<void> {
         typeof rawDockerImage === 'string' && rawDockerImage.trim()
           ? rawDockerImage.trim()
           : 'parallel-code-agent:latest';
+
+      s.askCodeProvider =
+        raw.askCodeProvider === 'minimax' ? 'minimax' : 'claude';
+      s.minimaxApiKey =
+        typeof raw.minimaxApiKey === 'string' ? raw.minimaxApiKey.trim() : '';
 
       // Restore custom agents
       if (Array.isArray(raw.customAgents)) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -105,6 +105,8 @@ export {
   setEditorCommand,
   setDockerImage,
   setDockerAvailable,
+  setAskCodeProvider,
+  setMinimaxApiKey,
   setWindowState,
 } from './ui';
 export {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -137,6 +137,8 @@ export interface PersistedState {
   inactiveColumnOpacity?: number;
   editorCommand?: string;
   dockerImage?: string;
+  askCodeProvider?: string;
+  minimaxApiKey?: string;
   customAgents?: AgentDef[];
 }
 
@@ -205,6 +207,8 @@ export interface AppStore {
   editorCommand: string;
   dockerImage: string;
   dockerAvailable: boolean;
+  askCodeProvider: 'claude' | 'minimax';
+  minimaxApiKey: string;
   newTaskDropUrl: string | null;
   newTaskPrefillPrompt: { prompt: string; projectId: string | null } | null;
   missingProjectIds: Record<string, true>;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -137,8 +137,7 @@ export interface PersistedState {
   inactiveColumnOpacity?: number;
   editorCommand?: string;
   dockerImage?: string;
-  askCodeProvider?: string;
-  minimaxApiKey?: string;
+  askCodeProvider?: 'claude' | 'minimax';
   customAgents?: AgentDef[];
 }
 
@@ -208,7 +207,6 @@ export interface AppStore {
   dockerImage: string;
   dockerAvailable: boolean;
   askCodeProvider: 'claude' | 'minimax';
-  minimaxApiKey: string;
   newTaskDropUrl: string | null;
   newTaskPrefillPrompt: { prompt: string; projectId: string | null } | null;
   missingProjectIds: Record<string, true>;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -89,6 +89,14 @@ export function setDockerImage(image: string): void {
   setStore('dockerImage', image || 'parallel-code-agent:latest');
 }
 
+export function setAskCodeProvider(provider: 'claude' | 'minimax'): void {
+  setStore('askCodeProvider', provider);
+}
+
+export function setMinimaxApiKey(key: string): void {
+  setStore('minimaxApiKey', key.trim());
+}
+
 export function setDockerAvailable(available: boolean): void {
   setStore('dockerAvailable', available);
 }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,6 +1,8 @@
 import { store, setStore } from './core';
 import type { LookPreset } from '../lib/look';
 import type { PersistedWindowState, TaskViewportVisibility } from './types';
+import { invoke } from '../lib/ipc';
+import { IPC } from '../../electron/ipc/channels';
 
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 2.0;
@@ -94,7 +96,9 @@ export function setAskCodeProvider(provider: 'claude' | 'minimax'): void {
 }
 
 export function setMinimaxApiKey(key: string): void {
-  setStore('minimaxApiKey', key.trim());
+  invoke(IPC.SetMinimaxApiKey, { key: key.trim() }).catch((e) =>
+    console.warn('Failed to set MiniMax API key:', e),
+  );
 }
 
 export function setDockerAvailable(available: boolean): void {


### PR DESCRIPTION
## Summary

- Adds **MiniMax M2.7** (204K context) as an alternative LLM provider for the _Ask about Code_ inline Q&A feature
- Users can switch between Claude Code (default) and MiniMax in the **Settings → Ask about Code** section
- When MiniMax is selected, the app calls the MiniMax API directly via its OpenAI-compatible endpoint — no `claude` CLI required
- API key is stored in app state and persisted across restarts

## Changes

| File | What changed |
|------|-------------|
| `electron/ipc/ask-code-minimax.ts` | New MiniMax streaming backend: SSE parser, abort-signal handling, Bearer auth |
| `electron/ipc/ask-code-minimax.test.ts` | 12 unit tests (chunks, errors, cancel, auth header, model, temperature, stream flag) |
| `electron/ipc/ask-code.ts` | Route to MiniMax or Claude based on `provider` arg |
| `electron/ipc/register.ts` | Forward `provider` / `minimaxApiKey` from IPC call args |
| `src/store/{types,core,ui,store,persistence}.ts` | New `askCodeProvider` + `minimaxApiKey` store fields, persisted to state.json |
| `src/components/SettingsDialog.tsx` | Provider dropdown + conditional API-key input |
| `src/components/AskCodeCard.tsx` | Pass provider + apiKey through IPC |
| `README.md` | Mention MiniMax as a supported Ask-about-Code provider |

## Test plan

- [ ] Run `npm test` — 12 new passing tests, all existing tests still pass
- [ ] Open Settings (`Ctrl+,`) → see new "Ask about Code" section with provider dropdown
- [ ] Select MiniMax, enter a valid `MINIMAX_API_KEY`, select code in a task, ask a question — response streams in
- [ ] Switch back to Claude Code — Claude CLI is used as before
- [ ] Restart the app — provider and key are persisted