### PR TITLE
docs(openspec): seed OpenSpec with current-state capability specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,11 @@ Electron desktop app — SolidJS frontend, Node.js backend. Published for **macO
 - Electron IPC for all frontend-backend communication
 - IPC channel names defined in `electron/ipc/channels.ts` (shared enum)
 - `strict: true` TypeScript, no `any`
+
+## Specs
+
+This repo uses OpenSpec. Capability specs for current behavior live under
+`openspec/specs/`. For new or changed behavior, propose a change in
+`openspec/changes/<name>/` (e.g. via `/opsx:propose`) rather than editing
+specs directly — the change is archived into `specs/` when it ships. Run
+`openspec validate --all --strict` before committing.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,32 +1,17 @@
 schema: spec-driven
 
 context: |
-  Project: parallel-code — an Electron desktop app that runs Claude Code,
-  Codex, and Gemini side by side, each in its own git worktree.
+  Project: parallel-code — Electron desktop app that runs Claude Code, Codex,
+  and Gemini side by side, each in its own git worktree. macOS + Linux only.
 
-  Published for macOS and Linux only. No Windows support.
-
-  Stack:
-  - Frontend: SolidJS (functional components, signals/stores — no classes),
-    TypeScript with `strict: true` and no `any`, Vite.
-  - Backend: Node.js inside the Electron main process, node-pty for terminals.
-  - Package manager: npm.
-
-  Layout:
-  - `src/` — SolidJS renderer (components, store, IPC wrappers, lib utilities).
-  - `src/store/` — app state (signals + stores, persisted via electron-store).
-  - `electron/` — Electron main process (window, preload, IPC handlers).
-  - `electron/ipc/` — backend IPC handlers (pty, git, tasks, persistence,
-    steps, remote). IPC channel names live in `electron/ipc/channels.ts` as a
-    shared enum imported by both processes.
-
-  Conventions:
-  - All frontend ↔ backend communication goes through typed Electron IPC.
-  - Channel names are defined once in the `IPC` enum in
-    `electron/ipc/channels.ts` and re-exported to the preload allowlist in
-    `electron/preload.cjs`.
-  - IPC message payload types live in `src/ipc/types.ts`.
-  - Commits follow conventional-commit style (`feat:`, `fix:`, `docs:`, etc.).
+  For stack, layout, and conventions see `CLAUDE.md` (the single source of
+  truth). Highlights relevant when authoring specs:
+  - Frontend ↔ backend communication goes through typed Electron IPC.
+  - IPC channel names live in the `IPC` enum in `electron/ipc/channels.ts`
+    and are re-exported to the preload allowlist in `electron/preload.cjs`.
+  - IPC payload types live in `src/ipc/types.ts`.
+  - Capability specs describe CURRENT behavior; propose new behavior through
+    `openspec/changes/<name>/` (run `/opsx:propose`).
 
 rules:
   proposal:
@@ -34,3 +19,7 @@ rules:
   specs:
     - Requirements MUST use SHALL/MUST; avoid should/may for normative text.
     - Every requirement MUST have at least one scenario with WHEN/THEN.
+    - Describe observable behavior, not library names or internal APIs. If
+      you need to name an exported identifier (e.g. an IPC channel the
+      renderer calls), prefer ones that are already part of the public
+      contract rather than internal helpers.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,36 @@
+schema: spec-driven
+
+context: |
+  Project: parallel-code — an Electron desktop app that runs Claude Code,
+  Codex, and Gemini side by side, each in its own git worktree.
+
+  Published for macOS and Linux only. No Windows support.
+
+  Stack:
+  - Frontend: SolidJS (functional components, signals/stores — no classes),
+    TypeScript with `strict: true` and no `any`, Vite.
+  - Backend: Node.js inside the Electron main process, node-pty for terminals.
+  - Package manager: npm.
+
+  Layout:
+  - `src/` — SolidJS renderer (components, store, IPC wrappers, lib utilities).
+  - `src/store/` — app state (signals + stores, persisted via electron-store).
+  - `electron/` — Electron main process (window, preload, IPC handlers).
+  - `electron/ipc/` — backend IPC handlers (pty, git, tasks, persistence,
+    steps, remote). IPC channel names live in `electron/ipc/channels.ts` as a
+    shared enum imported by both processes.
+
+  Conventions:
+  - All frontend ↔ backend communication goes through typed Electron IPC.
+  - Channel names are defined once in the `IPC` enum in
+    `electron/ipc/channels.ts` and re-exported to the preload allowlist in
+    `electron/preload.cjs`.
+  - IPC message payload types live in `src/ipc/types.ts`.
+  - Commits follow conventional-commit style (`feat:`, `fix:`, `docs:`, etc.).
+
+rules:
+  proposal:
+    - Keep proposals focused on WHY; put HOW in design.md.
+  specs:
+    - Requirements MUST use SHALL/MUST; avoid should/may for normative text.
+    - Every requirement MUST have at least one scenario with WHEN/THEN.

