### PR TITLE
docs: add OpenSpec trial specs for remote-access and steps-tracking

### DIFF
--- a/openspec/changes/remote-access/design.md
+++ b/openspec/changes/remote-access/design.md
@@ -1,0 +1,100 @@
+# Remote Access — Technical Design
+
+## Architecture Overview
+
+```
+┌─────────────────┐     HTTP/WS      ┌──────────────────┐
+│  Mobile Browser  │ ◄─────────────► │  Remote Server    │
+│  (SPA client)    │                  │  (Node.js)        │
+└─────────────────┘                  └────────┬─────────┘
+                                              │
+                                     ┌────────▼─────────┐
+                                     │  PTY Manager      │
+                                     │  (agent processes) │
+                                     └──────────────────┘
+```
+
+The remote server is an HTTP + WebSocket server embedded in the Electron main process. It serves a mobile-optimized SPA and provides real-time agent communication over WebSocket.
+
+## Components
+
+### 1. HTTP Server (`electron/remote/server.ts`)
+
+Single `http.createServer` instance handling:
+- **Static file serving**: serves the pre-built remote SPA from disk
+- **REST API**: `/api/agents` and `/api/agents/:agentId` for initial data loads
+- **WebSocket upgrade**: `ws` library mounted on the same HTTP server
+
+The server is started/stopped on demand via IPC (`StartRemoteServer` / `StopRemoteServer`). Only one instance runs at a time.
+
+### 2. WebSocket Layer
+
+Uses the `ws` library (`WebSocketServer`) with:
+- `maxPayload: 64KB` — prevents memory abuse
+- `verifyClient` — enforces 10-connection cap
+- Per-client subscription tracking via `WeakMap<WebSocket, Map<agentId, callback>>`
+- Authenticated client tracking via `Set<WebSocket>`
+
+Connection lifecycle:
+1. `connection` event → start auth timer (5s)
+2. First message → validate token → add to authenticated set → send agent list
+3. Subsequent messages → dispatch to PTY operations
+4. `close` event → unsubscribe all agent listeners, clean up
+
+### 3. Agent List Building
+
+`buildAgentList()` constructs the agent list by:
+- Iterating all active agent IDs from the PTY manager
+- Filtering out shell/sub-terminals (`isShell`)
+- Deduplicating by taskId (preferring running agents)
+- Enriching with task name and status from callbacks
+
+Broadcast triggers:
+- `spawn` event → refreshes full list
+- `list-changed` event → refreshes full list
+- `exit` event → sends status change + delayed list refresh (100ms)
+
+### 4. Ring Buffer (`electron/remote/ring-buffer.ts`)
+
+Fixed-capacity circular buffer (default 64KB) for terminal scrollback:
+- Stores raw terminal bytes
+- On `subscribe`, dumps entire buffer as base64 for initial replay
+- Handles data larger than capacity by keeping only the tail
+- Separate from the main terminal scrollback (lightweight, remote-only)
+
+### 5. Remote SPA (`src/remote/`)
+
+Separate Vite build target producing a standalone SPA:
+- Connects via WebSocket with first-message auth
+- Renders agent list and terminal output using xterm.js
+- Responsive layout optimized for phone screens
+- Token stored in localStorage for reconnection
+
+## Data Flow
+
+### Live Output Streaming
+```
+PTY output → subscribeToAgent callback → ws.send(output message) → client xterm
+```
+
+### User Input
+```
+Client xterm keypress → ws.send(input message) → writeToAgent(agentId, data) → PTY stdin
+```
+
+### Scrollback Replay
+```
+Client subscribes → getAgentScrollback(agentId) → ws.send(scrollback) → client xterm.write
+```
+
+## Key Decisions
+
+1. **First-message auth over URL auth**: Tokens in URLs leak through proxy logs, browser history, and Referer headers. First-message auth keeps the token in the WebSocket frame only.
+
+2. **WeakMap for per-client state**: Subscription maps and auth timers use WeakMap keyed by WebSocket, so cleanup is automatic when the client disconnects and the WebSocket is garbage collected.
+
+3. **Bind to 0.0.0.0**: Required for access from other devices on the network. The token-based auth protects against unauthorized access.
+
+4. **Separate SPA build**: The remote UI has different dependencies (no Electron APIs, mobile layout) and is served as static files. Keeping it as a separate Vite build avoids bundling Electron-specific code.
+
+5. **No persistent scrollback**: The ring buffer is in-memory only. If the app restarts, scrollback is lost. This keeps the implementation simple and avoids disk I/O for a monitoring feature.

