### PR TITLE
Add Paper light theme preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When you're happy with the result, merge the branch back to main from the sideba
 - Built-in diff viewer and changed files list per task
 - Shell terminals per task, scoped to the worktree
 - Direct mode for working on the main branch without isolation
-- Six themes — Minimal, Graphite, Classic, Indigo, Ember, Glacier
+- Nine themes — Minimal, Graphite, Midnight, Classic, Indigo, Ember, Glacier, Paper, Zenburnesque
 - State persists across restarts
 - macOS and Linux
 

--- a/src/lib/look.ts
+++ b/src/lib/look.ts
@@ -6,6 +6,7 @@ export type LookPreset =
   | 'ember'
   | 'glacier'
   | 'minimal'
+  | 'paper'
   | 'zenburnesque';
 
 export interface LookPresetOption {
@@ -49,6 +50,11 @@ export const LOOK_PRESETS: LookPresetOption[] = [
     id: 'glacier',
     label: 'Glacier',
     description: 'Clean teal accents with softer depth',
+  },
+  {
+    id: 'paper',
+    label: 'Paper',
+    description: 'Bright warm canvas with crisp blue accents',
   },
   {
     id: 'zenburnesque',

--- a/src/lib/monaco-theme.ts
+++ b/src/lib/monaco-theme.ts
@@ -2,6 +2,7 @@ import * as monaco from 'monaco-editor';
 import type { LookPreset } from './look';
 
 interface PresetColors {
+  base: 'vs-dark' | 'vs';
   bgElevated: string;
   fg: string;
   fgMuted: string;
@@ -14,6 +15,7 @@ interface PresetColors {
 // but may intentionally diverge (e.g. midnight uses #000 editor background for OLED).
 // Diff highlight colors use the GitHub Dark palette (shared across all presets).
 const graphiteColors: PresetColors = {
+  base: 'vs-dark',
   bgElevated: '#1c2630',
   fg: '#d7e4f0',
   fgMuted: '#9bb0c3',
@@ -24,6 +26,7 @@ const graphiteColors: PresetColors = {
 
 const presetColors: Record<LookPreset, PresetColors> = {
   classic: {
+    base: 'vs-dark',
     bgElevated: '#2d2e32',
     fg: '#cccdd2',
     fgMuted: '#8b8d93',
@@ -37,6 +40,7 @@ const presetColors: Record<LookPreset, PresetColors> = {
     bgElevated: '#000000',
   },
   indigo: {
+    base: 'vs-dark',
     bgElevated: '#1c2038',
     fg: '#deddff',
     fgMuted: '#b1b2de',
@@ -45,6 +49,7 @@ const presetColors: Record<LookPreset, PresetColors> = {
     accent: '#7a78ff',
   },
   ember: {
+    base: 'vs-dark',
     bgElevated: '#211918',
     fg: '#f2ddd1',
     fgMuted: '#d5ab94',
@@ -53,6 +58,7 @@ const presetColors: Record<LookPreset, PresetColors> = {
     accent: '#ff944d',
   },
   glacier: {
+    base: 'vs-dark',
     bgElevated: '#232e3a',
     fg: '#e5eff5',
     fgMuted: '#bed2dc',
@@ -61,6 +67,7 @@ const presetColors: Record<LookPreset, PresetColors> = {
     accent: '#50e2d3',
   },
   minimal: {
+    base: 'vs-dark',
     bgElevated: '#161514',
     fg: '#e8e8e8',
     fgMuted: '#b8b8b8',
@@ -69,6 +76,7 @@ const presetColors: Record<LookPreset, PresetColors> = {
     accent: '#c8bfa0',
   },
   zenburnesque: {
+    base: 'vs-dark',
     bgElevated: '#2e2d2a',
     fg: '#dcdccc',
     fgMuted: '#a0a090',
@@ -76,11 +84,21 @@ const presetColors: Record<LookPreset, PresetColors> = {
     border: '#484640',
     accent: '#cc9393',
   },
+  paper: {
+    base: 'vs',
+    bgElevated: '#ffffff',
+    fg: '#18212b',
+    fgMuted: '#4f6277',
+    fgSubtle: '#6f8092',
+    border: '#cfd8e3',
+    accent: '#2563eb',
+  },
 };
 
 function buildThemeData(c: PresetColors): monaco.editor.IStandaloneThemeData {
+  const isLight = c.base === 'vs';
   return {
-    base: 'vs-dark',
+    base: c.base,
     inherit: true,
     rules: [
       { token: 'comment', foreground: c.fgSubtle.slice(1) },
@@ -89,19 +107,18 @@ function buildThemeData(c: PresetColors): monaco.editor.IStandaloneThemeData {
     colors: {
       'editor.background': c.bgElevated,
       'editor.foreground': c.fg,
-      'editor.lineHighlightBackground': '#ffffff06',
+      'editor.lineHighlightBackground': isLight ? '#00000008' : '#ffffff06',
       'editorLineNumber.foreground': c.fgSubtle,
       'editorLineNumber.activeForeground': c.fgMuted,
-      'editor.selectionBackground': c.accent + '33',
+      'editor.selectionBackground': c.accent + (isLight ? '22' : '33'),
       'editorWidget.background': c.bgElevated,
       'editorWidget.border': c.border,
-      // GitHub-inspired diff palette, toned down for dark backgrounds
-      'diffEditor.insertedLineBackground': '#2ea04315',
-      'diffEditor.removedLineBackground': '#f8514915',
-      'diffEditor.insertedTextBackground': '#2ea04340',
-      'diffEditor.removedTextBackground': '#f8514940',
-      'diffEditorGutter.insertedLineBackground': '#2ea04326',
-      'diffEditorGutter.removedLineBackground': '#f8514926',
+      'diffEditor.insertedLineBackground': isLight ? '#2da44e14' : '#2ea04315',
+      'diffEditor.removedLineBackground': isLight ? '#cf222e14' : '#f8514915',
+      'diffEditor.insertedTextBackground': isLight ? '#2da44e30' : '#2ea04340',
+      'diffEditor.removedTextBackground': isLight ? '#cf222e30' : '#f8514940',
+      'diffEditorGutter.insertedLineBackground': isLight ? '#2da44e22' : '#2ea04326',
+      'diffEditorGutter.removedLineBackground': isLight ? '#cf222e22' : '#f8514926',
       'diffEditor.unchangedRegionBackground': c.border,
       'diffEditor.unchangedRegionForeground': c.fgMuted,
       'diffEditor.unchangedRegionShadow': '#00000000',

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -39,23 +39,74 @@ export const theme = {
   taskPanelBg: 'var(--task-panel-bg)',
 } as const;
 
-/** Opaque terminal background per preset — matches --task-panel-bg */
-const terminalBackground: Record<LookPreset, string> = {
-  classic: '#2d2e32',
-  graphite: '#1c2630',
-  midnight: '#000000',
-  indigo: '#1c2038',
-  ember: '#211918',
-  glacier: '#232e3a',
-  minimal: '#262626',
-  zenburnesque: '#2e2d2a',
+type TerminalThemeColors = {
+  background: string;
+  foreground: string;
+  cursor: string;
+  selectionBackground: string;
+};
+
+/** Opaque terminal colors per preset — aligned with the task panel palette. */
+const terminalColors: Record<LookPreset, TerminalThemeColors> = {
+  classic: {
+    background: '#2d2e32',
+    foreground: '#cccdd2',
+    cursor: '#4c6fff',
+    selectionBackground: '#4c6fff33',
+  },
+  graphite: {
+    background: '#1c2630',
+    foreground: '#d7e4f0',
+    cursor: '#2ec8ff',
+    selectionBackground: '#2ec8ff33',
+  },
+  midnight: {
+    background: '#000000',
+    foreground: '#d7e4f0',
+    cursor: '#2ec8ff',
+    selectionBackground: '#2ec8ff33',
+  },
+  indigo: {
+    background: '#1c2038',
+    foreground: '#deddff',
+    cursor: '#7a78ff',
+    selectionBackground: '#7a78ff33',
+  },
+  ember: {
+    background: '#211918',
+    foreground: '#f2ddd1',
+    cursor: '#ff944d',
+    selectionBackground: '#ff944d33',
+  },
+  glacier: {
+    background: '#232e3a',
+    foreground: '#e5eff5',
+    cursor: '#50e2d3',
+    selectionBackground: '#50e2d333',
+  },
+  minimal: {
+    background: '#262626',
+    foreground: '#ececec',
+    cursor: '#c8bfa0',
+    selectionBackground: '#c8bfa033',
+  },
+  paper: {
+    background: '#fbfcfe',
+    foreground: '#18212b',
+    cursor: '#2563eb',
+    selectionBackground: '#2563eb22',
+  },
+  zenburnesque: {
+    background: '#2e2d2a',
+    foreground: '#dcdccc',
+    cursor: '#cc9393',
+    selectionBackground: '#cc939333',
+  },
 };
 
 /** Returns an xterm-compatible theme object for the given preset */
 export function getTerminalTheme(preset: LookPreset) {
-  return {
-    background: terminalBackground[preset],
-  };
+  return terminalColors[preset];
 }
 
 /** Generates a styled banner (warning/error/info) using color-mix for background+border. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,7 +52,7 @@ body,
   height: 100%;
   margin: 0;
   overflow: hidden;
-  background: #0e1215;
+  background: var(--bg);
 }
 
 body {
@@ -286,6 +286,37 @@ html[data-look='minimal'] {
   --shadow-pop: 0 2px 8px rgba(0, 0, 0, 0.6);
 }
 
+html[data-look='paper'] {
+  --font-ui: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: radial-gradient(140% 120% at 0% 0%, #f8fbff 0%, #eef3f8 58%, #e6ebf1 100%);
+  --bg-elevated: #ffffff;
+  --bg-input: #f6f8fb;
+  --bg-hover: #edf2f7;
+  --bg-selected: #dcecff;
+  --bg-selected-subtle: #dcecff88;
+  --border: #cfd8e3;
+  --border-subtle: #dde5ee;
+  --border-focus: #2563eb;
+  --fg: #18212b;
+  --fg-muted: #4f6277;
+  --fg-subtle: #6f8092;
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-text: #ffffff;
+  --link: #1d4ed8;
+  --success: #1f8f5f;
+  --error: #c53b4b;
+  --warning: #b7791f;
+  --island-bg: #ffffff;
+  --island-border: #cfd8e3;
+  --island-radius: 10px;
+  --task-container-bg: #f3f6fa;
+  --task-panel-bg: #fbfcfe;
+  --shadow-soft: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --shadow-pop: 0 0 0 1px rgba(37, 99, 235, 0.18), 0 12px 30px rgba(37, 99, 235, 0.12);
+}
+
 html[data-look='zenburnesque'] {
   --bg: radial-gradient(120% 120% at 40% 10%, #353430 0%, #232220 55%, #181716 100%);
   --bg-elevated: #2e2d2a;
@@ -317,9 +348,19 @@ html[data-look='zenburnesque'] {
   background: none !important;
 }
 
+.app-shell[data-look='paper']::before {
+  opacity: 0 !important;
+  background: none !important;
+}
+
 .app-shell[data-look='minimal'] .task-column.active {
   box-shadow: none;
   border-color: color-mix(in srgb, var(--border) 85%, transparent) !important;
+}
+
+.app-shell[data-look='paper'] .task-column.active {
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.08);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border)) !important;
 }
 
 * {


### PR DESCRIPTION
 Adds a new Paper light theme preset for the desktop app, including CSS variables, terminal colors, and
  Monaco light-theme support. Remote/phone UI is intentionally unchanged.