--- a/openspec/specs/remote-access/spec.md
+++ b/openspec/specs/remote-access/spec.md
@@ -4,9 +4,7 @@
 
 Let users monitor and interact with their parallel-code AI agents from a phone
 or tablet on the same local network (or Tailscale) without returning to the
-desktop. The Electron main process embeds an on-demand HTTP + WebSocket server
-that serves a mobile-optimized SPA and streams live PTY output from every
-running agent.
+desktop.
 
 ## Requirements
 
@@ -19,8 +17,8 @@ port so that other devices on the same network can reach it.
 #### Scenario: User starts the remote server
 
 - **WHEN** the renderer sends the `StartRemoteServer` IPC request
-- **THEN** the main process starts an `http.createServer` instance with a
-  `ws` WebSocketServer mounted on the same port
+- **THEN** the main process starts an HTTP server with a WebSocket server
+  accepting upgrades on the same listener
 - **AND** the server binds to `0.0.0.0` on the configured port
 - **AND** the response includes the generated auth token and the access URLs
   for the detected WiFi and Tailscale interfaces
@@ -61,8 +59,8 @@ timing-safe comparison.
 #### Scenario: Token is generated per server session
 
 - **WHEN** the server starts
-- **THEN** a new 24-byte random token is generated via `crypto.randomBytes`
-  and base64url-encoded (32 characters)
+- **THEN** a fresh token is generated from the platform's cryptographic RNG
+  and base64url-encoded
 - **AND** the token is not persisted to disk
 - **AND** stopping and restarting the server produces a new token
 
@@ -70,7 +68,7 @@ timing-safe comparison.
 
 - **WHEN** a client connects and sends `{ "type": "auth", "token": "<valid>" }`
   as its first message
-- **THEN** the server compares tokens via `crypto.timingSafeEqual`
+- **THEN** the server compares tokens with a timing-safe comparison
 - **AND** marks the connection as authenticated
 - **AND** sends the current agent list as an `agents` message
 
@@ -105,13 +103,12 @@ message.
 
 - **WHEN** an 11th WebSocket client attempts to connect while 10 are already
   authenticated
-- **THEN** `verifyClient` rejects the upgrade with HTTP `429`
+- **THEN** the server rejects the upgrade handshake with HTTP `429`
 
 #### Scenario: Oversized WebSocket frame
 
-- **WHEN** a client sends a message larger than 64 KB
-- **THEN** the `ws` server rejects the frame via its `maxPayload` setting and
-  closes the connection
+- **WHEN** a client sends a WebSocket frame larger than 64 KB
+- **THEN** the server rejects the frame and closes the connection
 
 #### Scenario: Malformed or unknown client message
 
@@ -236,9 +233,8 @@ client-side routing.
 #### Scenario: Static asset request
 
 - **WHEN** a request maps to an existing file in the static root
-- **THEN** the server streams the file with `Cache-Control: public,
-  max-age=31536000, immutable` for hashed assets
-- **AND** serves `index.html` with `Cache-Control: no-cache`
+- **THEN** hashed assets are served with a long-lived, immutable cache policy
+- **AND** `index.html` is served with a no-cache policy
 
 #### Scenario: Path traversal is rejected
 
@@ -277,5 +273,10 @@ connected clients, and SHALL drive start/stop through IPC.
 - **THEN** the renderer sends `StartRemoteServer`
 - **AND** the returned URL and token are rendered as a QR code plus copyable
   text
-- **AND** the connected-client counter updates as the server reports
-  connection churn
+
+#### Scenario: Connected-client counter stays current
+
+- **WHEN** the server's connected-client count changes while the UI is
+  visible
+- **THEN** the displayed counter updates within a few seconds via periodic
+  `GetRemoteStatus` polling