--- a/openspec/changes/remote-access/proposal.md
+++ b/openspec/changes/remote-access/proposal.md
@@ -1,0 +1,30 @@
+# Remote Access
+
+## Problem
+
+Users running long-lived AI agent tasks on their desktop need a way to monitor progress from their phone or tablet without being at their computer. Currently, there is no way to check on agent status, view terminal output, or interact with agents remotely.
+
+## Motivation
+
+AI coding tasks often run for minutes to hours. Users step away from their desk and lose visibility into what their agents are doing. They want to:
+
+- Glance at their phone to see if a task finished or errored
+- Read terminal output from agents working in parallel
+- Send input or kill a stuck agent without returning to their desk
+- Share a monitoring view with a collaborator on the same network
+
+## Scope
+
+- Real-time remote monitoring of all running agents via WebSocket
+- Mobile-optimized web UI served from the Electron app
+- Token-based authentication (no account system)
+- Works over local WiFi and Tailscale networks
+- Read terminal output (scrollback + live stream)
+- Send input, resize, and kill agents remotely
+
+## Out of Scope
+
+- Internet-accessible tunneling (ngrok, Cloudflare Tunnel)
+- Multi-user access control or permissions
+- Persistent session history (scrollback is in-memory only)
+- File browsing or diff viewing from the remote UI

