### PR TITLE
feat(steps): polish UI and add sub-agent + terminal-jump support

### DIFF
--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -1,4 +1,4 @@
-import { Show, For, createSignal, onMount, onCleanup } from 'solid-js';
+import { Show, For, createSignal, createEffect, onMount, onCleanup } from 'solid-js';
 
 import {
   store,
@@ -26,10 +26,30 @@ interface TaskAITerminalProps {
   task: Task;
   isActive: boolean;
   promptHandle: PromptInputHandle | undefined;
+  /** Receives a function that scrolls the AI terminal to the moment a given step
+   *  index was recorded. Called with `undefined` when the terminal unmounts. */
+  onStepJumpReady?: (jump: ((stepIndex: number) => boolean) | undefined) => void;
 }
 
 export function TaskAITerminal(props: TaskAITerminalProps) {
   onCleanup(() => unregisterFocusFn(`${props.task.id}:ai-terminal`));
+
+  // Step bookmarks — TerminalView hands us a mark/jump API once the xterm
+  // instance is ready. We mark each newly arrived step at the current scrollback
+  // position, and expose `jump` upward so the steps panel can scroll back to it.
+  let stepNav: { mark: (i: number) => void; jump: (i: number) => boolean } | undefined;
+  let lastMarkedLen = 0;
+  onCleanup(() => props.onStepJumpReady?.(undefined));
+
+  createEffect(() => {
+    const len = props.task.stepsContent?.length ?? 0;
+    if (!stepNav || len <= lastMarkedLen) {
+      lastMarkedLen = len;
+      return;
+    }
+    for (let i = lastMarkedLen; i < len; i++) stepNav.mark(i);
+    lastMarkedLen = len;
+  });
 
   // --- Markdown file viewer ---
   const [mdViewerContent, setMdViewerContent] = createSignal('');
@@ -192,6 +212,16 @@ export function TaskAITerminal(props: TaskAITerminalProps) {
                     onFileLink={handleFileLink}
                     onPromptDetected={(text) => setLastPrompt(props.task.id, text)}
                     onReady={(focusFn) => registerFocusFn(`${props.task.id}:ai-terminal`, focusFn)}
+                    onStepNavReady={(api) => {
+                      stepNav = api;
+                      // Backfill markers for steps that already exist when the terminal mounts.
+                      // They all anchor to the current line — best-effort, since we can't know
+                      // where each historical step was originally written.
+                      const len = props.task.stepsContent?.length ?? 0;
+                      for (let i = 0; i < len; i++) api.mark(i);
+                      lastMarkedLen = len;
+                      props.onStepJumpReady?.(api.jump);
+                    }}
                     fontSize={14}
                   />
                 </Show>

--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -37,13 +37,17 @@ export function TaskAITerminal(props: TaskAITerminalProps) {
   // Step bookmarks — TerminalView hands us a mark/jump API once the xterm
   // instance is ready. We mark each newly arrived step at the current scrollback
   // position, and expose `jump` upward so the steps panel can scroll back to it.
+  // On agent restart the inner TerminalView remounts (keyed Show), so the API
+  // reference must be reset to undefined and lastMarkedLen back to 0 — the new
+  // mount will then re-backfill markers for all existing steps.
   let stepNav: { mark: (i: number) => void; jump: (i: number) => boolean } | undefined;
   let lastMarkedLen = 0;
   onCleanup(() => props.onStepJumpReady?.(undefined));
 
   createEffect(() => {
     const len = props.task.stepsContent?.length ?? 0;
-    if (!stepNav || len <= lastMarkedLen) {
+    if (!stepNav) return; // Don't advance lastMarkedLen until a terminal is ready.
+    if (len <= lastMarkedLen) {
       lastMarkedLen = len;
       return;
     }
@@ -213,6 +217,14 @@ export function TaskAITerminal(props: TaskAITerminalProps) {
                     onPromptDetected={(text) => setLastPrompt(props.task.id, text)}
                     onReady={(focusFn) => registerFocusFn(`${props.task.id}:ai-terminal`, focusFn)}
                     onStepNavReady={(api) => {
+                      if (!api) {
+                        // TerminalView is unmounting (agent restart). Drop the stale API
+                        // and reset the watermark so the next mount's backfill marks every step.
+                        stepNav = undefined;
+                        lastMarkedLen = 0;
+                        props.onStepJumpReady?.(undefined);
+                        return;
+                      }
                       stepNav = api;
                       // Backfill markers for steps that already exist when the terminal mounts.
                       // They all anchor to the current line — best-effort, since we can't know

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -55,6 +55,8 @@ export function TaskPanel(props: TaskPanelProps) {
   const [selectedCommit, setSelectedCommit] = createSignal<string | null>(null);
   const [editingProjectId, setEditingProjectId] = createSignal<string | null>(null);
   const [stepsNaturalHeight, setStepsNaturalHeight] = createSignal(110);
+  // Stored as a ref (not a signal) — only invoked from user click handlers, never read reactively.
+  let stepJumpFn: ((stepIndex: number) => boolean) | undefined;
   let panelRef!: HTMLDivElement;
   let promptRef: HTMLTextAreaElement | undefined;
   let titleEditHandle: EditableTextHandle | undefined;
@@ -210,6 +212,10 @@ export function TaskPanel(props: TaskPanelProps) {
             setPrefillPrompt(props.task.id, text);
             triggerFocus(`${props.task.id}:prompt`);
           }}
+          onJumpToStep={(idx) => {
+            const ok = stepJumpFn?.(idx);
+            if (ok) setTaskFocusedPanel(props.task.id, 'ai-terminal');
+          }}
         />
       ),
     };
@@ -252,7 +258,12 @@ export function TaskPanel(props: TaskPanelProps) {
       id: 'ai-terminal',
       minSize: 80,
       content: () => (
-        <TaskAITerminal task={props.task} isActive={props.isActive} promptHandle={promptHandle} />
+        <TaskAITerminal
+          task={props.task}
+          isActive={props.isActive}
+          promptHandle={promptHandle}
+          onStepJumpReady={(fn) => (stepJumpFn = fn)}
+        />
       ),
     };
   }

--- a/src/components/TaskStepsSection.tsx
+++ b/src/components/TaskStepsSection.tsx
@@ -5,6 +5,7 @@ import { badgeStyle } from '../lib/badgeStyle';
 import { useFocusRegistration } from '../lib/focus-registration';
 import { setTaskFocusedPanel } from '../store/store';
 import type { Task } from '../store/types';
+import type { StepEntry } from '../ipc/types';
 
 const STATUS_COLORS: Record<string, string> = {
   starting: '#fb923c',
@@ -17,11 +18,6 @@ const STATUS_COLORS: Record<string, string> = {
 
 function statusColor(status: string): string {
   return STATUS_COLORS[status] ?? theme.fgMuted;
-}
-
-function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max - 1) + '…';
 }
 
 /** Append Z when no timezone is present — ISO strings without TZ are parsed as local time. */
@@ -62,6 +58,8 @@ interface TaskStepsSectionProps {
   onFileClick?: (file: string) => void;
   onNaturalHeight?: (h: number) => void;
   onNextClick?: (text: string) => void;
+  /** Scroll the AI terminal to the moment a given step index was recorded. */
+  onJumpToStep?: (stepIndex: number) => void;
 }
 
 /** Clickable file path badge shown on step cards. */
@@ -95,6 +93,63 @@ function FileBadge(props: { file: string; onFileClick?: (file: string) => void }
   );
 }
 
+/** Dashed badge identifying a sub-agent's entries. */
+function AgentBadge(props: { agentId: string }) {
+  return (
+    <span
+      title={`Sub-agent: ${props.agentId}`}
+      style={{
+        'font-size': sf(9),
+        padding: '0 5px',
+        'border-radius': '3px',
+        background: 'transparent',
+        color: theme.fgMuted,
+        border: `1px dashed color-mix(in srgb, ${theme.fgMuted} 50%, transparent)`,
+        'flex-shrink': '0',
+        'font-family': "'JetBrains Mono', monospace",
+      }}
+    >
+      {props.agentId}
+    </span>
+  );
+}
+
+/** Inline copy-to-clipboard control. Only meaningful on hover (parent toggles `visible`). */
+function CopyButton(props: { text: string; visible: boolean; label: string }) {
+  const [copied, setCopied] = createSignal(false);
+  return (
+    <button
+      type="button"
+      title={`Copy ${props.label}`}
+      aria-label={`Copy ${props.label}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        navigator.clipboard
+          .writeText(props.text)
+          .then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          })
+          .catch(() => {});
+      }}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        padding: '0 4px',
+        cursor: 'pointer',
+        color: copied() ? theme.success : theme.fgSubtle,
+        opacity: props.visible || copied() ? 1 : 0,
+        transition: 'opacity 120ms',
+        'font-size': sf(11),
+        'flex-shrink': '0',
+        'line-height': '1',
+      }}
+    >
+      {copied() ? '✓' : '⧉'}
+    </button>
+  );
+}
+
 function WaitingIndicator(props: { fontSize: string }) {
   return (
     <>
@@ -118,6 +173,8 @@ function WaitingIndicator(props: { fontSize: string }) {
 
 export function TaskStepsSection(props: TaskStepsSectionProps) {
   const [expandedHistory, setExpandedHistory] = createSignal<Set<number>>(new Set());
+  const [hoveredHistory, setHoveredHistory] = createSignal<number | null>(null);
+  const [latestHovered, setLatestHovered] = createSignal<'summary' | 'detail' | null>(null);
   let scrollRef!: HTMLDivElement;
   const [latestCardRef, setLatestCardRef] = createSignal<HTMLDivElement | undefined>();
 
@@ -130,7 +187,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
     const s = steps();
     return s.length > 0 ? s[s.length - 1] : null;
   });
-  const historySteps = createMemo(() => {
+  const historySteps = createMemo<StepEntry[]>(() => {
     const s = steps();
     if (s.length <= 1) return [];
     return s.slice(0, -1);
@@ -165,8 +222,6 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
     reportHeight();
   });
 
-  // Re-measure when the card itself resizes (e.g. window width changes cause
-  // the `next` line to wrap differently).
   createEffect(() => {
     const el = latestCardRef();
     if (!el) return;
@@ -198,7 +253,6 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
         'border-radius': '6px',
       }}
     >
-      {/* Waiting placeholder — shown when steps tracking is on but no steps written yet */}
       <Show when={steps().length === 0}>
         <div
           style={{
@@ -231,7 +285,6 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
         </div>
       </Show>
 
-      {/* Scrollable content — keyboard-navigable when focused */}
       <Show when={steps().length > 0}>
         <div
           ref={scrollRef}
@@ -264,17 +317,37 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
             outline: 'none',
           }}
         >
-          {/* History — collapsible entries */}
           <Show when={historySteps().length > 0}>
-            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '2px' }}>
+            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0' }}>
               <For each={historySteps()}>
                 {(step, idx) => {
                   const isExpanded = () => expandedHistory().has(idx());
+                  const isHovered = () => hoveredHistory() === idx();
+                  const prevStep = () => (idx() > 0 ? historySteps()[idx() - 1] : null);
+                  // Phase divider when status changes between adjacent entries.
+                  const phaseChanged = () => {
+                    const p = prevStep();
+                    if (!p) return false;
+                    return String(p.status ?? '') !== String(step.status ?? '');
+                  };
+                  const indented = () => Boolean(step.agent_id);
 
                   return (
                     <div>
+                      <Show when={phaseChanged()}>
+                        <div
+                          style={{
+                            height: '1px',
+                            background: theme.border,
+                            margin: '4px 0 4px 28px',
+                            opacity: 0.5,
+                          }}
+                        />
+                      </Show>
                       <div
                         onClick={() => toggleHistory(idx())}
+                        onMouseEnter={() => setHoveredHistory(idx())}
+                        onMouseLeave={() => setHoveredHistory(null)}
                         style={{
                           display: 'flex',
                           'align-items': 'center',
@@ -283,12 +356,11 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                           cursor: 'pointer',
                           'border-radius': '4px',
                           'user-select': 'none',
-                        }}
-                        onMouseEnter={(e) => {
-                          e.currentTarget.style.background = `color-mix(in srgb, ${theme.fgMuted} 8%, transparent)`;
-                        }}
-                        onMouseLeave={(e) => {
-                          e.currentTarget.style.background = 'transparent';
+                          'border-left': `3px solid ${statusColor(String(step.status ?? ''))}`,
+                          'padding-left': indented() ? '24px' : '8px',
+                          background: isHovered()
+                            ? `color-mix(in srgb, ${theme.fgMuted} 8%, transparent)`
+                            : 'transparent',
                         }}
                       >
                         <span
@@ -296,12 +368,15 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                             'font-size': sf(10),
                             color: theme.fgSubtle,
                             'flex-shrink': '0',
-                            width: '20px',
+                            width: '18px',
                             'text-align': 'right',
                           }}
                         >
                           {idx() + 1}
                         </span>
+                        <Show when={step.agent_id}>
+                          <AgentBadge agentId={step.agent_id ?? ''} />
+                        </Show>
                         <span
                           style={{
                             ...badgeStyle(statusColor(String(step.status ?? ''))),
@@ -322,8 +397,38 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                             flex: '1',
                           }}
                         >
-                          {truncate(step.summary ?? '', 60)}
+                          {step.summary ?? ''}
                         </span>
+                        <CopyButton
+                          text={step.summary ?? ''}
+                          visible={isHovered()}
+                          label="summary"
+                        />
+                        <Show when={props.onJumpToStep}>
+                          <button
+                            type="button"
+                            title="Jump to terminal moment"
+                            aria-label="Jump to terminal moment"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              props.onJumpToStep?.(idx());
+                            }}
+                            style={{
+                              background: 'transparent',
+                              border: 'none',
+                              padding: '0 4px',
+                              cursor: 'pointer',
+                              color: theme.fgSubtle,
+                              opacity: isHovered() ? 1 : 0,
+                              transition: 'opacity 120ms',
+                              'font-size': sf(11),
+                              'flex-shrink': '0',
+                              'line-height': '1',
+                            }}
+                          >
+                            ↗
+                          </button>
+                        </Show>
                         <Show when={step.timestamp}>
                           <span
                             style={{
@@ -355,11 +460,11 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                       <Show when={isExpanded()}>
                         <div
                           style={{
-                            'margin-left': '32px',
+                            'margin-left': indented() ? '52px' : '32px',
                             padding: '4px 8px',
                             'font-size': sf(12),
                             color: theme.fgMuted,
-                            'border-left': `2px solid ${theme.border}`,
+                            'border-left': `2px solid ${statusColor(String(step.status ?? ''))}`,
                           }}
                         >
                           <Show when={step.timestamp}>
@@ -374,8 +479,16 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                             </div>
                           </Show>
                           <Show when={step.detail}>
-                            <div style={{ 'margin-bottom': '4px' }}>
-                              {truncate(step.detail ?? '', 280)}
+                            <div
+                              style={{
+                                display: 'flex',
+                                'align-items': 'flex-start',
+                                gap: '4px',
+                                'margin-bottom': '4px',
+                              }}
+                            >
+                              <div style={{ flex: '1', 'line-height': '1.45' }}>{step.detail}</div>
+                              <CopyButton text={step.detail ?? ''} visible label="detail" />
                             </div>
                           </Show>
                           <Show
@@ -408,94 +521,149 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
 
           {/* Latest step — always expanded, anchored at bottom */}
           <Show when={latestStep()}>
-            {(step) => (
-              <div
-                ref={setLatestCardRef}
-                style={{
-                  'border-radius': '6px',
-                  padding: '8px 10px',
-                }}
-              >
+            {(step) => {
+              const indented = () => Boolean(step().agent_id);
+              return (
                 <div
+                  ref={setLatestCardRef}
                   style={{
-                    display: 'flex',
-                    'align-items': 'center',
-                    gap: '8px',
-                    'margin-bottom': '4px',
+                    'border-radius': '6px',
+                    padding: '8px 10px 8px 12px',
+                    'border-left': `3px solid ${statusColor(String(step().status ?? ''))}`,
+                    'margin-left': indented() ? '16px' : '0',
                   }}
                 >
-                  <span style={badgeStyle(statusColor(String(step().status ?? '')))}>
-                    {String(step().status ?? '').replaceAll('_', ' ')}
-                  </span>
-                  <span
-                    style={{
-                      'font-size': sf(12),
-                      'font-weight': '600',
-                      color: theme.fg,
-                      flex: '1',
-                    }}
-                  >
-                    {truncate(step().summary ?? '', 140)}
-                  </span>
-                  <Show when={step().timestamp}>
-                    <span
-                      style={{ 'font-size': sf(10), color: theme.fgSubtle, 'flex-shrink': '0' }}
-                    >
-                      {relativeTime(step().timestamp)}
-                    </span>
-                  </Show>
-                </div>
-                <Show when={step().next}>
                   <div
-                    onClick={() => props.onNextClick?.(step().next ?? '')}
-                    onMouseEnter={(e) => {
-                      if (props.onNextClick) e.currentTarget.style.opacity = '0.75';
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.opacity = '1';
-                    }}
-                    style={{
-                      'font-size': sf(12),
-                      color: theme.accent,
-                      'margin-top': '4px',
-                      'line-height': '1.4',
-                      cursor: props.onNextClick ? 'pointer' : 'default',
-                    }}
-                  >
-                    → `{truncate(step().next ?? '', 160)}`
-                  </div>
-                </Show>
-                <Show when={step().detail}>
-                  <div
-                    style={{
-                      'font-size': sf(12),
-                      color: theme.fgMuted,
-                      'margin-top': '4px',
-                      'line-height': '1.4',
-                    }}
-                  >
-                    {truncate(step().detail ?? '', 280)}
-                  </div>
-                </Show>
-                <Show when={(step().files_touched ?? []).length > 0}>
-                  <div
+                    onMouseEnter={() => setLatestHovered('summary')}
+                    onMouseLeave={() => setLatestHovered(null)}
                     style={{
                       display: 'flex',
-                      'flex-wrap': 'wrap',
-                      gap: '4px',
-                      'margin-top': '6px',
+                      'align-items': 'center',
+                      gap: '8px',
+                      'margin-bottom': '4px',
                     }}
                   >
-                    <For each={step().files_touched}>
-                      {(file) => <FileBadge file={file} onFileClick={props.onFileClick} />}
-                    </For>
+                    <Show when={step().agent_id}>
+                      <AgentBadge agentId={step().agent_id ?? ''} />
+                    </Show>
+                    <span style={badgeStyle(statusColor(String(step().status ?? '')))}>
+                      {String(step().status ?? '').replaceAll('_', ' ')}
+                    </span>
+                    <span
+                      style={{
+                        'font-size': sf(12),
+                        'font-weight': '600',
+                        color: theme.fg,
+                        flex: '1',
+                        'line-height': '1.4',
+                      }}
+                    >
+                      {step().summary ?? ''}
+                    </span>
+                    <CopyButton
+                      text={step().summary ?? ''}
+                      visible={latestHovered() === 'summary'}
+                      label="summary"
+                    />
+                    <Show when={props.onJumpToStep}>
+                      <button
+                        type="button"
+                        title="Jump to terminal moment"
+                        aria-label="Jump to terminal moment"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const len = steps().length;
+                          if (len > 0) props.onJumpToStep?.(len - 1);
+                        }}
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          padding: '0 4px',
+                          cursor: 'pointer',
+                          color: theme.fgSubtle,
+                          opacity: latestHovered() === 'summary' ? 1 : 0,
+                          transition: 'opacity 120ms',
+                          'font-size': sf(11),
+                          'flex-shrink': '0',
+                          'line-height': '1',
+                        }}
+                      >
+                        ↗
+                      </button>
+                    </Show>
+                    <Show when={step().timestamp}>
+                      <span
+                        style={{ 'font-size': sf(10), color: theme.fgSubtle, 'flex-shrink': '0' }}
+                      >
+                        {relativeTime(step().timestamp)}
+                      </span>
+                    </Show>
                   </div>
-                </Show>
-              </div>
-            )}
+                  <Show when={step().next}>
+                    <div
+                      onClick={() => props.onNextClick?.(step().next ?? '')}
+                      onMouseEnter={(e) => {
+                        if (props.onNextClick) e.currentTarget.style.opacity = '0.75';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.opacity = '1';
+                      }}
+                      style={{
+                        display: 'flex',
+                        'align-items': 'flex-start',
+                        gap: '6px',
+                        'font-size': sf(12),
+                        color: theme.accent,
+                        'margin-top': '4px',
+                        'line-height': '1.4',
+                        cursor: props.onNextClick ? 'pointer' : 'default',
+                      }}
+                    >
+                      <span style={{ 'flex-shrink': '0', opacity: '0.7' }}>›</span>
+                      <span style={{ flex: '1', 'font-style': 'italic' }}>{step().next}</span>
+                    </div>
+                  </Show>
+                  <Show when={step().detail}>
+                    <div
+                      onMouseEnter={() => setLatestHovered('detail')}
+                      onMouseLeave={() => setLatestHovered(null)}
+                      style={{
+                        display: 'flex',
+                        'align-items': 'flex-start',
+                        gap: '4px',
+                        'font-size': sf(12),
+                        color: theme.fgMuted,
+                        'margin-top': '4px',
+                        'line-height': '1.4',
+                      }}
+                    >
+                      <div style={{ flex: '1' }}>{step().detail}</div>
+                      <CopyButton
+                        text={step().detail ?? ''}
+                        visible={latestHovered() === 'detail'}
+                        label="detail"
+                      />
+                    </div>
+                  </Show>
+                  <Show when={(step().files_touched ?? []).length > 0}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        'flex-wrap': 'wrap',
+                        gap: '4px',
+                        'margin-top': '6px',
+                      }}
+                    >
+                      <For each={step().files_touched}>
+                        {(file) => <FileBadge file={file} onFileClick={props.onFileClick} />}
+                      </For>
+                    </div>
+                  </Show>
+                </div>
+              );
+            }}
           </Show>
 
-          {/* Interacting indicator — shown when user sent input after last step */}
           <Show when={isInteracting()}>
             <div
               style={{

--- a/src/components/TaskStepsSection.tsx
+++ b/src/components/TaskStepsSection.tsx
@@ -20,6 +20,11 @@ function statusColor(status: string): string {
   return STATUS_COLORS[status] ?? theme.fgMuted;
 }
 
+/** Visual offset applied to a sub-agent step. The collapsed history row absorbs this
+ *  via padding; the latest card via margin; the expanded detail panel adds it on top
+ *  of the base 32px indent so the detail aligns under the row's text. */
+const SUB_AGENT_INDENT_PX = 16;
+
 /** Append Z when no timezone is present — ISO strings without TZ are parsed as local time. */
 function normalizeIsoTimestamp(ts: string): string {
   if (!ts) return '';
@@ -93,7 +98,8 @@ function FileBadge(props: { file: string; onFileClick?: (file: string) => void }
   );
 }
 
-/** Dashed badge identifying a sub-agent's entries. */
+/** Dashed badge identifying a sub-agent's entries. Caps width so an oversized agent_id
+ *  can't push controls off the row. */
 function AgentBadge(props: { agentId: string }) {
   return (
     <span
@@ -107,6 +113,10 @@ function AgentBadge(props: { agentId: string }) {
         border: `1px dashed color-mix(in srgb, ${theme.fgMuted} 50%, transparent)`,
         'flex-shrink': '0',
         'font-family': "'JetBrains Mono', monospace",
+        'max-width': '120px',
+        overflow: 'hidden',
+        'text-overflow': 'ellipsis',
+        'white-space': 'nowrap',
       }}
     >
       {props.agentId}
@@ -117,6 +127,10 @@ function AgentBadge(props: { agentId: string }) {
 /** Inline copy-to-clipboard control. Only meaningful on hover (parent toggles `visible`). */
 function CopyButton(props: { text: string; visible: boolean; label: string }) {
   const [copied, setCopied] = createSignal(false);
+  let resetTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => {
+    if (resetTimer !== undefined) clearTimeout(resetTimer);
+  });
   return (
     <button
       type="button"
@@ -128,7 +142,11 @@ function CopyButton(props: { text: string; visible: boolean; label: string }) {
           .writeText(props.text)
           .then(() => {
             setCopied(true);
-            setTimeout(() => setCopied(false), 1200);
+            if (resetTimer !== undefined) clearTimeout(resetTimer);
+            resetTimer = setTimeout(() => {
+              resetTimer = undefined;
+              setCopied(false);
+            }, 1200);
           })
           .catch(() => {});
       }}
@@ -146,6 +164,35 @@ function CopyButton(props: { text: string; visible: boolean; label: string }) {
       }}
     >
       {copied() ? '✓' : '⧉'}
+    </button>
+  );
+}
+
+/** Hover-revealed button that scrolls the AI terminal back to a step's moment. */
+function JumpButton(props: { onClick: () => void; visible: boolean }) {
+  return (
+    <button
+      type="button"
+      title="Jump to terminal moment"
+      aria-label="Jump to terminal moment"
+      onClick={(e) => {
+        e.stopPropagation();
+        props.onClick();
+      }}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        padding: '0 4px',
+        cursor: 'pointer',
+        color: theme.fgSubtle,
+        opacity: props.visible ? 1 : 0,
+        transition: 'opacity 120ms',
+        'font-size': sf(11),
+        'flex-shrink': '0',
+        'line-height': '1',
+      }}
+    >
+      ↗
     </button>
   );
 }
@@ -357,7 +404,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                           'border-radius': '4px',
                           'user-select': 'none',
                           'border-left': `3px solid ${statusColor(String(step.status ?? ''))}`,
-                          'padding-left': indented() ? '24px' : '8px',
+                          'padding-left': indented() ? `${8 + SUB_AGENT_INDENT_PX}px` : '8px',
                           background: isHovered()
                             ? `color-mix(in srgb, ${theme.fgMuted} 8%, transparent)`
                             : 'transparent',
@@ -405,29 +452,10 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                           label="summary"
                         />
                         <Show when={props.onJumpToStep}>
-                          <button
-                            type="button"
-                            title="Jump to terminal moment"
-                            aria-label="Jump to terminal moment"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              props.onJumpToStep?.(idx());
-                            }}
-                            style={{
-                              background: 'transparent',
-                              border: 'none',
-                              padding: '0 4px',
-                              cursor: 'pointer',
-                              color: theme.fgSubtle,
-                              opacity: isHovered() ? 1 : 0,
-                              transition: 'opacity 120ms',
-                              'font-size': sf(11),
-                              'flex-shrink': '0',
-                              'line-height': '1',
-                            }}
-                          >
-                            ↗
-                          </button>
+                          <JumpButton
+                            visible={isHovered()}
+                            onClick={() => props.onJumpToStep?.(idx())}
+                          />
                         </Show>
                         <Show when={step.timestamp}>
                           <span
@@ -460,7 +488,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                       <Show when={isExpanded()}>
                         <div
                           style={{
-                            'margin-left': indented() ? '52px' : '32px',
+                            'margin-left': indented() ? `${32 + SUB_AGENT_INDENT_PX}px` : '32px',
                             padding: '4px 8px',
                             'font-size': sf(12),
                             color: theme.fgMuted,
@@ -530,7 +558,7 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                     'border-radius': '6px',
                     padding: '8px 10px 8px 12px',
                     'border-left': `3px solid ${statusColor(String(step().status ?? ''))}`,
-                    'margin-left': indented() ? '16px' : '0',
+                    'margin-left': indented() ? `${SUB_AGENT_INDENT_PX}px` : '0',
                   }}
                 >
                   <div
@@ -566,30 +594,13 @@ export function TaskStepsSection(props: TaskStepsSectionProps) {
                       label="summary"
                     />
                     <Show when={props.onJumpToStep}>
-                      <button
-                        type="button"
-                        title="Jump to terminal moment"
-                        aria-label="Jump to terminal moment"
-                        onClick={(e) => {
-                          e.stopPropagation();
+                      <JumpButton
+                        visible={latestHovered() === 'summary'}
+                        onClick={() => {
                           const len = steps().length;
                           if (len > 0) props.onJumpToStep?.(len - 1);
                         }}
-                        style={{
-                          background: 'transparent',
-                          border: 'none',
-                          padding: '0 4px',
-                          cursor: 'pointer',
-                          color: theme.fgSubtle,
-                          opacity: latestHovered() === 'summary' ? 1 : 0,
-                          transition: 'opacity 120ms',
-                          'font-size': sf(11),
-                          'flex-shrink': '0',
-                          'line-height': '1',
-                        }}
-                      >
-                        ↗
-                      </button>
+                      />
                     </Show>
                     <Show when={step().timestamp}>
                       <span

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -60,8 +60,12 @@ interface TerminalViewProps {
   onReady?: (focusFn: () => void) => void;
   onBufferReady?: (getBuffer: () => string) => void;
   /** Exposes step-bookmark API: `mark(i)` registers a marker at the current line for
-   *  step index `i`; `jump(i)` scrolls the viewport so that marker is visible. */
-  onStepNavReady?: (api: { mark: (i: number) => void; jump: (i: number) => boolean }) => void;
+   *  step index `i`; `jump(i)` scrolls the viewport so that marker is visible.
+   *  Called with `undefined` on unmount so the consumer can reset its state — important
+   *  on agent restart, where this component remounts but the parent does not. */
+  onStepNavReady?: (
+    api: { mark: (i: number) => void; jump: (i: number) => boolean } | undefined,
+  ) => void;
   fontSize?: number;
   autoFocus?: boolean;
   initialCommand?: string;
@@ -172,21 +176,24 @@ export function TerminalView(props: TerminalViewProps) {
     // user can jump from the steps panel back to the terminal moment a step was written.
     // Markers auto-track buffer truncation; once the marker scrolls past the scrollback
     // limit xterm disposes it, in which case `jump` returns false so the caller can no-op.
+    // The map is owned by xterm and freed implicitly when term.dispose() runs in onCleanup.
     const stepMarkers = new Map<number, IMarker>();
-    props.onStepNavReady?.({
-      mark(i) {
+    const stepNavApi = {
+      mark(i: number) {
         if (!term || stepMarkers.has(i)) return;
         const m = term.registerMarker(0);
         if (m) stepMarkers.set(i, m);
       },
-      jump(i) {
+      jump(i: number): boolean {
         if (!term) return false;
         const m = stepMarkers.get(i);
         if (!m || m.isDisposed) return false;
         term.scrollToLine(m.line);
         return true;
       },
-    });
+    };
+    props.onStepNavReady?.(stepNavApi);
+    onCleanup(() => props.onStepNavReady?.(undefined));
 
     props.onBufferReady?.(() => {
       if (!term) return '';

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,5 +1,5 @@
 import { onMount, onCleanup, createEffect } from 'solid-js';
-import { Terminal } from '@xterm/xterm';
+import { Terminal, type IMarker } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { WebLinksAddon } from '@xterm/addon-web-links';
@@ -59,6 +59,9 @@ interface TerminalViewProps {
   onFileLink?: (filePath: string) => void;
   onReady?: (focusFn: () => void) => void;
   onBufferReady?: (getBuffer: () => string) => void;
+  /** Exposes step-bookmark API: `mark(i)` registers a marker at the current line for
+   *  step index `i`; `jump(i)` scrolls the viewport so that marker is visible. */
+  onStepNavReady?: (api: { mark: (i: number) => void; jump: (i: number) => boolean }) => void;
   fontSize?: number;
   autoFocus?: boolean;
   initialCommand?: string;
@@ -164,6 +167,27 @@ export function TerminalView(props: TerminalViewProps) {
     });
 
     props.onReady?.(() => term?.focus());
+
+    // Step bookmarks — anchor each agent step to the current scrollback line so the
+    // user can jump from the steps panel back to the terminal moment a step was written.
+    // Markers auto-track buffer truncation; once the marker scrolls past the scrollback
+    // limit xterm disposes it, in which case `jump` returns false so the caller can no-op.
+    const stepMarkers = new Map<number, IMarker>();
+    props.onStepNavReady?.({
+      mark(i) {
+        if (!term || stepMarkers.has(i)) return;
+        const m = term.registerMarker(0);
+        if (m) stepMarkers.set(i, m);
+      },
+      jump(i) {
+        if (!term) return false;
+        const m = stepMarkers.get(i);
+        if (!m || m.isDisposed) return false;
+        term.scrollToLine(m.line);
+        return true;
+      },
+    });
+
     props.onBufferReady?.(() => {
       if (!term) return '';
       const buf = term.buffer.active;

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -76,5 +76,8 @@ export interface StepEntry {
   next?: string;
   status: 'starting' | 'investigating' | 'implementing' | 'testing' | 'awaiting_review' | 'done';
   files_touched?: string[];
+  /** Optional sub-agent identifier — short label (e.g. "auth-worker") so the UI can
+   *  group entries written on behalf of delegated work. Omit for the top-level agent. */
+  agent_id?: string;
   timestamp: string;
 }

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -81,8 +81,10 @@ const STEPS_INSTRUCTION =
   '  detail: one sentence max, only if it adds context the summary and next fields cannot carry — omit otherwise.\n' +
   '  status: starting | investigating | implementing | testing | awaiting_review | done.\n' +
   '  files_touched: only files you actually wrote or modified in this step, not files you read.\n' +
-  'Sub-agents: when you spawn sub-agents, append one entry describing what each will work on. When they finish, append a completion entry with their outcome.\n' +
+  '  agent_id: short label for the sub-agent doing this work (e.g. "auth-worker", "test-runner"). Omit for your own entries. Use the same id consistently across all entries from one delegated agent so the UI can group them.\n' +
+  'Sub-agents: when you spawn a sub-agent, append one entry describing what it will work on, including its agent_id. When it finishes, append a completion entry with the same agent_id and its outcome.\n' +
   'Example: {"summary":"Auth middleware complete — JWT + rate-limit","next":"Write integration tests for token expiry edge cases","status":"implementing","files_touched":["src/middleware/auth.ts"]}.\n' +
+  'Sub-agent example: {"summary":"Schema migration generated","next":"Run migration in staging","status":"implementing","agent_id":"db-worker","files_touched":["migrations/0042_users.sql"]}.\n' +
   'When you want the user to review your work: write an entry with status "awaiting_review", set next to the decision or action you need from them, then pause.';
 
 export interface CreateTaskOptions {


### PR DESCRIPTION
UI polish:
- Replace `→ \`...\`` formatting around `next` with a clean chevron + italic
- Add status-color spine on left edge of every step card
- Remove fixed-length truncation; let summary/next/detail wrap naturally
  and rely on CSS ellipsis for the collapsed history rows
- Insert a subtle divider between adjacent history entries when status
  changes phase (e.g. investigating → implementing)
- Hover reveals copy buttons on summary and detail

Sub-agent tree (minimal):
- New optional `agent_id` field on StepEntry for entries written on
  behalf of delegated work
- Steps panel indents and adds a dashed agent badge for entries with an
  agent_id; instruction prompt teaches the agent to populate it

Jump to terminal moment:
- TerminalView exposes mark/jump bookmarks backed by xterm IMarker
- TaskAITerminal registers a marker for each new step as it arrives
- Steps panel shows a hover affordance on each step that scrolls the AI
  terminal back to the moment the step was recorded