--- a/openspec/specs/remote-access/spec.md
+++ b/openspec/specs/remote-access/spec.md
@@ -1,0 +1,281 @@
+# Remote Access Specification
+
+## Purpose
+
+Let users monitor and interact with their parallel-code AI agents from a phone
+or tablet on the same local network (or Tailscale) without returning to the
+desktop. The Electron main process embeds an on-demand HTTP + WebSocket server
+that serves a mobile-optimized SPA and streams live PTY output from every
+running agent.
+
+## Requirements
+
+### Requirement: On-demand local server
+
+The app SHALL run at most one embedded remote server, started and stopped
+explicitly by the user through IPC, and bound to `0.0.0.0` on the configured
+port so that other devices on the same network can reach it.
+
+#### Scenario: User starts the remote server
+
+- **WHEN** the renderer sends the `StartRemoteServer` IPC request
+- **THEN** the main process starts an `http.createServer` instance with a
+  `ws` WebSocketServer mounted on the same port
+- **AND** the server binds to `0.0.0.0` on the configured port
+- **AND** the response includes the generated auth token and the access URLs
+  for the detected WiFi and Tailscale interfaces
+
+#### Scenario: User stops the remote server
+
+- **WHEN** the renderer sends the `StopRemoteServer` IPC request
+- **THEN** the server closes all open WebSocket connections
+- **AND** the HTTP listener is closed
+- **AND** subsequent `GetRemoteStatus` requests report the server as stopped
+
+#### Scenario: Only one server runs at a time
+
+- **WHEN** `StartRemoteServer` is requested while a server is already running
+- **THEN** the existing server instance is reused and its token and URLs are
+  returned
+- **AND** no second listener is opened on the port
+
+### Requirement: Network interface detection
+
+The server SHALL advertise reachable URLs by detecting the host's LAN and
+Tailscale IP addresses, and SHALL exclude container-only interfaces.
+
+#### Scenario: WiFi and Tailscale addresses are exposed
+
+- **WHEN** the server starts on a machine with both a LAN interface and a
+  Tailscale interface in the `100.x.x.x` range
+- **THEN** the returned URL list contains one entry for the LAN address and
+  one entry for the Tailscale address
+- **AND** Docker or container bridge addresses in `172.x.x.x` are omitted
+
+### Requirement: Token-based authentication
+
+The server SHALL require a session-scoped bearer token for every WebSocket
+connection and every `/api/` request, and SHALL compare tokens with a
+timing-safe comparison.
+
+#### Scenario: Token is generated per server session
+
+- **WHEN** the server starts
+- **THEN** a new 24-byte random token is generated via `crypto.randomBytes`
+  and base64url-encoded (32 characters)
+- **AND** the token is not persisted to disk
+- **AND** stopping and restarting the server produces a new token
+
+#### Scenario: WebSocket first-message auth succeeds
+
+- **WHEN** a client connects and sends `{ "type": "auth", "token": "<valid>" }`
+  as its first message
+- **THEN** the server compares tokens via `crypto.timingSafeEqual`
+- **AND** marks the connection as authenticated
+- **AND** sends the current agent list as an `agents` message
+
+#### Scenario: WebSocket auth times out
+
+- **WHEN** a connected client does not send a valid auth message within 5
+  seconds
+- **THEN** the server closes the connection with WebSocket close code `4001`
+- **AND** the client receives no further messages
+
+#### Scenario: REST request without credentials
+
+- **WHEN** a request to any `/api/*` route arrives without a valid
+  `Authorization: Bearer <token>` header or `?token=` query parameter
+- **THEN** the server responds with HTTP `401`
+- **AND** no agent data is returned
+
+#### Scenario: URL-token fallback for WebSockets
+
+- **WHEN** a WebSocket client connects with `?token=<valid>` on the upgrade URL
+  and does not send a `type: "auth"` message
+- **THEN** the server accepts the token as a fallback
+- **AND** marks the connection as authenticated
+
+### Requirement: Connection and payload limits
+
+The server SHALL bound resource usage by capping concurrent WebSocket
+connections, limiting inbound payload sizes, and validating every client
+message.
+
+#### Scenario: Too many concurrent clients
+
+- **WHEN** an 11th WebSocket client attempts to connect while 10 are already
+  authenticated
+- **THEN** `verifyClient` rejects the upgrade with HTTP `429`
+
+#### Scenario: Oversized WebSocket frame
+
+- **WHEN** a client sends a message larger than 64 KB
+- **THEN** the `ws` server rejects the frame via its `maxPayload` setting and
+  closes the connection
+
+#### Scenario: Malformed or unknown client message
+
+- **WHEN** an authenticated client sends a message that is not valid JSON, is
+  missing a `type` field, has a `type` the server does not handle, or has an
+  `agentId` longer than 100 characters
+- **THEN** the message is silently dropped
+- **AND** no error response is sent
+
+#### Scenario: Input and resize bounds
+
+- **WHEN** an `input` message has `data` longer than 4096 characters, or a
+  `resize` message has `cols` or `rows` outside the range 1–500
+- **THEN** the message is silently dropped
+
+### Requirement: Agent list broadcasting
+
+The server SHALL push the current agent list to every authenticated client on
+connect and whenever an agent spawns, exits, or the list changes, filtering
+out shell sub-terminals and deduplicating by task.
+
+#### Scenario: Initial agent list on connect
+
+- **WHEN** a client authenticates successfully
+- **THEN** the server sends one `agents` message containing every currently
+  tracked agent
+- **AND** shell / sub-terminal entries (where `isShell` is true) are excluded
+- **AND** duplicate entries for the same `taskId` are collapsed, preferring
+  the running agent over an exited one
+
+#### Scenario: Agent spawn broadcast
+
+- **WHEN** the PTY manager emits a `spawn` event
+- **THEN** the server rebuilds the agent list and sends an `agents` message to
+  every authenticated client
+
+#### Scenario: Agent exit broadcast
+
+- **WHEN** the PTY manager emits an `exit` event for an agent
+- **THEN** the server sends a `status` message with the final `exitCode` to
+  every authenticated client immediately
+- **AND** 100 ms later sends a refreshed `agents` message
+
+### Requirement: Live output streaming and scrollback
+
+The server SHALL stream terminal output live to subscribed clients, back it
+with a fixed-capacity in-memory ring buffer, and replay the buffer when a
+client subscribes so mid-session joiners see recent history.
+
+#### Scenario: Client subscribes to an agent
+
+- **WHEN** an authenticated client sends `{ "type": "subscribe", "agentId": ... }`
+- **THEN** the server registers a per-client subscription callback
+- **AND** sends the agent's current ring-buffer contents as a single
+  `scrollback` message (base64-encoded `data` and the current `cols`)
+- **AND** streams every subsequent chunk of PTY output as an `output` message
+
+#### Scenario: Client unsubscribes
+
+- **WHEN** the client sends `{ "type": "unsubscribe", "agentId": ... }`
+- **THEN** the subscription callback is removed
+- **AND** no further `output` messages for that agent are sent to the client
+
+#### Scenario: Scrollback capacity is bounded
+
+- **WHEN** total output for a single agent exceeds the 64 KB ring-buffer
+  capacity
+- **THEN** only the most recent 64 KB is retained
+- **AND** earlier bytes are discarded
+
+#### Scenario: Scrollback is not persisted across restarts
+
+- **WHEN** the Electron app restarts
+- **THEN** every ring buffer is empty at the next `StartRemoteServer`
+
+### Requirement: Remote agent control
+
+Authenticated clients SHALL be able to send input to an agent, resize its
+terminal, and kill it through WebSocket messages that map onto the existing
+PTY manager operations.
+
+#### Scenario: Client sends input
+
+- **WHEN** the client sends `{ "type": "input", "agentId": ..., "data": ... }`
+- **THEN** the server forwards `data` to the agent's PTY `stdin`
+
+#### Scenario: Client resizes terminal
+
+- **WHEN** the client sends `{ "type": "resize", "agentId": ..., "cols": N, "rows": M }`
+  with both dimensions between 1 and 500
+- **THEN** the server resizes the agent's PTY to those dimensions
+
+#### Scenario: Client kills an agent
+
+- **WHEN** the client sends `{ "type": "kill", "agentId": ... }`
+- **THEN** the server signals the agent process to terminate via the PTY
+  manager's kill operation
+
+### Requirement: REST endpoints for initial loads
+
+The server SHALL expose a read-only REST API for clients that need the agent
+list or a single agent's scrollback without opening a WebSocket.
+
+#### Scenario: List all agents
+
+- **WHEN** a client requests `GET /api/agents` with a valid token
+- **THEN** the response is `200 OK` with a JSON array matching the `list`
+  field of the `agents` WebSocket message
+
+#### Scenario: Fetch a single agent
+
+- **WHEN** a client requests `GET /api/agents/:agentId` with a valid token
+- **THEN** the response includes the agent's scrollback, status, and
+  `exitCode`
+
+### Requirement: Mobile SPA and static serving
+
+The server SHALL serve a separate, pre-built mobile SPA from disk with a safe
+path policy and sensible caching, and SHALL fall back to `index.html` for
+client-side routing.
+
+#### Scenario: Static asset request
+
+- **WHEN** a request maps to an existing file in the static root
+- **THEN** the server streams the file with `Cache-Control: public,
+  max-age=31536000, immutable` for hashed assets
+- **AND** serves `index.html` with `Cache-Control: no-cache`
+
+#### Scenario: Path traversal is rejected
+
+- **WHEN** a request resolves outside the static root (e.g. `..` segments)
+- **THEN** the server rejects the request without touching the filesystem
+
+#### Scenario: Unknown path falls through to SPA
+
+- **WHEN** a request targets a path that is not a static file and is not under
+  `/api/`
+- **THEN** the server responds with `index.html` so the SPA router can handle
+  the route
+- **AND** the response never lists directory contents
+
+### Requirement: HTTP security headers
+
+Every HTTP response SHALL include baseline security headers that block
+content-type sniffing, framing, and outbound referrer leakage.
+
+#### Scenario: Headers are applied to every response
+
+- **WHEN** the server sends any HTTP response
+- **THEN** it includes `X-Content-Type-Options: nosniff`
+- **AND** it includes `X-Frame-Options: DENY`
+- **AND** it includes `Referrer-Policy: no-referrer`
+
+### Requirement: Desktop UI integration
+
+The desktop renderer SHALL surface a remote-access control in settings that
+shows the server state, the connection URL and QR code, and the number of
+connected clients, and SHALL drive start/stop through IPC.
+
+#### Scenario: User toggles remote access on
+
+- **WHEN** the user flips the remote-access toggle in settings
+- **THEN** the renderer sends `StartRemoteServer`
+- **AND** the returned URL and token are rendered as a QR code plus copyable
+  text
+- **AND** the connected-client counter updates as the server reports
+  connection churn