--- a/openspec/changes/remote-access/specs/security.md
+++ b/openspec/changes/remote-access/specs/security.md
@@ -1,0 +1,56 @@
+# Security Specification
+
+## Authentication
+
+### Token Generation
+- 24 random bytes, base64url-encoded (32 characters)
+- Generated once per server session using `crypto.randomBytes()`
+- Not persisted — new token each time the server starts
+
+### Token Delivery
+- Primary: first WebSocket message `{ type: "auth", token: "..." }`
+- Fallback: URL query parameter `?token=...`
+- REST API: `Authorization: Bearer <token>` header, or `?token=` query parameter
+
+### Token Comparison
+- Timing-safe comparison via `crypto.timingSafeEqual()` to prevent timing attacks
+- Buffer length check before comparison (different lengths fail fast — acceptable since length is constant)
+
+### Unauthenticated Connection Handling
+- WebSocket connections have 5 seconds to authenticate before forced close (code `4001`)
+- REST API routes under `/api/` return `401 Unauthorized` immediately
+- Unauthenticated WebSocket clients cannot receive or send any messages
+
+## Connection Limits
+
+- Maximum 10 concurrent WebSocket connections (enforced in `verifyClient`)
+- Excess connections rejected with HTTP `429`
+
+## Input Validation
+
+- WebSocket payload max: 64 KB
+- Input data max: 4096 characters per message
+- Agent ID max: 100 characters
+- Terminal resize bounds: 1-500 for both cols and rows
+- Auth token max: 200 characters
+- Invalid/malformed messages are silently dropped (no error response)
+
+## HTTP Security Headers
+
+All HTTP responses include:
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: no-referrer`
+
+## Static File Serving
+
+- Path traversal prevention: resolved path must be within the static directory (relative path check, rejects `..`)
+- SPA fallback: unknown paths serve `index.html` (no directory listing)
+- Cache policy: HTML is `no-cache`, assets are immutable with 1-year max-age
+
+## Network Binding
+
+- Server binds to `0.0.0.0` (all interfaces) on the configured port
+- Detects WiFi and Tailscale IPs for generating access URLs
+- Tailscale IPs identified by `100.x.x.x` range
+- Docker/container IPs (`172.x.x.x`) are excluded from WiFi detection

--- a/openspec/changes/remote-access/specs/websocket-protocol.md
+++ b/openspec/changes/remote-access/specs/websocket-protocol.md
@@ -1,0 +1,122 @@
+# WebSocket Protocol Specification
+
+## Connection Flow
+
+1. Client connects to `ws://<host>:<port>`
+2. Client sends `{ type: "auth", token: "<token>" }` as the first message
+3. Server validates token (timing-safe comparison) and sends back the current agent list
+4. If auth fails, server closes connection with code `4001` ("Unauthorized")
+5. Unauthenticated connections are closed after 5 seconds
+
+Legacy flow: token may also be provided as a `?token=` query parameter on the WebSocket URL. The first-message auth flow is preferred because it avoids tokens appearing in proxy logs or browser history.
+
+## Server -> Client Messages
+
+### `agents`
+Sent on connect and whenever the agent list changes (spawn, exit).
+
+```json
+{
+  "type": "agents",
+  "list": [
+    {
+      "agentId": "uuid",
+      "taskId": "uuid",
+      "taskName": "Add JWT auth",
+      "status": "running",
+      "exitCode": null,
+      "lastLine": "Implementing middleware..."
+    }
+  ]
+}
+```
+
+- Deduplicated by taskId (one entry per task, prefers running agent over exited)
+- Shell/sub-terminals are excluded (only main agents shown)
+
+### `output`
+Live terminal output for a subscribed agent.
+
+```json
+{ "type": "output", "agentId": "uuid", "data": "<base64>" }
+```
+
+### `scrollback`
+Full terminal history sent when subscribing to an agent.
+
+```json
+{ "type": "scrollback", "agentId": "uuid", "data": "<base64>", "cols": 120 }
+```
+
+### `status`
+Agent status change (currently only sent on exit).
+
+```json
+{ "type": "status", "agentId": "uuid", "status": "exited", "exitCode": 0 }
+```
+
+## Client -> Server Messages
+
+### `auth`
+First message to authenticate. Token max length: 200 chars.
+
+```json
+{ "type": "auth", "token": "base64url-encoded-token" }
+```
+
+### `subscribe` / `unsubscribe`
+Subscribe to live output for a specific agent. Subscribing sends the full scrollback first, then streams new output.
+
+```json
+{ "type": "subscribe", "agentId": "uuid" }
+{ "type": "unsubscribe", "agentId": "uuid" }
+```
+
+### `input`
+Send terminal input to an agent. Data max length: 4096 chars.
+
+```json
+{ "type": "input", "agentId": "uuid", "data": "yes\n" }
+```
+
+### `resize`
+Resize an agent's terminal. Cols and rows must be integers between 1 and 500.
+
+```json
+{ "type": "resize", "agentId": "uuid", "cols": 80, "rows": 24 }
+```
+
+### `kill`
+Kill a running agent.
+
+```json
+{ "type": "kill", "agentId": "uuid" }
+```
+
+## Validation Rules
+
+- All messages are JSON. Invalid JSON is silently dropped.
+- `type` must be a string.
+- `agentId` must be a string, max 100 chars.
+- Unknown message types are silently dropped.
+- Max WebSocket payload: 64 KB.
+- Max concurrent connections: 10.
+
+## REST API
+
+### `GET /api/agents`
+Returns the current agent list (same format as the `agents` WebSocket message `list` field).
+
+### `GET /api/agents/:agentId`
+Returns agent details including scrollback.
+
+```json
+{
+  "agentId": "uuid",
+  "scrollback": "<base64>",
+  "status": "running",
+  "exitCode": null
+}
+```
+
+All API routes require authentication via `Authorization: Bearer <token>` header or `?token=` query parameter.

--- a/openspec/changes/remote-access/tasks.md
+++ b/openspec/changes/remote-access/tasks.md
@@ -1,0 +1,43 @@
+# Remote Access — Implementation Tasks
+
+## Backend
+
+- [x] Define WebSocket protocol types (ServerMessage, ClientMessage) in `electron/remote/protocol.ts`
+- [x] Implement message parsing with validation (`parseClientMessage`)
+- [x] Implement ring buffer for scrollback storage (`electron/remote/ring-buffer.ts`)
+- [x] Create HTTP server with static file serving and path traversal protection
+- [x] Add REST API endpoints (`/api/agents`, `/api/agents/:agentId`)
+- [x] Set up WebSocket server with connection cap and payload limit
+- [x] Implement token generation (24 bytes, base64url)
+- [x] Implement timing-safe token comparison
+- [x] Add first-message auth flow with 5-second timeout
+- [x] Add legacy URL query parameter auth (backward compatibility)
+- [x] Implement agent list building with shell filtering and task deduplication
+- [x] Wire up PTY event listeners (spawn, exit, list-changed) for broadcasting
+- [x] Implement subscribe/unsubscribe with scrollback replay
+- [x] Handle client disconnect (unsubscribe all, clean up auth state)
+- [x] Detect WiFi and Tailscale network interfaces for URL generation
+
+## IPC Integration
+
+- [x] Add `StartRemoteServer`, `StopRemoteServer`, `GetRemoteStatus` IPC channels
+- [x] Register IPC handlers in `electron/ipc/register.ts`
+- [x] Track server state (token, port, URLs, connected clients) in app store
+
+## Frontend (Desktop)
+
+- [x] Add remote access toggle in settings/UI
+- [x] Display connection URL and QR code
+- [x] Show connected client count
+- [x] Support start/stop server lifecycle
+
+## Remote SPA (Mobile)
+
+- [x] Set up separate Vite build for `src/remote/`
+- [x] Implement WebSocket client with first-message auth
+- [x] Store token in localStorage for reconnection
+- [x] Build agent list view with status indicators
+- [x] Integrate xterm.js for terminal rendering
+- [x] Add input support (keyboard on mobile)
+- [x] Handle resize events
+- [x] Mobile-responsive layout

