### PR TITLE
fix(electron): inherit full login shell environment instead of PATH only

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,25 +25,33 @@ const __dirname = path.dirname(__filename);
 // welcome messages). Login-only (-lc) would be quieter but would miss tools
 // that are only added to PATH in .bashrc/.zshrc (e.g. nvm). We accept the
 // side effects since the sentinel-based parsing discards all other output.
-function fixPath(): void {
+function fixEnv(): void {
   if (process.platform === 'win32') return;
   try {
     const loginShell = resolveUserShell();
-    const sentinel = '__PCODE_PATH__';
-    const result = execFileSync(loginShell, ['-ilc', `printf "${sentinel}%s${sentinel}" "$PATH"`], {
-      encoding: 'utf8',
-      timeout: 5000,
-    });
-    const match = result.match(new RegExp(`${sentinel}(.+?)${sentinel}`));
-    if (match?.[1]) {
-      process.env.PATH = match[1];
+    const sentinel = '__PCODE_ENV__';
+    const result = execFileSync(
+      loginShell,
+      ['-ilc', `printf '${sentinel}' && env -0 && printf '${sentinel}'`],
+      { encoding: 'utf8', timeout: 5000 },
+    );
+    const startIdx = result.indexOf(sentinel);
+    const endIdx = result.lastIndexOf(sentinel);
+    if (startIdx === -1 || endIdx === -1 || startIdx === endIdx) return;
+
+    const envBlock = result.slice(startIdx + sentinel.length, endIdx);
+    for (const entry of envBlock.split('\0')) {
+      if (!entry) continue;
+      const eqIdx = entry.indexOf('=');
+      if (eqIdx <= 0) continue;
+      process.env[entry.slice(0, eqIdx)] = entry.slice(eqIdx + 1);
     }
   } catch (err) {
-    console.warn('[fixPath] Failed to resolve login shell PATH:', err);
+    console.warn('[fixEnv] Failed to resolve login shell environment:', err);
   }
 }
 
-fixPath();
+fixEnv();
 
 // Verify that preload.cjs ALLOWED_CHANNELS stays in sync with the IPC enum.
 // Logs a warning in dev if they drift — catches mismatches before they hit users.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,7 +32,10 @@ function fixEnv(): void {
     const sentinel = '__PCODE_ENV__';
     const result = execFileSync(
       loginShell,
-      ['-ilc', `printf '${sentinel}' && env -0 && printf '${sentinel}'`],
+      [
+        '-ilc',
+        `printf '${sentinel}' && perl -e 'print "$_=$ENV{$_}\\0" for keys %ENV' && printf '${sentinel}'`,
+      ],
       { encoding: 'utf8', timeout: 5000 },
     );
     const startIdx = result.indexOf(sentinel);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,19 @@ const __dirname = path.dirname(__filename);
 // Another trade-off: inheriting the *full* environment (rather than just PATH)
 // can pull in large variables (certificates, tokens, kubeconfig). We set a
 // generous maxBuffer and fall back to the original environment on failure.
+//
+// Skip vars that would alter Electron/Node runtime behavior if a user's shell
+// rc sets them — those belong to our process, not the login shell.
+const PROTECTED_ENV_KEYS = new Set([
+  'ELECTRON_RUN_AS_NODE',
+  'NODE_OPTIONS',
+  'NODE_EXTRA_CA_CERTS',
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+]);
+
 function fixEnv(): void {
   if (process.platform === 'win32') return;
   try {
@@ -53,7 +66,9 @@ function fixEnv(): void {
       if (!entry) continue;
       const eqIdx = entry.indexOf('=');
       if (eqIdx <= 0) continue;
-      process.env[entry.slice(0, eqIdx)] = entry.slice(eqIdx + 1);
+      const key = entry.slice(0, eqIdx);
+      if (PROTECTED_ENV_KEYS.has(key)) continue;
+      process.env[key] = entry.slice(eqIdx + 1);
     }
   } catch (err) {
     console.warn('[fixEnv] Failed to resolve login shell environment:', err);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,18 +13,24 @@ import { resolveUserShell } from './user-shell.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// When launched from a .desktop file, PATH is minimal (/usr/bin:/bin).
-// Resolve the user's full login-interactive shell PATH so spawned PTYs
-// can find CLI tools like claude, codex, gemini, etc.
+// When launched from a .desktop file (e.g. AppImage), the environment is
+// minimal — often just PATH=/usr/bin:/bin. Resolve the user's full
+// login-interactive shell environment and merge it into process.env so
+// spawned PTYs can find CLI tools (claude, codex, gemini, etc.) and
+// inherit other expected variables (SSH_AGENT_LAUNCHER, KUBECONFIG, etc.).
 //
 // Uses -ilc (interactive + login) to source both .zprofile/.profile AND
 // .zshrc/.bashrc, where version managers (nvm, volta, fnm) add to PATH.
-// Sentinel markers isolate PATH from noisy shell init output.
+// A perl one-liner dumps every env var as null-delimited key=value pairs,
+// bounded by sentinel markers to isolate the data from noisy shell init.
 //
 // Trade-off: -i (interactive) triggers .zshrc side effects (compinit, conda,
 // welcome messages). Login-only (-lc) would be quieter but would miss tools
 // that are only added to PATH in .bashrc/.zshrc (e.g. nvm). We accept the
 // side effects since the sentinel-based parsing discards all other output.
+// Another trade-off: inheriting the *full* environment (rather than just PATH)
+// can pull in large variables (certificates, tokens, kubeconfig). We set a
+// generous maxBuffer and fall back to the original environment on failure.
 function fixEnv(): void {
   if (process.platform === 'win32') return;
   try {
@@ -36,7 +42,7 @@ function fixEnv(): void {
         '-ilc',
         `printf '${sentinel}' && perl -e 'print "$_=$ENV{$_}\\0" for keys %ENV' && printf '${sentinel}'`,
       ],
-      { encoding: 'utf8', timeout: 5000 },
+      { encoding: 'utf8', timeout: 5000, maxBuffer: 10 * 1024 * 1024 },
     );
     const startIdx = result.indexOf(sentinel);
     const endIdx = result.lastIndexOf(sentinel);


### PR DESCRIPTION
# Description

When launched from a `.desktop` file or AppImage, the app previously only inherited `PATH` from the user's login shell via `fixPath()`. All other environment variables were lost, which caused two issues:

1. **Missing environment variables in PTYs** — Environment variables like `GOPATH`, `JAVA_HOME`, `SSH_AUTH_SOCK`, and `NVM_DIR` were not available in spawned PTYs, causing tools that depend on them to fail.
2. **Claude unusable with third-party API keys** — Users who access Claude through a third-party API provider need custom environment variables (e.g. `ANTHROPIC_BASE_URL`) configured in their shell profile. Since only `PATH` was inherited, these variables were missing and Claude could not connect at all.

This PR replaces `fixPath()` with `fixEnv()`, which runs `env -0` inside an interactive login shell to capture **all** environment variables (null-byte separated), then applies them to `process.env`. This ensures spawned PTYs have the same complete environment as the user's terminal.

## Issues Resolved

- AppImage / `.desktop` launcher only inherited `PATH` from the login shell; all other environment variables were lost in spawned PTYs.
- Claude was unusable when configured with third-party API keys, because custom environment variables (e.g. `ANTHROPIC_BASE_URL`) were not passed through to the PTY.