--- a/openspec/specs/steps-tracking/spec.md
+++ b/openspec/specs/steps-tracking/spec.md
@@ -2,12 +2,9 @@
 
 ## Purpose
 
-Give users a compact, structured progress timeline for each running AI agent
-that is separate from the raw terminal scrollback. The agent is asked (via an
-opt-in prompt injection) to append structured step entries to
-`.claude/steps.json` inside its worktree. The Electron main process watches
-that file and streams updates to the renderer, which renders a live timeline
-inside the task panel.
+Give users a compact, structured progress timeline for each running AI agent so
+they can see at a glance what the agent has done and is doing now, without
+reading through raw terminal scrollback.
 
 ## Requirements
 
@@ -46,8 +43,9 @@ how to write step entries, while preserving the user's original prompt text.
 - **THEN** the prompt sent to the agent is the user's original prompt
   followed by `\n\n---\n` and the standard steps instruction
 - **AND** the instruction tells the agent to write `.claude/steps.json`, the
-  append-only JSON array format, the 60-character summary limit, the allowed
-  status values, and the `awaiting_review` pause behavior
+  append-only JSON array format, the summary length limit, the allowed
+  status values, and to pause and wait for user input after writing a step
+  whose status is `awaiting_review`
 
 #### Scenario: Original prompt is preserved
 