--- a/openspec/changes/steps-tracking/design.md
+++ b/openspec/changes/steps-tracking/design.md
@@ -1,0 +1,106 @@
+# Steps Tracking — Technical Design
+
+## Architecture Overview
+
+```
+┌──────────────┐    prompt     ┌──────────────┐   fs.write    ┌─────────────┐
+│  Task Dialog  │ ──injection──►│  AI Agent     │ ────────────►│  steps.json │
+│  (opt-in)     │              │  (PTY process) │              │  (.claude/)  │
+└──────────────┘              └──────────────┘              └──────┬──────┘
+                                                                    │
+                                                              fs.watch (200ms debounce)
+                                                                    │
+┌──────────────┐    IPC push   ┌──────────────┐   read+parse  ┌────▼────────┐
+│  Steps UI     │ ◄────────────│  Store        │ ◄─────────────│  Watcher    │
+│  (SolidJS)    │              │  (frontend)   │              │  (backend)   │
+└──────────────┘              └──────────────┘              └─────────────┘
+```
+
+## Data Flow
+
+### 1. Prompt Injection (`src/store/tasks.ts`)
+
+When `stepsEnabled` is true, the steps instruction text is appended to the user's initial prompt after a `\n\n---\n` separator. The original prompt is preserved in `savedInitialPrompt` so the user can see what they typed vs. what was injected.
+
+The instruction tells the agent:
+- Where to write (`.claude/steps.json`)
+- The JSON format (append-only array)
+- Field constraints (summary ≤60 chars, action verbs, etc.)
+- The `awaiting_review` pause behavior
+
+### 2. Backend Watcher (`electron/ipc/steps.ts`)
+
+State per task:
+```ts
+interface StepsWatcher {
+  fsWatcher: fs.FSWatcher | null;
+  timeout: ReturnType<typeof setTimeout> | null;
+  stepsDir: string;      // /path/to/worktree/.claude
+  stepsFile: string;     // /path/to/worktree/.claude/steps.json
+}
+```
+
+Stored in a module-level `Map<string, StepsWatcher>` keyed by taskId.
+
+The watcher handles two scenarios:
+1. **`.claude/` exists**: watch it directly
+2. **`.claude/` doesn't exist**: watch worktree root, swap when `.claude/` appears
+
+On change (debounced 200ms):
+- Read `steps.json`
+- Parse JSON
+- Validate it's an array
+- Send via `win.webContents.send(IPC.StepsContent, { taskId, steps })`
+
+### 3. Frontend Store (`src/store/tasks.ts`)
+
+```ts
+setStepsContent(taskId: string, steps: unknown[] | null): void
+```
+
+Filters entries to keep only non-null objects (loose validation), stores as `StepEntry[]` on the task.
+
+### 4. UI Component (`src/components/TaskStepsSection.tsx`)
+
+Two-zone layout:
+- **History zone**: collapsed step entries (click to expand). Shows: index, status badge (colored), summary, duration between steps, file count.
+- **Latest step zone**: always expanded, anchored at bottom. Shows: status badge, summary, relative timestamp, detail text, file badges.
+- **Waiting indicator**: pulsing dot + "Waiting for next step" when user sent input after the last step completed.
+
+Auto-scrolls to bottom when new steps appear. Keyboard navigation (arrow keys, page up/down) when focused.
+
+### 5. Panel Integration (`src/components/TaskPanel.tsx`)
+
+Steps section is a conditional `PanelChild` in the `ResizablePanel`:
+- Initial size: 28px (header only when no steps)
+- Expands to 110px when steps arrive
+- Only included when `task.stepsEnabled` is true
+
+## Persistence
+
+### Task-level
+- `stepsEnabled` is saved on `PersistedTask` and restored on app restart
+- Steps content itself is NOT persisted (read fresh from disk via `ReadStepsContent` IPC)
+
+### App-level
+- `showSteps` (boolean) saves the last-used default for the new task dialog checkbox
+- Stored on `PersistedState`, restored on load (defaults to `false`)
+
+## Git Integration
+
+Steps files are excluded from git via `.git/info/exclude` (not `.gitignore`):
+- Local to the worktree — never committed
+- For linked worktrees, the exclude file is found by parsing `.git` (a file, not a directory) for the `gitdir:` pointer
+- The exclude entry `.claude/steps.json` is appended idempotently (checks for existing entry first)
+
+## Key Decisions
+
+1. **Append-only format**: Agents never edit previous entries. This avoids merge conflicts and makes the file trivially parseable — just read the whole array.
+
+2. **Prompt injection over config file**: The steps format is communicated via prompt text, not a config file the agent reads. This works with any agent that follows natural language instructions.
+
+3. **Watch directory, not file**: `fs.watch` on individual files breaks with atomic writes. Watching `.claude/` is more reliable across platforms.
+
+4. **Loose validation**: The frontend accepts any non-null object as a step entry. This forward-compatibility means adding new fields to `StepEntry` won't break older frontends.
+
+5. **No persistent storage**: Steps are ephemeral — they live in the worktree and are re-read from disk on restart. This avoids a separate database and keeps the feature zero-config.

