### PR TITLE
fix: resolve shell tabs via OS user shell

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,5 +12,3 @@ package-lock.json
 *.AppImage
 *.deb
 *.dmg
-CLAUDE.local.md
-.enzyme/

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,5 @@ package-lock.json
 *.AppImage
 *.deb
 *.dmg
+CLAUDE.local.md
+.enzyme/

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import type { BrowserWindow } from 'electron';
 import { RingBuffer } from '../remote/ring-buffer.js';
+import { resolveUserShell } from '../user-shell.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -102,7 +103,7 @@ export function spawnAgent(
   },
 ): void {
   const channelId = args.onOutput.__CHANNEL_ID__;
-  const command = args.command || process.env.SHELL || '/bin/sh';
+  const command = args.command || resolveUserShell();
   const cwd = args.cwd || process.env.HOME || '/';
 
   // Reject commands with shell metacharacters (node-pty uses execvp, but

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import { registerAllHandlers } from './ipc/register.js';
 import { killAllAgents } from './ipc/pty.js';
 import { stopAllPlanWatchers } from './ipc/plans.js';
 import { IPC } from './ipc/channels.js';
+import { resolveUserShell } from './user-shell.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,7 +27,7 @@ const __dirname = path.dirname(__filename);
 function fixPath(): void {
   if (process.platform === 'win32') return;
   try {
-    const loginShell = process.env.SHELL || '/bin/sh';
+    const loginShell = resolveUserShell();
     const sentinel = '__PCODE_PATH__';
     const result = execFileSync(loginShell, ['-ilc', `printf "${sentinel}%s${sentinel}" "$PATH"`], {
       encoding: 'utf8',

--- a/electron/user-shell.test.ts
+++ b/electron/user-shell.test.ts
@@ -8,6 +8,11 @@ const mockUserInfo = {
   homedir: '/home/test-user',
 };
 
+const allowShells =
+  (...shells: string[]) =>
+  (shell: string) =>
+    shells.includes(shell);
+
 describe('resolveUserShell', () => {
   it('prefers the OS account shell over the inherited SHELL env var', () => {
     const shell = resolveUserShell({
@@ -17,6 +22,7 @@ describe('resolveUserShell', () => {
       }),
       env: { SHELL: '/bin/bash' },
       platform: 'darwin',
+      canUseShell: allowShells('/bin/zsh', '/bin/bash'),
     });
 
     expect(shell).toBe('/bin/zsh');
@@ -30,6 +36,7 @@ describe('resolveUserShell', () => {
       }),
       env: { SHELL: '/opt/homebrew/bin/bash' },
       platform: 'darwin',
+      canUseShell: allowShells('/opt/homebrew/bin/bash'),
     });
 
     expect(shell).toBe('/opt/homebrew/bin/bash');
@@ -42,19 +49,35 @@ describe('resolveUserShell', () => {
       },
       env: { SHELL: '/bin/zsh' },
       platform: 'linux',
+      canUseShell: allowShells('/bin/zsh'),
     });
 
     expect(shell).toBe('/bin/zsh');
   });
 
-  it('falls back to /bin/sh on POSIX when neither OS nor env provides a shell', () => {
+  it('falls back to SHELL when the OS shell is not executable', () => {
     const shell = resolveUserShell({
       userInfo: () => ({
         ...mockUserInfo,
-        shell: '   ',
+        shell: '/missing/zsh',
       }),
-      env: {},
+      env: { SHELL: '/bin/bash' },
       platform: 'linux',
+      canUseShell: allowShells('/bin/bash'),
+    });
+
+    expect(shell).toBe('/bin/bash');
+  });
+
+  it('falls back to /bin/sh on POSIX when neither OS nor env provides a usable shell', () => {
+    const shell = resolveUserShell({
+      userInfo: () => ({
+        ...mockUserInfo,
+        shell: '/missing/zsh',
+      }),
+      env: { SHELL: '/missing/bash' },
+      platform: 'linux',
+      canUseShell: allowShells(),
     });
 
     expect(shell).toBe('/bin/sh');

--- a/electron/user-shell.test.ts
+++ b/electron/user-shell.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { resolveUserShell } from './user-shell.js';
+
+const mockUserInfo = {
+  username: 'test-user',
+  uid: 501,
+  gid: 20,
+  homedir: '/home/test-user',
+};
+
+describe('resolveUserShell', () => {
+  it('prefers the OS account shell over the inherited SHELL env var', () => {
+    const shell = resolveUserShell({
+      userInfo: () => ({
+        ...mockUserInfo,
+        shell: '/bin/zsh',
+      }),
+      env: { SHELL: '/bin/bash' },
+      platform: 'darwin',
+    });
+
+    expect(shell).toBe('/bin/zsh');
+  });
+
+  it('falls back to SHELL when the OS lookup has no shell', () => {
+    const shell = resolveUserShell({
+      userInfo: () => ({
+        ...mockUserInfo,
+        shell: '',
+      }),
+      env: { SHELL: '/opt/homebrew/bin/bash' },
+      platform: 'darwin',
+    });
+
+    expect(shell).toBe('/opt/homebrew/bin/bash');
+  });
+
+  it('falls back to SHELL when the OS lookup throws', () => {
+    const shell = resolveUserShell({
+      userInfo: () => {
+        throw new Error('unavailable');
+      },
+      env: { SHELL: '/bin/zsh' },
+      platform: 'linux',
+    });
+
+    expect(shell).toBe('/bin/zsh');
+  });
+
+  it('falls back to /bin/sh on POSIX when neither OS nor env provides a shell', () => {
+    const shell = resolveUserShell({
+      userInfo: () => ({
+        ...mockUserInfo,
+        shell: '   ',
+      }),
+      env: {},
+      platform: 'linux',
+    });
+
+    expect(shell).toBe('/bin/sh');
+  });
+});

--- a/electron/user-shell.ts
+++ b/electron/user-shell.ts
@@ -1,0 +1,30 @@
+import * as os from 'node:os';
+
+interface ResolveUserShellDeps {
+  userInfo?: () => { shell: string | null | undefined };
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}
+
+function normalizeShell(shell: string | null | undefined): string | null {
+  const value = shell?.trim();
+  return value ? value : null;
+}
+
+export function resolveUserShell(deps: ResolveUserShellDeps = {}): string {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const userInfo = deps.userInfo ?? os.userInfo;
+
+  try {
+    const osShell = normalizeShell(userInfo().shell);
+    if (osShell) return osShell;
+  } catch {
+    // Fall back to inherited environment if the OS lookup is unavailable.
+  }
+
+  const envShell = normalizeShell(env.SHELL);
+  if (envShell) return envShell;
+
+  return platform === 'win32' ? 'cmd.exe' : '/bin/sh';
+}

--- a/electron/user-shell.ts
+++ b/electron/user-shell.ts
@@ -1,9 +1,11 @@
-import * as os from 'node:os';
+import fs from 'fs';
+import * as os from 'os';
 
 interface ResolveUserShellDeps {
   userInfo?: () => { shell: string | null | undefined };
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+  canUseShell?: (shell: string) => boolean;
 }
 
 function normalizeShell(shell: string | null | undefined): string | null {
@@ -11,20 +13,31 @@ function normalizeShell(shell: string | null | undefined): string | null {
   return value ? value : null;
 }
 
+function isExecutablePosixShell(shell: string): boolean {
+  try {
+    fs.accessSync(shell, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function resolveUserShell(deps: ResolveUserShellDeps = {}): string {
   const env = deps.env ?? process.env;
   const platform = deps.platform ?? process.platform;
   const userInfo = deps.userInfo ?? os.userInfo;
+  const canUseShell =
+    deps.canUseShell ?? ((shell: string) => platform === 'win32' || isExecutablePosixShell(shell));
 
   try {
     const osShell = normalizeShell(userInfo().shell);
-    if (osShell) return osShell;
+    if (osShell && canUseShell(osShell)) return osShell;
   } catch {
     // Fall back to inherited environment if the OS lookup is unavailable.
   }
 
   const envShell = normalizeShell(env.SHELL);
-  if (envShell) return envShell;
+  if (envShell && canUseShell(envShell)) return envShell;
 
   return platform === 'win32' ? 'cmd.exe' : '/bin/sh';
 }


### PR DESCRIPTION
## Summary
- resolve default shell selection via `os.userInfo().shell` before falling back to `process.env.SHELL`
- use the shared resolver for both PTY shell tabs and PATH bootstrap in the Electron main process
- add focused tests covering OS shell, env fallback, and `/bin/sh` fallback behavior

## Why
Parallel Code currently falls back to the inherited `SHELL` environment variable when no explicit shell command is provided. That can cause shell tabs to launch `bash` even when the user's actual account login shell is `zsh` (or another shell), depending on how Electron was launched.

Using the OS-reported user shell first makes the default shell selection more faithful and predictable.

## Test Plan
- `npm run typecheck`
- `npm test`