@@ -61,31 +59,26 @@ how to write step entries, while preserving the user's original prompt text.
 - **THEN** the prompt sent to the agent is exactly what the user typed, with
   no separator or instruction appended
 
-### Requirement: Append-only `steps.json` format
+### Requirement: Step entry format
 
-The steps file SHALL be a JSON array of objects where each entry describes one
-step with a bounded set of fields, and the agent SHALL only append — never
-edit existing entries.
+The steps file SHALL be a JSON array of step entry objects. The app SHALL
+treat the file as append-only: it never rewrites existing entries on the
+agent's behalf, and it expects new entries to appear only at the end.
 
 #### Scenario: Valid step entry shape
 
-- **WHEN** the agent appends a step entry
-- **THEN** the entry has `summary` (≤ 60 chars, string), `status` (one of
-  `starting`, `investigating`, `implementing`, `testing`, `awaiting_review`,
-  `done`), and `timestamp` (ISO 8601 string)
-- **AND** MAY have `detail` (one-sentence string) and `files_touched` (array
-  of worktree-relative paths the agent wrote or modified in this step)
+- **WHEN** the app accepts a step entry
+- **THEN** the entry has `summary` (string, agent-enforced to ≤ 60 chars),
+  `status` (one of `starting`, `investigating`, `implementing`, `testing`,
+  `awaiting_review`, `done`), and `timestamp` (ISO 8601 string)
+- **AND** MAY have `detail` (string) and `files_touched` (array of
+  worktree-relative paths the agent wrote or modified in this step)
 
