### PR TITLE
feat(settings): add font smoothing toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,6 +235,11 @@ function App() {
     document.documentElement.dataset.look = store.themePreset;
   });
 
+  // Toggle font smoothing CSS class on body
+  createEffect(() => {
+    document.body.classList.toggle('font-smoothing', store.fontSmoothing);
+  });
+
   onMount(async () => {
     if (isMac) {
       await appWindow.setTitleBarStyle('overlay').catch((error) => {

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import {
   setAutoTrustFolders,
   setShowPlans,
   setShowPromptInput,
+  setFontSmoothing,
   setDesktopNotificationsEnabled,
   setInactiveColumnOpacity,
   setEditorCommand,
@@ -241,6 +242,31 @@ export function SettingsDialog(props: SettingsDialogProps) {
             </span>
             <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
               When hidden, the terminal occupies the full panel and auto-focuses on activation
+            </span>
+          </div>
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            'align-items': 'flex-start',
+            gap: '10px',
+            cursor: 'pointer',
+            padding: '8px 12px',
+            'border-radius': '8px',
+            background: theme.bgInput,
+            border: `1px solid ${theme.border}`,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={store.fontSmoothing}
+            onChange={(e) => setFontSmoothing(e.currentTarget.checked)}
+            style={{ 'accent-color': theme.accent, cursor: 'pointer' }}
+          />
+          <div style={{ display: 'flex', 'flex-direction': 'column', gap: '2px' }}>
+            <span style={{ 'font-size': '13px', color: theme.fg }}>Font smoothing</span>
+            <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
+              Enable antialiasing and geometric text rendering
             </span>
           </div>
         </label>

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -39,6 +39,7 @@ export const [store, setStore] = createStore<AppStore>({
   terminalFont: DEFAULT_TERMINAL_FONT,
   themePreset: 'minimal',
   showPromptInput: true,
+  fontSmoothing: true,
   windowState: null,
   autoTrustFolders: false,
   showPlans: true,

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -49,6 +49,7 @@ export async function saveState(): Promise<void> {
     terminalFont: store.terminalFont,
     themePreset: store.themePreset,
     showPromptInput: store.showPromptInput,
+    fontSmoothing: store.fontSmoothing,
     windowState: store.windowState ? { ...store.windowState } : undefined,
     autoTrustFolders: store.autoTrustFolders,
     showPlans: store.showPlans,
@@ -189,6 +190,7 @@ interface LegacyPersistedState {
   terminalFont?: unknown;
   themePreset?: unknown;
   showPromptInput?: unknown;
+  fontSmoothing?: unknown;
   windowState?: unknown;
   autoTrustFolders?: unknown;
   showPlans?: unknown;
@@ -300,6 +302,7 @@ export async function loadState(): Promise<void> {
           : DEFAULT_TERMINAL_FONT;
       s.themePreset = isLookPreset(raw.themePreset) ? raw.themePreset : 'minimal';
       s.showPromptInput = typeof raw.showPromptInput === 'boolean' ? raw.showPromptInput : true;
+      s.fontSmoothing = typeof raw.fontSmoothing === 'boolean' ? raw.fontSmoothing : true;
       s.windowState = parsePersistedWindowState(raw.windowState);
       s.autoTrustFolders = typeof raw.autoTrustFolders === 'boolean' ? raw.autoTrustFolders : false;
       s.showPlans = typeof raw.showPlans === 'boolean' ? raw.showPlans : true;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -97,6 +97,7 @@ export {
   setAutoTrustFolders,
   setShowPlans,
   setShowPromptInput,
+  setFontSmoothing,
   setDesktopNotificationsEnabled,
   setInactiveColumnOpacity,
   setEditorCommand,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -120,6 +120,7 @@ export interface PersistedState {
   terminalFont?: string;
   themePreset?: LookPreset;
   showPromptInput?: boolean;
+  fontSmoothing?: boolean;
   windowState?: PersistedWindowState;
   autoTrustFolders?: boolean;
   showPlans?: boolean;
@@ -185,6 +186,7 @@ export interface AppStore {
   terminalFont: string;
   themePreset: LookPreset;
   showPromptInput: boolean;
+  fontSmoothing: boolean;
   windowState: PersistedWindowState | null;
   autoTrustFolders: boolean;
   showPlans: boolean;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -90,6 +90,10 @@ export function setShowPromptInput(show: boolean): void {
   setStore('showPromptInput', show);
 }
 
+export function setFontSmoothing(enabled: boolean): void {
+  setStore('fontSmoothing', enabled);
+}
+
 export function setDesktopNotificationsEnabled(enabled: boolean): void {
   setStore('desktopNotificationsEnabled', enabled);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -58,8 +58,12 @@ body,
 body {
   font-family: var(--font-ui);
   color: var(--fg);
-  text-rendering: geometricPrecision;
+}
+
+body.font-smoothing {
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: geometricPrecision;
 }
 
 .app-shell {


### PR DESCRIPTION
## Summary
New setting to toggle font smoothing for the UI (Settings > Behavior).

**When enabled** (default): applies `-webkit-font-smoothing: antialiased` and `text-rendering: geometricPrecision` — the current hardcoded behavior.

**When disabled**: uses browser/OS default text rendering, which can appear sharper on some displays.

Does not affect terminal text (rendered by xterm.js WebGL addon).

## Motivation
The hardcoded antialiasing makes text appear softer on some Retina displays. This gives users the option to disable it and compare.

## Test plan
- [ ] Default: font smoothing enabled (existing behavior)
- [ ] Uncheck setting: UI text rendering changes immediately
- [ ] Setting persists across restarts
- [ ] Terminal text is unaffected by the toggle