--- a/openspec/changes/steps-tracking/proposal.md
+++ b/openspec/changes/steps-tracking/proposal.md
@@ -1,0 +1,31 @@
+# Steps Tracking
+
+## Problem
+
+When an AI agent runs a complex task, the user's only window into progress is the raw terminal output scrolling by. Terminal output is noisy — full of tool calls, file contents, and verbose logs. Users can't quickly answer "what has the agent done so far?" or "what is it working on right now?" without reading through hundreds of lines of output.
+
+## Motivation
+
+Users managing multiple parallel agents need a compact, structured progress view for each task. They want to:
+
+- See at a glance which phase the agent is in (investigating, implementing, testing)
+- Know which files were modified and when
+- Understand elapsed time per step to identify stuck agents
+- Know when the agent is waiting for their review
+- Get this information without parsing terminal output themselves
+
+## Scope
+
+- Agent writes structured progress entries to a JSON file (`.claude/steps.json`)
+- Backend watches for file changes and streams updates to the frontend via IPC
+- Frontend renders a live progress timeline in each task panel
+- Steps instruction is injected into the agent's initial prompt (opt-in per task)
+- Steps file is excluded from git (never committed)
+- Works with both worktree and direct-mode tasks
+
+## Out of Scope
+
+- Automatic step detection from terminal output (steps are agent-authored)
+- Step editing or reordering by the user
+- Cross-task step aggregation or dashboards
+- Step persistence beyond the task's lifetime (steps live in the worktree)