-#### Scenario: Timestamp without timezone defaults to UTC
+#### Scenario: Renderer tolerates timestamps without a timezone
 
 - **WHEN** a step entry's `timestamp` has no timezone suffix
-- **THEN** the renderer treats it as UTC by appending `Z`
-
-#### Scenario: `awaiting_review` pauses the agent
-
-- **WHEN** the agent writes a step whose `status` is `awaiting_review`
-- **THEN** the agent pauses and waits for user input before writing another
-  step
+- **THEN** the renderer treats it as UTC for display purposes
+- **AND** timestamps emitted by the app itself always include a UTC suffix
 
 ### Requirement: Backend file watching with debounce
 
@@ -188,22 +181,18 @@ two-zone timeline inside the task panel.
 - **AND** renders an always-expanded latest-step zone with status badge,
   summary, relative timestamp, detail text, and file badges
 
-#### Scenario: Auto-scroll on new step
-
-- **WHEN** a new step entry arrives
-- **THEN** the timeline auto-scrolls the latest-step zone into view
-
 #### Scenario: Waiting indicator after user input
 
-- **WHEN** the user has sent terminal input since the last step completed and
-  no new step has arrived
+- **WHEN** the user has sent terminal input to the task since the last step
+  entry was written and no new step entry has arrived
 - **THEN** the timeline shows a pulsing "Waiting for next step" indicator
+- **AND** the indicator clears as soon as a new step entry arrives
 
-#### Scenario: Keyboard navigation
+#### Scenario: Keyboard navigation through history
 
 - **WHEN** the timeline has keyboard focus
-- **THEN** Arrow keys, Page Up, and Page Down move selection through the
-  history entries
+- **THEN** Arrow keys move selection one history entry at a time
+- **AND** Page Up and Page Down move selection one page at a time
 
 ### Requirement: Panel integration
 

