### PR TITLE
fix(git): refactor untracked file handling in getAllFileDiffs function

### DIFF
--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -874,13 +874,12 @@ export async function getAllFileDiffs(worktreePath: string, baseBranch?: string)
   // Untracked files: build pseudo-diffs
   const untrackedParts: string[] = [];
   try {
-    const { stdout } = await exec('git', ['status', '--porcelain'], {
+    const { stdout } = await exec('git', ['ls-files', '--others', '--exclude-standard'], {
       cwd: worktreePath,
       maxBuffer: MAX_BUFFER,
     });
     for (const line of stdout.split('\n')) {
-      if (!line.startsWith('??')) continue;
-      const filePath = normalizeStatusPath(line.slice(3));
+      const filePath = normalizeStatusPath(line);
       if (!filePath) continue;
       const fullPath = path.join(worktreePath, filePath);
       try {


### PR DESCRIPTION
# Description                
                                                                                   
  Fixes untracked files not appearing in the diff viewer when multiple untracked files reside under a newly created
   directory.                                                                                                      
                                                                                                                   
  `getAllFileDiffs` previously used `git status --porcelain` to discover untracked files. When an entire directory 
  is untracked, Git collapses the output to a single directory entry (e.g. `?? src/components/`) instead of listing
   each individual file. The code treated this directory path as a file path, `stat.isFile()` returned `false`, and
   every untracked file inside that directory was silently skipped — so they never appeared in the diff preview. 

  This change replaces `git status --porcelain` with `git ls-files --others --exclude-standard`, which always emits
   one line per file regardless of directory structure. This aligns `getAllFileDiffs` with `getChangedFiles`, which
   already uses the same `ls-files` command for untracked file detection.                                          
                                                                                                                 
  ## Issues Resolved

  - Untracked files in new directories (e.g. `src/components/mdx/Blockquote.tsx`) are now correctly included in the
   diff viewer output.
  - Eliminates the discrepancy where the changed-files sidebar (powered by `getChangedFiles`) showed the files, but
   clicking them opened an empty diff because `getAllFileDiffs` had dropped them. 