--- a/openspec/changes/steps-tracking/specs/file-watching.md
+++ b/openspec/changes/steps-tracking/specs/file-watching.md
@@ -1,0 +1,70 @@
+# File Watching Specification
+
+## Watched Path
+
+The backend watches the `.claude/` directory (not `steps.json` directly) for changes.
+
+**Rationale**: `fs.watch` on a single file is unreliable with atomic writes (temp-file-then-rename pattern), especially on macOS. Watching the parent directory catches all write strategies.
+
+## Directory Existence Handling
+
+### `.claude/` exists at spawn time
+Watch `.claude/` immediately with `fs.watch`.
+
+### `.claude/` does not exist yet (fresh worktree)
+1. Watch the worktree root directory instead
+2. Filter events for `.claude` filename only
+3. When `.claude/` appears, close the root watcher and swap to watching `.claude/`
+4. If `steps.json` already exists at swap time, do an immediate read
+
+## Change Detection
+
+- Filter: only react to events where `filename === 'steps.json'` (when the platform provides a filename; some platforms pass `null`, in which case all events trigger a read)
+- Debounce: 200ms after the last change event before reading the file
+- This handles rapid sequential writes without redundant reads
+
+## Initial Read
+
+After setting up the watcher, perform an immediate read of `steps.json` if it exists. This handles the race condition where the agent writes before the watcher is established.
+
+## Error Handling
+
+- `ENOENT` when reading `steps.json`: silently return `null` (file not written yet)
+- Other read errors: log to console, return `null`
+- Watcher errors: log warning, watcher continues running
+- Failed to watch directory: log warning, skip (steps won't update but app continues)
+
+## IPC Events
+
+### `StepsContent` (server -> client push)
+Sent whenever steps.json content changes.
+```ts
+{ taskId: string; steps: unknown[] | null }
+```
+
+### `ReadStepsContent` (client request, one-shot)
+Used on app restart to restore steps for persisted tasks.
+```ts
+// Request
+{ worktreePath: string }
+// Response
+unknown[] | null
+```
+
+### `StopStepsWatcher` (client request)
+Stops and cleans up the watcher for a task. Called on:
+- Task close
+- Task collapse
+- Task removal from store
+
+Idempotent — safe to call multiple times for the same taskId.
+
+## Lifecycle
+
+| Event | Action |
+|-------|--------|
+| Agent spawns (stepsEnabled=true) | `startStepsWatcher()` — adds git exclude, starts watching |
+| Steps.json written/updated | Debounced read → IPC push to renderer |
+| Task collapsed | `stopStepsWatcher()` via IPC |
+| Task closed/removed | `stopStepsWatcher()` via IPC (called in `removeTaskFromStore`) |
+| App shutdown | `stopAllStepsWatchers()` |

--- a/openspec/changes/steps-tracking/specs/step-format.md
+++ b/openspec/changes/steps-tracking/specs/step-format.md
@@ -1,0 +1,71 @@
+# Step Entry Format Specification
+
+## File Location
+
+`.claude/steps.json` in the task's worktree root.
+
+## File Format
+
+JSON array of step entry objects. The agent appends new entries to the end of the array. Previous entries are never modified.
+
+```json
+[
+  {
+    "summary": "Add JWT validation middleware",
+    "status": "implementing",
+    "detail": "Wraps every protected route handler.",
+    "files_touched": ["src/middleware/auth.ts"],
+    "timestamp": "2024-01-15T10:30:00Z"
+  }
+]
+```
+
+## Fields
+
+### `summary` (required, string)
+- Maximum 60 characters
+- Starts with an action verb (e.g. "Add", "Fix", "Refactor")
+- No filler words ("Successfully", "Now", "Going to")
+- Describes what the agent is doing or has done
+
+### `status` (required, string enum)
+One of:
+| Status | Meaning | Color |
+|--------|---------|-------|
+| `starting` | Beginning a new step | Orange |
+| `investigating` | Reading code, understanding the problem | Blue |
+| `implementing` | Writing or modifying code | Purple |
+| `testing` | Running tests or verifying changes | Amber |
+| `awaiting_review` | Agent paused, waiting for user input | Red |
+| `done` | Step completed successfully | Green |
+
+### `detail` (optional, string)
+- One sentence maximum
+- Only included when it adds context the summary cannot carry
+- Omit the field entirely (don't set to empty string) when not needed
+
+### `files_touched` (optional, string array)
+- Only files the agent actually wrote or modified in this step
+- Not files the agent merely read
+- Relative paths from the worktree root
+
+### `timestamp` (required, string)
+- ISO 8601 format
+- Should include timezone (UTC preferred with `Z` suffix)
+- Timestamps without timezone info are treated as UTC by the UI (appends `Z`)
+
+## Step Lifecycle
+
+For each major unit of work, the agent writes two entries:
+1. A "starting" entry before beginning the work
+2. A completion entry ("done", "implementing", etc.) after finishing
+
+The `awaiting_review` status is special: when the agent writes this status, it should pause and wait for user input before continuing.
+
+## Validation
+
+The frontend filters step entries, keeping only objects that are non-null and non-array. No strict schema validation is applied — unknown fields are silently ignored. This allows forward compatibility with future extensions.
+
+## Git Exclusion
+
+The steps file is added to `.git/info/exclude` (local, per-worktree, never committed) so it doesn't appear in diffs or status. For linked worktrees, the exclude file is located by following the `.git` file's `gitdir:` pointer.

--- a/openspec/changes/steps-tracking/tasks.md
+++ b/openspec/changes/steps-tracking/tasks.md
@@ -1,0 +1,74 @@
+# Steps Tracking — Implementation Tasks
+
+## Data Format & Types
+
+- [x] Define `StepEntry` interface in `src/ipc/types.ts` (summary, detail, status, files_touched, timestamp)
+- [x] Define status enum values: starting, investigating, implementing, testing, awaiting_review, done
+
+## IPC Channels
+
+- [x] Add `StepsContent`, `ReadStepsContent`, `StopStepsWatcher` to IPC enum in `electron/ipc/channels.ts`
+- [x] Add channel strings to preload allowlist in `electron/preload.cjs`
+
+## Backend Watcher
+
+- [x] Create `electron/ipc/steps.ts` with watcher implementation
+- [x] Implement `startStepsWatcher(win, taskId, worktreePath)`
+  - [x] Handle `.claude/` existing at startup
+  - [x] Handle `.claude/` not existing (watch worktree root, swap when it appears)
+  - [x] Debounce changes at 200ms
+  - [x] Filter events to `steps.json` filename only
+  - [x] Perform initial read after watcher setup
+- [x] Implement `stopStepsWatcher(taskId)` — cleanup FSWatcher and timers
+- [x] Implement `readStepsForWorktree(worktreePath)` — one-shot read for restore
+- [x] Implement `stopAllStepsWatchers()` — shutdown cleanup
+- [x] Implement `ensureStepsIgnored(worktreePath)` — add to `.git/info/exclude`
+  - [x] Handle linked worktrees (parse `.git` file for `gitdir:`)
+
+## IPC Handler Registration
+
+- [x] Register `StopStepsWatcher` handler in `electron/ipc/register.ts`
+- [x] Register `ReadStepsContent` handler in `electron/ipc/register.ts`
+- [x] Start steps watcher in `SpawnAgent` handler when `stepsEnabled` is true
+
+## Store Integration
+
+- [x] Add `stepsEnabled?: boolean` and `stepsContent?: StepEntry[]` to `Task` interface
+- [x] Add `stepsEnabled?: boolean` to `PersistedTask`
+- [x] Add `showSteps: boolean` to `AppStore` and `PersistedState`
+- [x] Add `stepsEnabled` to `CreateTaskOptions`
+- [x] Inject steps prompt instruction in `createTask()` when enabled
+- [x] Implement `setStepsContent()` setter with loose validation
+- [x] Implement `setTaskStepsEnabled()` toggle
+- [x] Add `StopStepsWatcher` calls to `removeTaskFromStore()` and `collapseTask()`
+- [x] Persist and restore `stepsEnabled` and `showSteps` in `persistence.ts`
+
+## Frontend Plumbing
+
+- [x] Add IPC listener for `StepsContent` events in `App.tsx`
+- [x] Add restore loop for steps content on startup in `App.tsx`
+- [x] Pass `stepsEnabled` prop through `TaskAITerminal` -> `TerminalView` -> `SpawnAgent`
+
+## UI Component
+
+- [x] Create `TaskStepsSection.tsx` component
+  - [x] Empty state with "Steps: waiting..." placeholder
+  - [x] History zone: collapsible step entries with index, status badge, summary, duration, file count
+  - [x] Latest step zone: always expanded with full detail
+  - [x] Waiting indicator (pulsing dot) when user sent input after last step
+  - [x] Status color coding (6 colors for 6 statuses)
+  - [x] File badges with click-to-navigate
+  - [x] Auto-scroll to bottom on new steps
+  - [x] Keyboard navigation (arrows, page up/down)
+  - [x] Focus registration for panel navigation
+
+## Task Panel Integration
+
+- [x] Add steps section as conditional `PanelChild` in `TaskPanel.tsx`
+- [x] Initial size 28px, expand to 110px when steps arrive
+
+## New Task Dialog
+
+- [x] Add "Steps tracking" checkbox in `NewTaskDialog.tsx`
+- [x] Default to `store.showSteps` (remembers last-used preference)
+- [x] Pass `stepsEnabled` to `createTask()`


### PR DESCRIPTION
Testing the OpenSpec folder convention by documenting two existing features
(remote access, steps tracking) with proposal, specs, design, and tasks files.

https://claude.ai/code/session_01NBQtVUHfbXCL32Sg1swdFc