--- a/openspec/specs/steps-tracking/spec.md
+++ b/openspec/specs/steps-tracking/spec.md
@@ -1,0 +1,270 @@
+# Steps Tracking Specification
+
+## Purpose
+
+Give users a compact, structured progress timeline for each running AI agent
+that is separate from the raw terminal scrollback. The agent is asked (via an
+opt-in prompt injection) to append structured step entries to
+`.claude/steps.json` inside its worktree. The Electron main process watches
+that file and streams updates to the renderer, which renders a live timeline
+inside the task panel.
+
+## Requirements
+
+### Requirement: Opt-in per task with remembered default
+
+Steps tracking SHALL be opt-in on a per-task basis, with a persistent app-level
+default that the new-task dialog uses to pre-fill the checkbox.
+
+#### Scenario: New task dialog reflects the last-used default
+
+- **WHEN** the user opens the new-task dialog
+- **THEN** the "Steps tracking" checkbox is pre-checked if and only if the
+  persisted `showSteps` app-level flag is true
+
+#### Scenario: Default updates when user toggles the checkbox
+
+- **WHEN** the user creates a task with the checkbox in the opposite state
+- **THEN** the persisted `showSteps` app-level flag is updated to match
+- **AND** the next new-task dialog uses that value as the default
+
+#### Scenario: `stepsEnabled` is per-task and persisted
+
+- **WHEN** a task is created with the checkbox enabled
+- **THEN** the task's `stepsEnabled` flag is stored on the `PersistedTask`
+- **AND** on app restart the flag is restored together with the task
+
+### Requirement: Prompt injection when enabled
+
+When a task is started with `stepsEnabled`, the system SHALL append a standard
+steps instruction to the user's initial prompt so the agent knows where and
+how to write step entries, while preserving the user's original prompt text.
+
+#### Scenario: Instruction is appended to the prompt
+
+- **WHEN** a task with `stepsEnabled` is spawned
+- **THEN** the prompt sent to the agent is the user's original prompt
+  followed by `\n\n---\n` and the standard steps instruction
+- **AND** the instruction tells the agent to write `.claude/steps.json`, the
+  append-only JSON array format, the 60-character summary limit, the allowed
+  status values, and the `awaiting_review` pause behavior
+
+#### Scenario: Original prompt is preserved
+
+- **WHEN** the task is persisted
+- **THEN** the original user prompt is stored as `savedInitialPrompt`
+  separately from the injected version
+
+#### Scenario: Instruction is not injected when disabled
+
+- **WHEN** a task with `stepsEnabled` false is spawned
+- **THEN** the prompt sent to the agent is exactly what the user typed, with
+  no separator or instruction appended
+
+### Requirement: Append-only `steps.json` format
+
+The steps file SHALL be a JSON array of objects where each entry describes one
+step with a bounded set of fields, and the agent SHALL only append — never
+edit existing entries.
+
+#### Scenario: Valid step entry shape
+
+- **WHEN** the agent appends a step entry
+- **THEN** the entry has `summary` (≤ 60 chars, string), `status` (one of
+  `starting`, `investigating`, `implementing`, `testing`, `awaiting_review`,
+  `done`), and `timestamp` (ISO 8601 string)
+- **AND** MAY have `detail` (one-sentence string) and `files_touched` (array
+  of worktree-relative paths the agent wrote or modified in this step)
+
+#### Scenario: Timestamp without timezone defaults to UTC
+
+- **WHEN** a step entry's `timestamp` has no timezone suffix
+- **THEN** the renderer treats it as UTC by appending `Z`
+
+#### Scenario: `awaiting_review` pauses the agent
+
+- **WHEN** the agent writes a step whose `status` is `awaiting_review`
+- **THEN** the agent pauses and waits for user input before writing another
+  step
+
+### Requirement: Backend file watching with debounce
+
+The main process SHALL watch each task's `.claude/` directory (not the
+individual file) for changes, debounce rapid writes, and push updates to the
+renderer through IPC.
+
+#### Scenario: `.claude/` already exists at spawn
+
+- **WHEN** a task with `stepsEnabled` is spawned and `.claude/` is already
+  present in the worktree
+- **THEN** the main process attaches an `fs.watch` on `.claude/`
+
+#### Scenario: `.claude/` does not exist yet
+
+- **WHEN** a task with `stepsEnabled` is spawned and `.claude/` does not exist
+- **THEN** the main process watches the worktree root
+- **AND** filters events for the `.claude` filename
+- **AND** when `.claude/` appears, closes the root watcher and attaches a new
+  watcher on `.claude/`
+- **AND** if `steps.json` already exists at swap time, performs an immediate
+  read
+
+#### Scenario: Only `steps.json` triggers reads
+
+- **WHEN** the watcher fires with a `filename` that is not `steps.json`
+- **THEN** the event is ignored
+- **AND** when the platform provides a `null` filename, every event triggers
+  a read (platform fallback)
+
+#### Scenario: Rapid writes are debounced
+
+- **WHEN** multiple change events fire within 200 ms
+- **THEN** the watcher schedules one read 200 ms after the last event
+- **AND** only one `StepsContent` IPC push is emitted
+
+#### Scenario: Initial read handles the startup race
+
+- **WHEN** the watcher is first attached
+- **THEN** the main process immediately reads `steps.json` if it exists and
+  sends a `StepsContent` push so steps written before the watcher was ready
+  are not missed
+
+#### Scenario: Read errors are handled gracefully
+
+- **WHEN** reading `steps.json` fails with `ENOENT`
+- **THEN** the main process silently pushes `steps: null` and continues
+  watching
+- **AND** other read errors are logged and produce a `steps: null` push
+
+### Requirement: IPC contract for steps
+
+The system SHALL communicate step updates through dedicated IPC channels
+declared in `electron/ipc/channels.ts` and allowlisted in the preload.
+
+#### Scenario: Push channel for live updates
+
+- **WHEN** the watcher produces a new step array
+- **THEN** the main process sends `StepsContent` with payload
+  `{ taskId, steps }` on the task's window's webContents
+
+#### Scenario: One-shot read for restore
+
+- **WHEN** the renderer sends `ReadStepsContent` with a `worktreePath`
+- **THEN** the main process reads `steps.json` once and returns the parsed
+  array or `null`
+
+#### Scenario: Watcher teardown
+
+- **WHEN** the renderer sends `StopStepsWatcher` for a task
+- **THEN** the main process closes the `fs.watch` handle, clears the debounce
+  timer, and removes the entry from the watcher map
+- **AND** a second `StopStepsWatcher` for the same task is a no-op
+
+#### Scenario: Watcher stops on task lifecycle events
+
+- **WHEN** a task is closed, collapsed, or removed from the store
+- **THEN** the renderer calls `StopStepsWatcher` for that task
+- **AND** on app shutdown the main process stops every remaining watcher
+
+### Requirement: Frontend validation and rendering
+
+The renderer SHALL apply only loose validation to accepted step entries so
+forward-compatible fields do not break older clients, and SHALL render a
+two-zone timeline inside the task panel.
+
+#### Scenario: Loose validation filters entries
+
+- **WHEN** the renderer receives a `StepsContent` payload
+- **THEN** every array entry that is a non-null object is retained as a
+  `StepEntry`
+- **AND** entries that are `null`, arrays, or primitives are dropped
+- **AND** unknown fields are preserved but ignored by the renderer
+
+#### Scenario: Two-zone timeline layout
+
+- **WHEN** a task has at least one step entry
+- **THEN** the panel renders a collapsible history zone with index, status
+  badge, summary, duration between steps, and file count
+- **AND** renders an always-expanded latest-step zone with status badge,
+  summary, relative timestamp, detail text, and file badges
+
+#### Scenario: Auto-scroll on new step
+
+- **WHEN** a new step entry arrives
+- **THEN** the timeline auto-scrolls the latest-step zone into view
+
+#### Scenario: Waiting indicator after user input
+
+- **WHEN** the user has sent terminal input since the last step completed and
+  no new step has arrived
+- **THEN** the timeline shows a pulsing "Waiting for next step" indicator
+
+#### Scenario: Keyboard navigation
+
+- **WHEN** the timeline has keyboard focus
+- **THEN** Arrow keys, Page Up, and Page Down move selection through the
+  history entries
+
+### Requirement: Panel integration
+
+The task panel SHALL include the steps section as a conditional, resizable
+child only when `stepsEnabled` is true.
+
+#### Scenario: Panel sizes
+
+- **WHEN** `stepsEnabled` is true and no steps have arrived yet
+- **THEN** the steps section renders at 28 px (header only)
+- **AND** expands to 110 px once the first step arrives
+
+#### Scenario: Panel hidden when disabled
+
+- **WHEN** `stepsEnabled` is false
+- **THEN** the steps section is not mounted as a `PanelChild`
+
+### Requirement: Git exclusion for steps files
+
+The steps file SHALL be excluded from git through `.git/info/exclude` (local,
+per-worktree), never via a committed `.gitignore`, and the exclusion SHALL
+work for both normal and linked worktrees.
+
+#### Scenario: Normal worktree
+
+- **WHEN** a task with `stepsEnabled` starts in a normal git worktree
+- **THEN** `.claude/steps.json` is appended to `.git/info/exclude` if not
+  already present
+
+#### Scenario: Linked worktree
+
+- **WHEN** the worktree has a `.git` file (linked worktree) rather than a
+  directory
+- **THEN** the main process reads the file, parses its `gitdir:` pointer, and
+  appends the exclusion to the pointed-to `info/exclude`
+
+#### Scenario: Idempotent exclusion
+
+- **WHEN** `.claude/steps.json` is already listed in `info/exclude`
+- **THEN** no duplicate line is appended
+
+#### Scenario: Steps file is never committed
+
+- **WHEN** the user runs `git status` inside the worktree
+- **THEN** `.claude/steps.json` does not appear as an untracked or modified
+  file
+
+### Requirement: Steps content is not persisted
+
+Step content itself SHALL NOT be persisted in the app's store; it SHALL be
+read fresh from disk on app restart for each task whose `stepsEnabled` is
+true.
+
+#### Scenario: Restore on startup
+
+- **WHEN** the app starts and loads persisted tasks
+- **THEN** for each task with `stepsEnabled` true the renderer issues a
+  `ReadStepsContent` for the worktree path
+- **AND** populates the task's in-memory `stepsContent` from the response
+
+#### Scenario: Store does not hold steps across restart
+
+- **WHEN** the app is closed and reopened
+- **THEN** the persisted store does not contain any `stepsContent` field


### PR DESCRIPTION
Introduce OpenSpec by scaffolding `openspec/` via the canonical
`openspec init` layout and documenting two already-shipped capabilities as
living specs (not in-flight change proposals):

- openspec/config.yaml — schema + project context (stack, layout,
  conventions) consumed by the OpenSpec CLI and agent skills.
- openspec/specs/remote-access/spec.md — HTTP+WebSocket server, token auth,
  agent list broadcasting, streaming, ring-buffer scrollback, mobile SPA.
- openspec/specs/steps-tracking/spec.md — opt-in prompt injection,
  `.claude/steps.json` watcher with debounce, IPC contract, panel rendering,
  git exclude for linked worktrees.

Specs use the canonical Requirement/Scenario (WHEN/THEN) format and pass
`openspec validate --strict`. `openspec/changes/` is intentionally empty —
reserved for genuinely new proposals. Editor integrations under `.claude/`
are regenerated locally via `npx @fission-ai/openspec@latest init --tools
claude` since `.claude/` is gitignored.