### PR TITLE
feat: support folders without git

### DIFF
--- a/src/components/CloseTaskDialog.tsx
+++ b/src/components/CloseTaskDialog.tsx
@@ -28,7 +28,7 @@ export function CloseTaskDialog(props: CloseTaskDialogProps) {
       title="Close Task"
       message={
         <div>
-          <Show when={props.task.gitIsolation === 'direct'}>
+          <Show when={props.task.gitIsolation !== 'worktree'}>
             <p style={{ margin: '0' }}>
               This will stop all running agents and shells for this task. No git operations will be
               performed.
@@ -120,7 +120,7 @@ export function CloseTaskDialog(props: CloseTaskDialogProps) {
         </div>
       }
       confirmLabel={
-        props.task.gitIsolation === 'direct' || props.task.externalWorktree ? 'Close' : 'Delete'
+        props.task.gitIsolation !== 'worktree' || props.task.externalWorktree ? 'Close' : 'Delete'
       }
       danger={props.task.gitIsolation === 'worktree' && !props.task.externalWorktree}
       onConfirm={() => {

--- a/src/components/EditProjectDialog.tsx
+++ b/src/components/EditProjectDialog.tsx
@@ -240,54 +240,56 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
               />
             </div>
 
-            {/* Branch prefix */}
-            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
-              <label style={sectionLabelStyle}>Branch prefix</label>
-              <input
-                class="input-field"
-                type="text"
-                value={branchPrefix()}
-                onInput={(e) => setBranchPrefix(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && canSave()) handleSave();
-                }}
-                placeholder="task"
-                style={{
-                  background: theme.bgInput,
-                  border: `1px solid ${theme.border}`,
-                  'border-radius': '8px',
-                  padding: '10px 14px',
-                  color: theme.fg,
-                  'font-size': '14px',
-                  'font-family': "'JetBrains Mono', monospace",
-                  outline: 'none',
-                }}
-              />
-              <Show when={branchPrefix().trim()}>
-                <div
-                  style={{
-                    'font-size': '12px',
-                    'font-family': "'JetBrains Mono', monospace",
-                    color: theme.fgSubtle,
-                    padding: '2px 2px 0',
-                    display: 'flex',
-                    'align-items': 'center',
-                    gap: '6px',
+            {/* Branch prefix — git projects only */}
+            <Show when={props.project?.isGitRepo !== false}>
+              <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
+                <label style={sectionLabelStyle}>Branch prefix</label>
+                <input
+                  class="input-field"
+                  type="text"
+                  value={branchPrefix()}
+                  onInput={(e) => setBranchPrefix(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && canSave()) handleSave();
                   }}
-                >
-                  <svg
-                    width="11"
-                    height="11"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    style={{ 'flex-shrink': '0' }}
+                  placeholder="task"
+                  style={{
+                    background: theme.bgInput,
+                    border: `1px solid ${theme.border}`,
+                    'border-radius': '8px',
+                    padding: '10px 14px',
+                    color: theme.fg,
+                    'font-size': '14px',
+                    'font-family': "'JetBrains Mono', monospace",
+                    outline: 'none',
+                  }}
+                />
+                <Show when={branchPrefix().trim()}>
+                  <div
+                    style={{
+                      'font-size': '12px',
+                      'font-family': "'JetBrains Mono', monospace",
+                      color: theme.fgSubtle,
+                      padding: '2px 2px 0',
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '6px',
+                    }}
                   >
-                    <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
-                  </svg>
-                  {sanitizeBranchPrefix(branchPrefix())}/{toBranchName('example-branch-name')}
-                </div>
-              </Show>
-            </div>
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      style={{ 'flex-shrink': '0' }}
+                    >
+                      <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
+                    </svg>
+                    {sanitizeBranchPrefix(branchPrefix())}/{toBranchName('example-branch-name')}
+                  </div>
+                </Show>
+              </div>
+            </Show>
 
             {/* Color palette */}
             <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
@@ -321,64 +323,67 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
               </div>
             </div>
 
-            {/* Merge cleanup preference */}
-            <label
-              style={{
-                display: 'flex',
-                'align-items': 'center',
-                gap: '8px',
-                cursor: 'pointer',
-                'font-size': '14px',
-                color: theme.fg,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={deleteBranchOnClose()}
-                onChange={(e) => setDeleteBranchOnClose(e.currentTarget.checked)}
-                style={{ cursor: 'pointer' }}
-              />
-              Always delete branch and worklog on merge
-            </label>
-
-            {/* Default isolation mode */}
-            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
-              <label style={sectionLabelStyle}>Default Git Isolation</label>
-              <SegmentedButtons
-                options={[
-                  { value: 'worktree', label: 'Worktree' },
-                  { value: 'direct', label: 'Current Branch' },
-                ]}
-                value={defaultGitIsolation()}
-                onChange={setDefaultGitIsolation}
-              />
-            </div>
-
-            {/* Default base branch */}
-            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
-              <label style={sectionLabelStyle}>
-                Default base branch{' '}
-                <span style={{ opacity: '0.5', 'text-transform': 'none' }}>
-                  (blank = auto-detect main)
-                </span>
-              </label>
-              <input
-                class="input-field"
-                type="text"
-                value={defaultBaseBranch()}
-                onInput={(e) => setDefaultBaseBranch(e.currentTarget.value)}
-                placeholder="main"
+            {/* Git-specific settings — hidden for non-git projects */}
+            <Show when={props.project?.isGitRepo !== false}>
+              {/* Merge cleanup preference */}
+              <label
                 style={{
-                  background: theme.bgInput,
-                  border: `1px solid ${theme.border}`,
-                  'border-radius': '8px',
-                  padding: '10px 14px',
-                  color: theme.fg,
+                  display: 'flex',
+                  'align-items': 'center',
+                  gap: '8px',
+                  cursor: 'pointer',
                   'font-size': '14px',
-                  outline: 'none',
+                  color: theme.fg,
                 }}
-              />
-            </div>
+              >
+                <input
+                  type="checkbox"
+                  checked={deleteBranchOnClose()}
+                  onChange={(e) => setDeleteBranchOnClose(e.currentTarget.checked)}
+                  style={{ cursor: 'pointer' }}
+                />
+                Always delete branch and worklog on merge
+              </label>
+
+              {/* Default isolation mode */}
+              <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
+                <label style={sectionLabelStyle}>Default Git Isolation</label>
+                <SegmentedButtons
+                  options={[
+                    { value: 'worktree', label: 'Worktree' },
+                    { value: 'direct', label: 'Current Branch' },
+                  ]}
+                  value={defaultGitIsolation()}
+                  onChange={setDefaultGitIsolation}
+                />
+              </div>
+
+              {/* Default base branch */}
+              <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
+                <label style={sectionLabelStyle}>
+                  Default base branch{' '}
+                  <span style={{ opacity: '0.5', 'text-transform': 'none' }}>
+                    (blank = auto-detect main)
+                  </span>
+                </label>
+                <input
+                  class="input-field"
+                  type="text"
+                  value={defaultBaseBranch()}
+                  onInput={(e) => setDefaultBaseBranch(e.currentTarget.value)}
+                  placeholder="main"
+                  style={{
+                    background: theme.bgInput,
+                    border: `1px solid ${theme.border}`,
+                    'border-radius': '8px',
+                    padding: '10px 14px',
+                    color: theme.fg,
+                    'font-size': '14px',
+                    outline: 'none',
+                  }}
+                />
+              </div>
+            </Show>
 
             {/* Command Bookmarks */}
             <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -12,6 +12,7 @@ import {
   getProjectBranchPrefix,
   updateProject,
   hasDirectTask,
+  projectIsGitRepo,
   getGitHubDropDefaults,
   setPrefillPrompt,
   setDockerAvailable,
@@ -193,11 +194,15 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   createEffect(() => {
     const pid = selectedProjectId();
     const path = pid ? getProjectPath(pid) : undefined;
+    const isGit = pid ? projectIsGitRepo(pid) : true;
     let cancelled = false;
 
-    if (!path) {
+    if (!path || !isGit) {
       setIgnoredDirs([]);
       setSelectedDirs(new Set<string>());
+      onCleanup(() => {
+        cancelled = true;
+      });
       return;
     }
 
@@ -233,7 +238,9 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     const projectPath = pid ? getProjectPath(pid) : undefined;
     let cancelled = false;
 
-    if (!open || !projectPath) {
+    const isGit = pid ? projectIsGitRepo(pid) : true;
+
+    if (!open || !projectPath || !isGit) {
       setBranches([]);
       setBaseBranch('');
       setBranchesLoading(false);
@@ -283,6 +290,10 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   createEffect(() => {
     const pid = selectedProjectId();
     if (!pid) return;
+    if (!projectIsGitRepo(pid)) {
+      setGitIsolation('none');
+      return;
+    }
     if (hasDirectTask(pid)) {
       setGitIsolation('worktree');
       return;
@@ -424,6 +435,11 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const selectedProjectPath = () => {
     const pid = selectedProjectId();
     return pid ? getProjectPath(pid) : undefined;
+  };
+
+  const isNonGitProject = () => {
+    const pid = selectedProjectId();
+    return pid ? !projectIsGitRepo(pid) : false;
   };
 
   const directDisabled = () => {
@@ -630,7 +646,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
               outline: 'none',
             }}
           />
-          <Show when={gitIsolation() === 'direct' && selectedProjectPath()}>
+          <Show when={gitIsolation() === 'direct' && !isNonGitProject() && selectedProjectPath()}>
             <div
               style={{
                 'font-size': '12px',
@@ -685,78 +701,82 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
           onSelect={setSelectedAgent}
         />
 
-        {/* Isolation mode selector */}
-        <div
-          data-nav-field="git-isolation"
-          style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}
-        >
-          <label style={sectionLabelStyle}>Git Isolation</label>
-          <SegmentedButtons
-            options={[
-              {
-                value: 'worktree',
-                label: 'Worktree',
-                title:
-                  'Creates a git branch and worktree so the AI agent can work in isolation without affecting your current branch.',
-              },
-              {
-                value: 'direct',
-                label: 'Current Branch',
-                disabled: directDisabled(),
-                title: 'The AI agent will work on your current branch in the project root.',
-              },
-            ]}
-            value={gitIsolation()}
-            onChange={setGitIsolation}
-          />
-          <Show when={directDisabled()}>
-            <span style={{ 'font-size': '12px', color: theme.fgSubtle }}>
-              This project already has a task on the current branch
-            </span>
-          </Show>
-          <Show when={gitIsolation() === 'direct'}>
-            <div style={{ ...bannerStyle(theme.warning), 'font-size': '13px' }}>
-              Changes will be made on the selected branch without worktree isolation.
-            </div>
-          </Show>
-        </div>
-
-        {/* Branch picker */}
-        <div
-          data-nav-field="base-branch"
-          style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}
-        >
-          <label style={sectionLabelStyle}>
-            {gitIsolation() === 'worktree' ? 'Base branch' : 'Branch'}
-            <Show when={branchesLoading()}>
-              {' '}
-              <span
-                class="inline-spinner"
-                aria-hidden="true"
-                style={{ 'vertical-align': 'middle' }}
-              />
-            </Show>
-          </label>
-          <select
-            class="input-field"
-            value={baseBranch()}
-            onChange={(e) => setBaseBranch(e.currentTarget.value)}
-            disabled={branchesLoading()}
-            style={{
-              background: theme.bgInput,
-              border: `1px solid ${theme.border}`,
-              'border-radius': '8px',
-              padding: '10px 14px',
-              color: theme.fg,
-              'font-size': '14px',
-              'font-family': "'JetBrains Mono', monospace",
-              outline: 'none',
-              opacity: branchesLoading() ? '0.5' : '1',
-            }}
+        {/* Isolation mode selector — hidden for non-git projects */}
+        <Show when={!isNonGitProject()}>
+          <div
+            data-nav-field="git-isolation"
+            style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}
           >
-            <For each={branches()}>{(b) => <option value={b}>{b}</option>}</For>
-          </select>
-        </div>
+            <label style={sectionLabelStyle}>Git Isolation</label>
+            <SegmentedButtons
+              options={[
+                {
+                  value: 'worktree',
+                  label: 'Worktree',
+                  title:
+                    'Creates a git branch and worktree so the AI agent can work in isolation without affecting your current branch.',
+                },
+                {
+                  value: 'direct',
+                  label: 'Current Branch',
+                  disabled: directDisabled(),
+                  title: 'The AI agent will work on your current branch in the project root.',
+                },
+              ]}
+              value={gitIsolation()}
+              onChange={setGitIsolation}
+            />
+            <Show when={directDisabled()}>
+              <span style={{ 'font-size': '12px', color: theme.fgSubtle }}>
+                This project already has a task on the current branch
+              </span>
+            </Show>
+            <Show when={gitIsolation() === 'direct'}>
+              <div style={{ ...bannerStyle(theme.warning), 'font-size': '13px' }}>
+                Changes will be made on the selected branch without worktree isolation.
+              </div>
+            </Show>
+          </div>
+        </Show>
+
+        {/* Branch picker — hidden for non-git projects */}
+        <Show when={!isNonGitProject()}>
+          <div
+            data-nav-field="base-branch"
+            style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}
+          >
+            <label style={sectionLabelStyle}>
+              {gitIsolation() === 'worktree' ? 'Base branch' : 'Branch'}
+              <Show when={branchesLoading()}>
+                {' '}
+                <span
+                  class="inline-spinner"
+                  aria-hidden="true"
+                  style={{ 'vertical-align': 'middle' }}
+                />
+              </Show>
+            </label>
+            <select
+              class="input-field"
+              value={baseBranch()}
+              onChange={(e) => setBaseBranch(e.currentTarget.value)}
+              disabled={branchesLoading()}
+              style={{
+                background: theme.bgInput,
+                border: `1px solid ${theme.border}`,
+                'border-radius': '8px',
+                padding: '10px 14px',
+                color: theme.fg,
+                'font-size': '14px',
+                'font-family': "'JetBrains Mono', monospace",
+                outline: 'none',
+                opacity: branchesLoading() ? '0.5' : '1',
+              }}
+            >
+              <For each={branches()}>{(b) => <option value={b}>{b}</option>}</For>
+            </select>
+          </div>
+        </Show>
 
         {/* Checkboxes group */}
         <div style={{ display: 'flex', 'flex-direction': 'column', gap: '10px' }}>

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -200,9 +200,6 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     if (!path || !isGit) {
       setIgnoredDirs([]);
       setSelectedDirs(new Set<string>());
-      onCleanup(() => {
-        cancelled = true;
-      });
       return;
     }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -827,6 +827,25 @@ function OffscreenAttentionBadge(props: { taskId: string }) {
   );
 }
 
+function NoGitBadge() {
+  return (
+    <span
+      style={{
+        'font-size': sf(10),
+        'font-weight': '600',
+        padding: '1px 5px',
+        'border-radius': '3px',
+        background: `color-mix(in srgb, ${theme.fgMuted} 12%, transparent)`,
+        color: theme.fgMuted,
+        'flex-shrink': '0',
+        'line-height': '1.5',
+      }}
+    >
+      no git
+    </span>
+  );
+}
+
 function CollapsedTaskRow(props: { taskId: string }) {
   const task = () => store.tasks[props.taskId];
   const offscreenAttention = createOffscreenAttentionState(() => props.taskId);
@@ -878,6 +897,9 @@ function CollapsedTaskRow(props: { taskId: string }) {
           />
           <Show when={t().gitIsolation === 'direct'}>
             <CurrentBranchBadge branchName={t().branchName} />
+          </Show>
+          <Show when={t().gitIsolation === 'none'}>
+            <NoGitBadge />
           </Show>
           <span style={{ flex: '1', overflow: 'hidden', 'text-overflow': 'ellipsis' }}>
             {t().name}
@@ -965,6 +987,9 @@ function TaskRow(props: TaskRowProps) {
               >
                 {t().branchName}
               </span>
+            </Show>
+            <Show when={t().gitIsolation === 'none'}>
+              <NoGitBadge />
             </Show>
             <span style={{ flex: '1', overflow: 'hidden', 'text-overflow': 'ellipsis' }}>
               {t().name}

--- a/src/components/TaskBranchInfoBar.tsx
+++ b/src/components/TaskBranchInfoBar.tsx
@@ -126,38 +126,40 @@ export function TaskBranchInfoBar(props: TaskBranchInfoBarProps) {
           );
         }}
       </Show>
-      <button
-        type="button"
-        title={editorTitle()}
-        onClick={handleOpenInEditor}
-        style={{ ...infoBarBtnStyle, 'margin-right': '12px' }}
-      >
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="currentColor"
-          style={{ 'flex-shrink': '0' }}
+      <Show when={props.task.gitIsolation !== 'none'}>
+        <button
+          type="button"
+          title={editorTitle()}
+          onClick={handleOpenInEditor}
+          style={{ ...infoBarBtnStyle, 'margin-right': '12px' }}
         >
-          <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
-        </svg>
-        <Show when={props.task.gitIsolation !== 'direct'}>{props.task.branchName}</Show>
-        <Show when={props.task.gitIsolation === 'direct'}>
-          <span
-            style={{
-              'font-size': '11px',
-              'font-weight': '600',
-              padding: '1px 6px',
-              'border-radius': '4px',
-              background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
-              color: theme.warning,
-              border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
-            }}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            style={{ 'flex-shrink': '0' }}
           >
-            {props.task.branchName}
-          </span>
-        </Show>
-      </button>
+            <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
+          </svg>
+          <Show when={props.task.gitIsolation !== 'direct'}>{props.task.branchName}</Show>
+          <Show when={props.task.gitIsolation === 'direct'}>
+            <span
+              style={{
+                'font-size': '11px',
+                'font-weight': '600',
+                padding: '1px 6px',
+                'border-radius': '4px',
+                background: `color-mix(in srgb, ${theme.warning} 15%, transparent)`,
+                color: theme.warning,
+                border: `1px solid color-mix(in srgb, ${theme.warning} 25%, transparent)`,
+              }}
+            >
+              {props.task.branchName}
+            </span>
+          </Show>
+        </button>
+      </Show>
       <button
         type="button"
         title={editorTitle()}

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -308,21 +308,29 @@ export function TaskPanel(props: TaskPanelProps) {
   };
 
   // Stack-mode inner horizontal split: notes on the left, changed-files on the right.
-  const stackNotesSplitChildren: PanelChild[] = [
-    { id: 'notes', initialSize: 200, minSize: 100, content: () => notesBodyEl },
-    { id: 'changed-files', initialSize: 200, minSize: 100, content: () => changedFilesEl },
-  ];
+  // Non-git tasks only get the notes panel (no changed-files split).
+  const isNoneGit = () => props.task.gitIsolation === 'none';
+  const stackNotesSplitChildren = (): PanelChild[] =>
+    isNoneGit()
+      ? [{ id: 'notes', initialSize: 200, minSize: 100, content: () => notesBodyEl }]
+      : [
+          { id: 'notes', initialSize: 200, minSize: 100, content: () => notesBodyEl },
+          { id: 'changed-files', initialSize: 200, minSize: 100, content: () => changedFilesEl },
+        ];
   const notesAndFilesChild: PanelChild = {
     id: 'notes-files',
     initialSize: 150,
     minSize: 60,
-    content: () => (
-      <ResizablePanel
-        direction="horizontal"
-        persistKey={`task:${props.task.id}:notes-split`}
-        children={stackNotesSplitChildren}
-      />
-    ),
+    content: () =>
+      isNoneGit() ? (
+        notesBodyEl
+      ) : (
+        <ResizablePanel
+          direction="horizontal"
+          persistKey={`task:${props.task.id}:notes-split`}
+          children={stackNotesSplitChildren()}
+        />
+      ),
   };
 
   // Split-mode right-column children.
@@ -421,7 +429,7 @@ export function TaskPanel(props: TaskPanelProps) {
                     direction="vertical"
                     persistKey={`task:${props.task.id}:split-right`}
                     children={[
-                      splitChangedFilesChild,
+                      ...(isNoneGit() ? [] : [splitChangedFilesChild]),
                       splitNotesBodyChild,
                       ...(props.task.stepsEnabled ? [stepsSectionChild] : []),
                       shellSectionChild,
@@ -438,55 +446,57 @@ export function TaskPanel(props: TaskPanelProps) {
         task={props.task}
         onDone={() => setShowCloseConfirm(false)}
       />
-      <MergeDialog
-        open={showMergeConfirm()}
-        task={props.task}
-        initialCleanup={
-          props.task.externalWorktree
-            ? false
-            : (getProject(props.task.projectId)?.deleteBranchOnClose ?? true)
-        }
-        onDone={() => setShowMergeConfirm(false)}
-        onDiffFileClick={(file) => setDiffScrollTarget(file.path)}
-      />
-      <PushDialog
-        open={showPushConfirm()}
-        task={props.task}
-        onStart={() => {
-          setPushing(true);
-          setPushSuccess(false);
-          clearTimeout(pushSuccessTimer);
-        }}
-        onClose={() => {
-          setShowPushConfirm(false);
-        }}
-        onDone={(success) => {
-          const wasHidden = !showPushConfirm();
-          setShowPushConfirm(false);
-          setPushing(false);
-          if (success) {
-            setPushSuccess(true);
-            pushSuccessTimer = setTimeout(() => setPushSuccess(false), 3000);
+      <Show when={props.task.gitIsolation !== 'none'}>
+        <MergeDialog
+          open={showMergeConfirm()}
+          task={props.task}
+          initialCleanup={
+            props.task.externalWorktree
+              ? false
+              : (getProject(props.task.projectId)?.deleteBranchOnClose ?? true)
           }
-          if (wasHidden) {
-            showNotification(success ? 'Push completed' : 'Push failed');
-          }
-        }}
-      />
-      <DiffViewerDialog
-        scrollToFile={diffScrollTarget()}
-        worktreePath={props.task.worktreePath}
-        projectRoot={getProject(props.task.projectId)?.path}
-        branchName={props.task.branchName}
-        baseBranch={props.task.baseBranch}
-        onClose={() => setDiffScrollTarget(null)}
-        taskId={props.task.id}
-        agentId={props.task.agentIds[0]}
-        commitList={commitList()}
-        selectedCommit={selectedCommit()}
-        onCommitNavigate={setSelectedCommit}
-        gitIsolation={props.task.gitIsolation}
-      />
+          onDone={() => setShowMergeConfirm(false)}
+          onDiffFileClick={(file) => setDiffScrollTarget(file.path)}
+        />
+        <PushDialog
+          open={showPushConfirm()}
+          task={props.task}
+          onStart={() => {
+            setPushing(true);
+            setPushSuccess(false);
+            clearTimeout(pushSuccessTimer);
+          }}
+          onClose={() => {
+            setShowPushConfirm(false);
+          }}
+          onDone={(success) => {
+            const wasHidden = !showPushConfirm();
+            setShowPushConfirm(false);
+            setPushing(false);
+            if (success) {
+              setPushSuccess(true);
+              pushSuccessTimer = setTimeout(() => setPushSuccess(false), 3000);
+            }
+            if (wasHidden) {
+              showNotification(success ? 'Push completed' : 'Push failed');
+            }
+          }}
+        />
+        <DiffViewerDialog
+          scrollToFile={diffScrollTarget()}
+          worktreePath={props.task.worktreePath}
+          projectRoot={getProject(props.task.projectId)?.path}
+          branchName={props.task.branchName}
+          baseBranch={props.task.baseBranch}
+          onClose={() => setDiffScrollTarget(null)}
+          taskId={props.task.id}
+          agentId={props.task.agentIds[0]}
+          commitList={commitList()}
+          selectedCommit={selectedCommit()}
+          onCommitNavigate={setSelectedCommit}
+          gitIsolation={props.task.gitIsolation}
+        />
+      </Show>
       <EditProjectDialog project={editingProject()} onClose={() => setEditingProjectId(null)} />
       <PlanViewerDialog
         open={planFullscreen()}

--- a/src/components/TaskTitleBar.tsx
+++ b/src/components/TaskTitleBar.tsx
@@ -70,6 +70,9 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
         <Show when={props.task.gitIsolation === 'direct'}>
           <span style={badgeStyle(theme.warning)}>{props.task.branchName}</span>
         </Show>
+        <Show when={props.task.gitIsolation === 'none'}>
+          <span style={badgeStyle(theme.fgMuted)}>no git</span>
+        </Show>
         <Show when={props.task.dockerMode}>
           <span style={badgeStyle(theme.fgMuted)} title={props.task.dockerImage}>
             {dockerBadgeLabel()}
@@ -87,7 +90,7 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
         />
       </div>
       <div style={{ display: 'flex', gap: '4px', 'margin-left': '8px', 'flex-shrink': '0' }}>
-        <Show when={props.task.gitIsolation !== 'direct'}>
+        <Show when={props.task.gitIsolation === 'worktree'}>
           <IconButton
             icon={
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -285,7 +285,7 @@ export function TilingLayout() {
                             const task = store.tasks[panelId];
                             if (task) {
                               const msg =
-                                task.gitIsolation === 'direct' || task.externalWorktree
+                                task.gitIsolation !== 'worktree' || task.externalWorktree
                                   ? 'Close this task? Running agents and shells will be stopped.'
                                   : 'Close this task? The worktree and branch will be deleted.';
                               if (window.confirm(msg)) closeTask(panelId);

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -1,5 +1,5 @@
 import { produce } from 'solid-js/store';
-import { confirm, openDialog } from '../lib/dialog';
+import { openDialog } from '../lib/dialog';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { store, setStore } from './core';
@@ -18,10 +18,10 @@ export function getProject(projectId: string): Project | undefined {
   return store.projects.find((p) => p.id === projectId);
 }
 
-export function addProject(name: string, path: string): string {
+export function addProject(name: string, path: string, isGitRepo?: boolean): string {
   const id = crypto.randomUUID();
   const color = randomPastelColor();
-  const project: Project = { id, name, path, color };
+  const project: Project = { id, name, path, color, isGitRepo };
   setStore(
     produce((s) => {
       s.projects.push(project);
@@ -65,6 +65,7 @@ export function updateProject(
       | 'defaultGitIsolation'
       | 'defaultBaseBranch'
       | 'terminalBookmarks'
+      | 'isGitRepo'
     >
   >,
 ): void {
@@ -84,6 +85,7 @@ export function updateProject(
         s.projects[idx].defaultBaseBranch = updates.defaultBaseBranch;
       if (updates.terminalBookmarks !== undefined)
         s.projects[idx].terminalBookmarks = updates.terminalBookmarks;
+      if (updates.isGitRepo !== undefined) s.projects[idx].isGitRepo = updates.isGitRepo;
     }),
   );
 }
@@ -123,15 +125,8 @@ export async function removeProjectWithTasks(projectId: string): Promise<void> {
   removeProject(projectId);
 }
 
-/** Returns true if the path is not a git repo root (and shows a warning dialog). */
-async function rejectNonGitFolder(dirPath: string): Promise<boolean> {
-  const isGit = await invoke<boolean>(IPC.CheckIsGitRepo, { path: dirPath });
-  if (isGit) return false;
-  await confirm(
-    'Parallel Code requires each project to be a git repository. It uses branches and worktrees to let AI agents work in isolation.\n\nTo initialize git, run "git init" in your project folder, then try again.',
-    { title: 'Not a Git Repository', kind: 'warning', okLabel: 'OK' },
-  );
-  return true;
+export function projectIsGitRepo(projectId: string): boolean {
+  return getProject(projectId)?.isGitRepo !== false;
 }
 
 export async function pickAndAddProject(): Promise<string | null> {
@@ -139,11 +134,11 @@ export async function pickAndAddProject(): Promise<string | null> {
   if (!selected) return null;
   const path = selected as string;
 
-  if (await rejectNonGitFolder(path)) return null;
+  const isGitRepo = await invoke<boolean>(IPC.CheckIsGitRepo, { path });
 
   const segments = path.split('/');
   const name = segments[segments.length - 1] || path;
-  return addProject(name, path);
+  return addProject(name, path, isGitRepo);
 }
 
 /** Check each project path and record which ones are missing. */
@@ -166,13 +161,14 @@ export async function relinkProject(projectId: string): Promise<boolean> {
   if (!selected) return false;
   const newPath = selected as string;
 
-  if (await rejectNonGitFolder(newPath)) return false;
+  const isGitRepo = await invoke<boolean>(IPC.CheckIsGitRepo, { path: newPath });
 
   setStore(
     produce((s) => {
       const idx = s.projects.findIndex((p) => p.id === projectId);
       if (idx === -1) return;
       s.projects[idx].path = newPath;
+      s.projects[idx].isGitRepo = isGitRepo;
     }),
   );
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,6 +12,7 @@ export {
   validateProjectPaths,
   relinkProject,
   isProjectMissing,
+  projectIsGitRepo,
   PASTEL_HUES,
 } from './projects';
 export {

--- a/src/store/taskStatus.ts
+++ b/src/store/taskStatus.ts
@@ -808,6 +808,7 @@ export function getTaskDotStatus(taskId: string): TaskDotStatus {
     if (latest.status === 'awaiting_review') return 'review';
   }
 
+  if (task.gitIsolation === 'none') return 'waiting';
   if (isTaskReady(taskId)) return 'ready';
   return 'waiting';
 }
@@ -816,7 +817,7 @@ export function getTaskDotStatus(taskId: string): TaskDotStatus {
 
 async function refreshTaskGitStatus(taskId: string): Promise<void> {
   const task = store.tasks[taskId];
-  if (!task) return;
+  if (!task || task.gitIsolation === 'none') return;
 
   try {
     const status = await invoke<WorktreeStatus>(IPC.GetWorktreeStatus, {

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -146,12 +146,17 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
     taskId = result.id;
     branchName = result.branch_name;
     worktreePath = result.worktree_path;
-  } else {
+  } else if (gitIsolation === 'direct') {
     if (hasDirectTask(projectId)) {
       throw new Error('This project already has a task on the current branch');
     }
     taskId = crypto.randomUUID();
     branchName = baseBranch;
+    worktreePath = projectRoot;
+  } else {
+    // 'none' — no git, work directly in the project folder
+    taskId = crypto.randomUUID();
+    branchName = '';
     worktreePath = projectRoot;
   }
 
@@ -388,7 +393,7 @@ export async function mergeTask(
 ): Promise<void> {
   const task = store.tasks[taskId];
   if (!task || task.closingStatus === 'removing') return;
-  if (task.gitIsolation === 'direct') return;
+  if (task.gitIsolation !== 'worktree') return;
 
   const projectRoot = getProjectPath(task.projectId);
   if (!projectRoot) return;
@@ -425,7 +430,7 @@ export async function mergeTask(
 
 export async function pushTask(taskId: string, onOutput: Channel<string>): Promise<void> {
   const task = store.tasks[taskId];
-  if (!task || task.gitIsolation === 'direct') return;
+  if (!task || task.gitIsolation !== 'worktree') return;
 
   const projectRoot = getProjectPath(task.projectId);
   if (!projectRoot) return;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -6,7 +6,7 @@ import type { KeyBinding } from '../lib/keybindings';
 /** A user override for a binding: partial key/modifiers to apply, or null to unbind. */
 export type KeybindingOverride = Partial<Pick<KeyBinding, 'key' | 'modifiers'>> | null;
 
-export type GitIsolationMode = 'worktree' | 'direct';
+export type GitIsolationMode = 'worktree' | 'direct' | 'none';
 
 export type TaskViewportVisibility = 'visible' | 'offscreen-left' | 'offscreen-right';
 
@@ -25,6 +25,7 @@ export interface Project {
   defaultGitIsolation?: GitIsolationMode;
   defaultBaseBranch?: string;
   terminalBookmarks?: TerminalBookmark[];
+  isGitRepo?: boolean; // undefined treated as true for backward compat
 }
 
 export interface Agent {


### PR DESCRIPTION
## Summary

Closes #66.

- Adds a `'none'` git isolation mode for projects that aren't git repositories
- Non-git folders can now be added as projects — the "Not a Git Repository" error dialog is removed
- `isGitRepo` is detected at project add/relink time and stored on the project
- When creating a task on a non-git project, git UI is automatically hidden (isolation selector, branch picker, branch prefix, merge/push buttons, changed files panel, diff viewer)
- "no git" badge shown in sidebar and title bar for these tasks
- Close dialog shows simple "stop agents" message without git warnings
- Fully backward compatible — existing projects default to `isGitRepo: true`

## Test plan

- [x] Add a non-git folder as a project (no error dialog)
- [x] Create a task on a non-git project — git UI sections are hidden
- [ ] Agents spawn and run in the project folder
- [x] Close task — simple close dialog, no git warnings
- [x] Sidebar/title bar show "no git" badge
- [ ] Add a git folder — all git UI still works as before
- [ ] Persistence: close and reopen app, non-git project and tasks restore correctly
- [ ] Edit non-git project settings — git settings (branch prefix, delete branch, isolation, base branch) are hidden