### PR TITLE
fix(shortcuts): allow ESC to close dialogs when terminal is focused

### DIFF
--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -37,9 +37,14 @@ export function registerShortcut(shortcut: Shortcut): () => void {
   };
 }
 
+/** Whether a dialog overlay is currently mounted in the DOM. */
+function isDialogOpen(): boolean {
+  return document.querySelector('.dialog-overlay') !== null;
+}
+
 /** Returns true if the event matches any shortcut that should bypass terminal input. */
 export function matchesGlobalShortcut(e: KeyboardEvent): boolean {
-  const dialogOpen = document.querySelector('.dialog-overlay') !== null;
+  const dialogOpen = isDialogOpen();
   return shortcuts.some((s) => (s.global || (dialogOpen && s.dialogSafe)) && matches(e, s));
 }
 
@@ -50,7 +55,7 @@ export function initShortcuts(): () => void {
     const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 
     // Suppress non-dialog-safe shortcuts when a dialog overlay is open
-    const dialogOpen = document.querySelector('.dialog-overlay') !== null;
+    const dialogOpen = isDialogOpen();
 
     for (const s of shortcuts) {
       if (matches(e, s) && (!inInput || s.global) && (!dialogOpen || s.dialogSafe)) {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -37,9 +37,10 @@ export function registerShortcut(shortcut: Shortcut): () => void {
   };
 }
 
-/** Returns true if the event matches any shortcut with `global: true`. */
+/** Returns true if the event matches any shortcut that should bypass terminal input. */
 export function matchesGlobalShortcut(e: KeyboardEvent): boolean {
-  return shortcuts.some((s) => s.global && matches(e, s));
+  const dialogOpen = document.querySelector('.dialog-overlay') !== null;
+  return shortcuts.some((s) => (s.global || (dialogOpen && s.dialogSafe)) && matches(e, s));
 }
 
 export function initShortcuts(): () => void {


### PR DESCRIPTION
## Summary
- When a dialog (Help, Settings, New Task) is open and a terminal has focus, pressing ESC now correctly closes the dialog instead of being swallowed by xterm.js
- `matchesGlobalShortcut` now also passes `dialogSafe` shortcuts through xterm when a `.dialog-overlay` is present in the DOM
- ESC still reaches the terminal normally when no dialog is open (vim, readline, etc. unaffected)

## Test plan
- [ ] Open keyboard shortcuts dialog (Cmd+/ or F1), click into a terminal, press ESC — dialog should close
- [ ] Open settings dialog, click into a terminal, press ESC — dialog should close
- [ ] With no dialog open, press ESC in terminal — should reach the terminal as before (e.g. exit vim insert mode)
- [ ] Cmd+/ and F1 still toggle the help dialog from terminal focus (unchanged, already had `global: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)