### PR TITLE
fix(ui): respect user's choice to disable Docker mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parallel-code",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parallel-code",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.12.0-beta.195",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-code",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "author": {
     "name": "Johannes Millan",

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -50,7 +50,6 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const [branchesLoading, setBranchesLoading] = createSignal(false);
   const [skipPermissions, setSkipPermissions] = createSignal(false);
   const [dockerMode, setDockerMode] = createSignal(false);
-  const [dockerUserOptedOut, setDockerUserOptedOut] = createSignal(false);
   const [dockerImageReady, setDockerImageReady] = createSignal<boolean | null>(null); // null = unknown
   const [dockerBuilding, setDockerBuilding] = createSignal(false);
   const [dockerBuildOutput, setDockerBuildOutput] = createSignal('');
@@ -120,7 +119,6 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     setGitIsolation('worktree');
     setSkipPermissions(false);
     setDockerMode(false);
-    setDockerUserOptedOut(false);
     setDockerImageReady(null);
     setDockerBuilding(false);
     setDockerBuildOutput('');
@@ -283,14 +281,6 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     }
     const proj = getProject(pid);
     setGitIsolation(proj?.defaultGitIsolation ?? 'worktree');
-  });
-
-  // Auto-enable Docker when skip-permissions is turned on and Docker is available,
-  // but respect the user's explicit choice to disable it
-  createEffect(() => {
-    if (skipPermissions() && store.dockerAvailable && !dockerUserOptedOut()) {
-      setDockerMode(true);
-    }
   });
 
   // Check if the default Docker image exists when Docker mode is enabled (debounced)
@@ -755,12 +745,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
               <input
                 type="checkbox"
                 checked={dockerMode()}
-                onChange={(e) => {
-                  const checked = e.currentTarget.checked;
-                  setDockerMode(checked);
-                  if (!checked) setDockerUserOptedOut(true);
-                  else setDockerUserOptedOut(false);
-                }}
+                onChange={(e) => setDockerMode(e.currentTarget.checked)}
                 style={{ 'accent-color': theme.accent, cursor: 'inherit' }}
               />
               Run in Docker container

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -50,6 +50,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const [branchesLoading, setBranchesLoading] = createSignal(false);
   const [skipPermissions, setSkipPermissions] = createSignal(false);
   const [dockerMode, setDockerMode] = createSignal(false);
+  const [dockerUserOptedOut, setDockerUserOptedOut] = createSignal(false);
   const [dockerImageReady, setDockerImageReady] = createSignal<boolean | null>(null); // null = unknown
   const [dockerBuilding, setDockerBuilding] = createSignal(false);
   const [dockerBuildOutput, setDockerBuildOutput] = createSignal('');
@@ -119,6 +120,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     setGitIsolation('worktree');
     setSkipPermissions(false);
     setDockerMode(false);
+    setDockerUserOptedOut(false);
     setDockerImageReady(null);
     setDockerBuilding(false);
     setDockerBuildOutput('');
@@ -283,9 +285,10 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     setGitIsolation(proj?.defaultGitIsolation ?? 'worktree');
   });
 
-  // Auto-enable Docker when skip-permissions is turned on and Docker is available
+  // Auto-enable Docker when skip-permissions is turned on and Docker is available,
+  // but respect the user's explicit choice to disable it
   createEffect(() => {
-    if (skipPermissions() && store.dockerAvailable) {
+    if (skipPermissions() && store.dockerAvailable && !dockerUserOptedOut()) {
       setDockerMode(true);
     }
   });
@@ -752,7 +755,12 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
               <input
                 type="checkbox"
                 checked={dockerMode()}
-                onChange={(e) => setDockerMode(e.currentTarget.checked)}
+                onChange={(e) => {
+                  const checked = e.currentTarget.checked;
+                  setDockerMode(checked);
+                  if (!checked) setDockerUserOptedOut(true);
+                  else setDockerUserOptedOut(false);
+                }}
                 style={{ 'accent-color': theme.accent, cursor: 'inherit' }}
               />
               Run in Docker container


### PR DESCRIPTION
The auto-enable Docker effect would re-enable Docker mode whenever
skip-permissions was on and Docker was available, even after the user
explicitly unchecked it. Track the user's opt-out so the effect doesn't
override their choice.

https://claude.ai/code/session_01SvsewC7VFxe7fZuy1pc5uV