### PR TITLE
[codex] Fix Codex arguments

### DIFF
--- a/electron/ipc/agents.ts
+++ b/electron/ipc/agents.ts
@@ -31,7 +31,7 @@ const DEFAULT_AGENTS: AgentDef[] = [
     command: 'codex',
     args: [],
     resume_args: ['resume', '--last'],
-    skip_permissions_args: ['--full-auto'],
+    skip_permissions_args: ['--dangerously-bypass-approvals-and-sandbox'],
     description: "OpenAI's Codex CLI agent",
   },
   {

--- a/electron/ipc/pty.test.ts
+++ b/electron/ipc/pty.test.ts
@@ -4,63 +4,66 @@ import path from 'path';
 import type { BrowserWindow } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockExecFileSync, mockExecFile, mockChildProcessSpawn, mockPtySpawn } = vi.hoisted(() => {
-  const mockExecFileSync = vi.fn((command: string, args?: string[]) => {
-    if (command === 'which' && args?.[0] === 'nonexistent-binary-xyz') {
-      throw new Error('not found');
-    }
-    return '';
-  });
+const { mockExecFileSync, mockExecFile, mockChildProcessSpawn, mockPtySpawn, mockLogDebug } =
+  vi.hoisted(() => {
+    const mockExecFileSync = vi.fn((command: string, args?: string[]) => {
+      if (command === 'which' && args?.[0] === 'nonexistent-binary-xyz') {
+        throw new Error('not found');
+      }
+      return '';
+    });
 
-  const mockExecFile = vi.fn();
-  const mockChildProcessSpawn = vi.fn(() => ({
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
-    on: vi.fn(),
-  }));
+    const mockExecFile = vi.fn();
+    const mockChildProcessSpawn = vi.fn(() => ({
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+    }));
 
-  const mockPtySpawn = vi.fn(
-    (_command: string, _args: string[], options: { cols: number; rows: number }) => {
-      let onDataHandler: ((data: string) => void) | undefined;
-      let onExitHandler:
-        | ((event: { exitCode: number; signal: number | undefined }) => void)
-        | undefined;
+    const mockPtySpawn = vi.fn(
+      (_command: string, _args: string[], options: { cols: number; rows: number }) => {
+        let onDataHandler: ((data: string) => void) | undefined;
+        let onExitHandler:
+          | ((event: { exitCode: number; signal: number | undefined }) => void)
+          | undefined;
 
-      const proc = {
-        cols: options.cols,
-        rows: options.rows,
-        write: vi.fn(),
-        resize: vi.fn((cols: number, rows: number) => {
-          proc.cols = cols;
-          proc.rows = rows;
-        }),
-        pause: vi.fn(),
-        resume: vi.fn(),
-        kill: vi.fn(() => {
-          onExitHandler?.({ exitCode: 0, signal: 15 });
-        }),
-        onData: vi.fn((handler: (data: string) => void) => {
-          onDataHandler = handler;
-        }),
-        onExit: vi.fn(
-          (handler: (event: { exitCode: number; signal: number | undefined }) => void) => {
-            onExitHandler = handler;
+        const proc = {
+          cols: options.cols,
+          rows: options.rows,
+          write: vi.fn(),
+          resize: vi.fn((cols: number, rows: number) => {
+            proc.cols = cols;
+            proc.rows = rows;
+          }),
+          pause: vi.fn(),
+          resume: vi.fn(),
+          kill: vi.fn(() => {
+            onExitHandler?.({ exitCode: 0, signal: 15 });
+          }),
+          onData: vi.fn((handler: (data: string) => void) => {
+            onDataHandler = handler;
+          }),
+          onExit: vi.fn(
+            (handler: (event: { exitCode: number; signal: number | undefined }) => void) => {
+              onExitHandler = handler;
+            },
+          ),
+          emitData(data: string) {
+            onDataHandler?.(data);
           },
-        ),
-        emitData(data: string) {
-          onDataHandler?.(data);
-        },
-        emitExit(event: { exitCode: number; signal: number | undefined }) {
-          onExitHandler?.(event);
-        },
-      };
+          emitExit(event: { exitCode: number; signal: number | undefined }) {
+            onExitHandler?.(event);
+          },
+        };
 
-      return proc;
-    },
-  );
+        return proc;
+      },
+    );
 
-  return { mockExecFileSync, mockExecFile, mockChildProcessSpawn, mockPtySpawn };
-});
+    const mockLogDebug = vi.fn();
+
+    return { mockExecFileSync, mockExecFile, mockChildProcessSpawn, mockPtySpawn, mockLogDebug };
+  });
 
 vi.mock('child_process', async () => {
   const actual = await vi.importActual<typeof import('child_process')>('child_process');
@@ -74,6 +77,10 @@ vi.mock('child_process', async () => {
 
 vi.mock('node-pty', () => ({
   spawn: mockPtySpawn,
+}));
+
+vi.mock('../log.js', () => ({
+  debug: mockLogDebug,
 }));
 
 import {
@@ -155,6 +162,14 @@ function getFlagValues(args: string[], flag: string): string[] {
   return values;
 }
 
+function getSpawnCommandLogCtx(): { args: string[]; command: string } {
+  const call = mockLogDebug.mock.calls.find(
+    ([category, msg]) => category === 'pty' && String(msg).startsWith('spawn command '),
+  );
+  expect(call).toBeTruthy();
+  return call?.[2] as { args: string[]; command: string };
+}
+
 function makeTempHome(entries: string[]): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pty-docker-home-'));
   tempPaths.push(home);
@@ -227,6 +242,61 @@ describe('spawnAgent docker mode', () => {
     ]);
     expect(envFlags).not.toContain(`HOME=${hostHome}`);
     expect(envFlags).not.toContain(`HOME=${rendererHome}`);
+  });
+
+  it('redacts docker env values in spawn debug logs', () => {
+    spawnAgent(
+      createMockWindow(),
+      buildSpawnArgs({
+        env: {
+          API_KEY: 'secret-api-key',
+          NO_VALUE: '',
+        },
+      }),
+    );
+
+    const ctx = getSpawnCommandLogCtx();
+    const logged = ctx.args.join(' ');
+
+    expect(ctx.command).toBe('docker');
+    expect(getFlagValues(ctx.args, '-e')).toContain('API_KEY=<redacted>');
+    expect(getFlagValues(ctx.args, '-e')).toContain('NO_VALUE=<redacted>');
+    expect(getFlagValues(ctx.args, '-e')).toContain(`HOME=<redacted>`);
+    expect(logged).not.toContain('secret-api-key');
+    expect(logged).not.toContain(`HOME=${DOCKER_CONTAINER_HOME}`);
+    expect(logged).toContain('parallel-code-agent:test');
+  });
+
+  it('redacts inline docker env values in spawn debug logs', () => {
+    spawnAgent(
+      createMockWindow(),
+      buildSpawnArgs({
+        args: ['--env=INLINE_TOKEN=inline-secret', '--env', 'SPLIT_TOKEN=split-secret'],
+      }),
+    );
+
+    const logged = getSpawnCommandLogCtx().args.join(' ');
+
+    expect(logged).toContain('--env=INLINE_TOKEN=<redacted>');
+    expect(logged).toContain('SPLIT_TOKEN=<redacted>');
+    expect(logged).not.toContain('inline-secret');
+    expect(logged).not.toContain('split-secret');
+  });
+
+  it('redacts shell command strings in spawn debug logs', () => {
+    spawnAgent(
+      createMockWindow(),
+      buildSpawnArgs({
+        command: '/bin/sh',
+        args: ['-c', 'codex exec "prompt containing private context"'],
+        dockerMode: false,
+      }),
+    );
+
+    const ctx = getSpawnCommandLogCtx();
+
+    expect(ctx.command).toBe('/bin/sh');
+    expect(ctx.args).toEqual(['-c', '<redacted>']);
   });
 
   it('redirects credential mounts under /tmp inside the container', () => {

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -64,6 +64,50 @@ const BATCH_INTERVAL = 8; // ms
 const TAIL_CAP = 8 * 1024;
 const MAX_LINES = 50;
 
+function redactedSpawnArgs(command: string, args: string[]): string[] {
+  if ((command === '/bin/sh' || command.endsWith('/sh')) && args[0] === '-c') {
+    return ['-c', '<redacted>'];
+  }
+  if (command === 'docker') {
+    return redactDockerArgs(args);
+  }
+  return args;
+}
+
+function redactDockerArgs(args: string[]): string[] {
+  const redacted: string[] = [];
+  let redactNextEnv = false;
+
+  for (const arg of args) {
+    if (redactNextEnv) {
+      redacted.push(redactEnvAssignment(arg));
+      redactNextEnv = false;
+      continue;
+    }
+
+    if (arg === '-e' || arg === '--env') {
+      redacted.push(arg);
+      redactNextEnv = true;
+      continue;
+    }
+
+    if (arg.startsWith('--env=')) {
+      redacted.push(`--env=${redactEnvAssignment(arg.slice('--env='.length))}`);
+      continue;
+    }
+
+    redacted.push(arg);
+  }
+
+  return redacted;
+}
+
+function redactEnvAssignment(value: string): string {
+  const eqIdx = value.indexOf('=');
+  if (eqIdx <= 0) return '<redacted>';
+  return `${value.slice(0, eqIdx)}=<redacted>`;
+}
+
 /** Verify that a command exists in PATH. Throws a descriptive error if not found. */
 export function validateCommand(command: string): void {
   if (!command || !command.trim()) {
@@ -229,6 +273,14 @@ export function spawnAgent(
     spawnCommand = command;
     spawnArgs = args.args;
   }
+
+  logDebug('pty', `spawn command ${args.agentId}`, {
+    taskId: args.taskId,
+    command: spawnCommand,
+    args: redactedSpawnArgs(spawnCommand, spawnArgs),
+    cwd,
+    dockerMode: args.dockerMode === true,
+  });
 
   const proc = pty.spawn(spawnCommand, spawnArgs, {
     name: 'xterm-256color',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:coverage": "vitest run --coverage",
     "check": "npm run typecheck && npm run lint && npm run format:check",
     "release": "npm run typecheck && npm version patch && git push --follow-tags",
+    "postinstall": "node scripts/fix-node-pty-spawn-helper.mjs",
     "prepare": "husky && git config core.hooksPath .husky"
   },
   "license": "MIT",

--- a/scripts/fix-node-pty-spawn-helper.mjs
+++ b/scripts/fix-node-pty-spawn-helper.mjs
@@ -1,0 +1,18 @@
+import { chmodSync, existsSync } from 'fs';
+import { join } from 'path';
+import process from 'process';
+
+if (process.platform === 'darwin') {
+  const helperPath = join(
+    process.cwd(),
+    'node_modules',
+    'node-pty',
+    'prebuilds',
+    `darwin-${process.arch}`,
+    'spawn-helper',
+  );
+
+  if (existsSync(helperPath)) {
+    chmodSync(helperPath, 0o755);
+  }
+}

--- a/src/arena/ConfigScreen.tsx
+++ b/src/arena/ConfigScreen.tsx
@@ -24,7 +24,7 @@ import type { BattleCompetitor } from './types';
 /** Built-in tool presets — click to fill the next empty competitor slot */
 const TOOL_PRESETS: Array<{ name: string; command: string }> = [
   { name: 'Claude', command: 'claude -p "{prompt}" --dangerously-skip-permissions' },
-  { name: 'Codex', command: 'codex exec --full-auto "{prompt}"' },
+  { name: 'Codex', command: 'codex exec --dangerously-bypass-approvals-and-sandbox "{prompt}"' },
   { name: 'Gemini', command: 'gemini -p "{prompt}" --yolo' },
   { name: 'Copilot', command: 'copilot -p "{prompt}" --yolo' },
   { name: 'Aider', command: 'aider -m "{prompt}" --yes' },

--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -1,5 +1,83 @@
-import { describe, expect, it } from 'vitest';
-import { resolveIncomingPanelUserSize } from './persistence';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentDef } from '../ipc/types';
+import type { PersistedTask } from './types';
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock('../lib/ipc', () => ({
+  invoke: mockInvoke,
+}));
+
+import { loadState, resolveIncomingPanelUserSize } from './persistence';
+import { setStore, store } from './core';
+
+function agentDef(overrides: Partial<AgentDef> = {}): AgentDef {
+  return {
+    id: 'codex',
+    name: 'Codex CLI',
+    command: 'codex',
+    args: [],
+    resume_args: ['resume', '--last'],
+    skip_permissions_args: [],
+    description: 'Codex',
+    ...overrides,
+  };
+}
+
+function persistedTask(def: AgentDef): PersistedTask {
+  return {
+    id: 'task-1',
+    name: 'Task',
+    projectId: 'project-1',
+    branchName: 'task/task-1',
+    worktreePath: '/repo/.worktrees/task-1',
+    notes: '',
+    lastPrompt: '',
+    shellCount: 0,
+    agentDef: def,
+    gitIsolation: 'worktree',
+  };
+}
+
+async function loadPersistedAgent(def: AgentDef): Promise<AgentDef> {
+  mockInvoke.mockResolvedValueOnce(
+    JSON.stringify({
+      projects: [{ id: 'project-1', name: 'Repo', path: '/repo', color: 'hsl(0, 70%, 75%)' }],
+      lastProjectId: 'project-1',
+      lastAgentId: null,
+      taskOrder: ['task-1'],
+      collapsedTaskOrder: [],
+      tasks: {
+        'task-1': persistedTask(def),
+      },
+      activeTaskId: 'task-1',
+      sidebarVisible: true,
+    }),
+  );
+
+  await loadState();
+
+  const agentId = store.tasks['task-1']?.agentIds[0];
+  expect(agentId).toBeTruthy();
+  return store.agents[agentId as string].def;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setStore('projects', []);
+  setStore('lastProjectId', null);
+  setStore('lastAgentId', null);
+  setStore('taskOrder', []);
+  setStore('collapsedTaskOrder', []);
+  setStore('tasks', {});
+  setStore('agents', {});
+  setStore('activeTaskId', null);
+  setStore('activeAgentId', null);
+  setStore('availableAgents', []);
+  setStore('customAgents', []);
+});
 
 describe('resolveIncomingPanelUserSize', () => {
   it('prefers panelUserSize when both new and legacy are present', () => {
@@ -27,7 +105,7 @@ describe('resolveIncomingPanelUserSize', () => {
         'sidebar:width': 240,
       },
       undefined,
-      undefined, // no migration flag
+      undefined,
     );
     expect(result).toEqual({
       'tiling:uuid-1': 520,
@@ -54,8 +132,6 @@ describe('resolveIncomingPanelUserSize', () => {
   });
 
   it('rejects records containing non-finite numbers (NaN / Infinity)', () => {
-    // NaN and Infinity survive JSON.parse through custom reviver or hand edits
-    // — tighter validation here prevents them from becoming `flex: 0 0 NaNpx`.
     const result = resolveIncomingPanelUserSize(
       { 'tiling:a': Number.NaN, 'tiling:b': 200 },
       undefined,
@@ -80,5 +156,40 @@ describe('resolveIncomingPanelUserSize', () => {
       'sidebar:width': 240,
       'tiling:b': 15_000,
     });
+  });
+});
+
+describe('loadState agent definition migrations', () => {
+  it('migrates persisted Codex --full-auto skip-permissions args', async () => {
+    const restored = await loadPersistedAgent(
+      agentDef({
+        skip_permissions_args: ['--full-auto', '--stale-extra'],
+      }),
+    );
+
+    expect(restored.skip_permissions_args).toEqual(['--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('leaves non-Codex --full-auto skip-permissions args unchanged', async () => {
+    const restored = await loadPersistedAgent(
+      agentDef({
+        id: 'custom-agent',
+        name: 'Custom Agent',
+        command: 'custom',
+        skip_permissions_args: ['--full-auto'],
+      }),
+    );
+
+    expect(restored.skip_permissions_args).toEqual(['--full-auto']);
+  });
+
+  it('leaves current Codex skip-permissions args unchanged', async () => {
+    const restored = await loadPersistedAgent(
+      agentDef({
+        skip_permissions_args: ['--dangerously-bypass-approvals-and-sandbox'],
+      }),
+    );
+
+    expect(restored.skip_permissions_args).toEqual(['--dangerously-bypass-approvals-and-sandbox']);
   });
 });

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -28,6 +28,9 @@ function enrichAgentDef(agentDef: AgentDef | null | undefined, availableAgents: 
     if (!agentDef.skip_permissions_args)
       agentDef.skip_permissions_args = fresh.skip_permissions_args;
   }
+  if (agentDef.id === 'codex' && agentDef.skip_permissions_args?.includes('--full-auto')) {
+    agentDef.skip_permissions_args = ['--dangerously-bypass-approvals-and-sandbox'];
+  }
 }
 
 export async function saveState(): Promise<void> {


### PR DESCRIPTION
## Summary

Updates Codex launch arguments now that `--full-auto` is deprecated.

- Replaces the default Codex skip-permissions args with `--dangerously-bypass-approvals-and-sandbox` so the UI's “Dangerously skip all confirms” mode keeps bypassing prompts.
- Updates the Arena Codex preset to use the same bypass flag.
- Migrates restored persisted Codex agent definitions that still contain `--full-auto`.
- Adds PTY spawn command debug logging so future launch args are visible in logs.
- Redacts Docker `-e KEY=value` env values from PTY spawn logs.
- Repairs the macOS `node-pty` `spawn-helper` executable bit after install so PTY spawning works after dependency installs.

## Root Cause

Codex CLI no longer supports the old `--full-auto` flag. Existing defaults and persisted task definitions could still pass that deprecated flag. The replacement needs to preserve the existing skip-permissions behavior, which maps to Codex's explicit bypass flag. Separately, the local macOS `node-pty` helper could be installed without execute permissions, causing `posix_spawnp failed` before Codex launched.

## Validation

- `npm run check`
- Verified a local Codex session launches and logs the expected bypass args when skip-permissions mode is enabled.

## Note

Codex supports safer sandbox modes such as `--sandbox workspace-write`, but this PR intentionally preserves the existing “Dangerously skip all confirms” behavior. A future UI improvement could let Codex users choose between safer workspace automation and full bypass mode.