### PR TITLE
Share Docker agent auth across containers

### DIFF
--- a/electron/ipc/pty.test.ts
+++ b/electron/ipc/pty.test.ts
@@ -346,6 +346,21 @@ describe('spawnAgent docker mode', () => {
       expect(fs.existsSync(hostDir)).toBe(true);
     });
 
+    it('bind-mounts .claude.json file for claude so auth persists across containers', () => {
+      const home = makeTempHome([]);
+      vi.stubEnv('HOME', home);
+
+      spawnAgent(
+        createMockWindow(),
+        buildSpawnArgs({ command: 'claude', shareDockerAgentAuth: true }),
+      );
+
+      const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
+      const expectedHostFile = `${home}/.parallel-code/agent-auth/claude/.claude.json`;
+      expect(volumeFlags).toContain(`${expectedHostFile}:${DOCKER_CONTAINER_HOME}/.claude.json`);
+      expect(fs.existsSync(expectedHostFile)).toBe(true);
+    });
+
     it('does not mount agent auth directory when shareDockerAgentAuth is disabled', () => {
       const home = makeTempHome([]);
       vi.stubEnv('HOME', home);

--- a/electron/ipc/pty.test.ts
+++ b/electron/ipc/pty.test.ts
@@ -126,6 +126,7 @@ function buildSpawnArgs(
     rows: 40,
     dockerMode: true,
     dockerImage: 'parallel-code-agent:test',
+    shareDockerAgentAuth: false,
     onOutput: { __CHANNEL_ID__: 'channel-1' },
     ...overrides,
   };
@@ -309,6 +310,67 @@ describe('spawnAgent docker mode', () => {
     expect(volumeFlags).toContain(`${home}/.ssh:${DOCKER_CONTAINER_HOME}/.ssh:ro`);
     expect(volumeFlags).toContain(`${home}/.gitconfig:${DOCKER_CONTAINER_HOME}/.gitconfig:ro`);
     expect(volumeFlags).toContain(`${home}/.config/gh:${DOCKER_CONTAINER_HOME}/.config/gh:ro`);
+  });
+
+  describe('agent config dir mounts (shareDockerAgentAuth)', () => {
+    it.each([
+      ['claude', '.claude'],
+      ['codex', '.codex'],
+      ['gemini', '.gemini'],
+      ['opencode', '.config/opencode'],
+      ['copilot', '.config/github-copilot'],
+    ])(
+      '%s bind-mounts a user-owned host directory when shareDockerAgentAuth is enabled',
+      (command, relDir) => {
+        const home = makeTempHome([]);
+        vi.stubEnv('HOME', home);
+
+        spawnAgent(createMockWindow(), buildSpawnArgs({ command, shareDockerAgentAuth: true }));
+
+        const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
+        const expectedHostDir = `${home}/.parallel-code/agent-auth/${command}`;
+        expect(volumeFlags).toContain(`${expectedHostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
+      },
+    );
+
+    it('creates the host auth directory so it is user-owned before mounting', () => {
+      const home = makeTempHome([]);
+      vi.stubEnv('HOME', home);
+
+      spawnAgent(
+        createMockWindow(),
+        buildSpawnArgs({ command: 'claude', shareDockerAgentAuth: true }),
+      );
+
+      const hostDir = `${home}/.parallel-code/agent-auth/claude`;
+      expect(fs.existsSync(hostDir)).toBe(true);
+    });
+
+    it('does not mount agent auth directory when shareDockerAgentAuth is disabled', () => {
+      const home = makeTempHome([]);
+      vi.stubEnv('HOME', home);
+
+      spawnAgent(
+        createMockWindow(),
+        buildSpawnArgs({ command: 'claude', shareDockerAgentAuth: false }),
+      );
+
+      const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
+      expect(volumeFlags.some((v) => v.includes('.parallel-code/agent-auth'))).toBe(false);
+    });
+
+    it('does not mount agent auth directory for an unknown agent command', () => {
+      const home = makeTempHome([]);
+      vi.stubEnv('HOME', home);
+
+      spawnAgent(
+        createMockWindow(),
+        buildSpawnArgs({ command: 'unknown-agent', shareDockerAgentAuth: true }),
+      );
+
+      const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
+      expect(volumeFlags.some((v) => v.includes('.parallel-code/agent-auth'))).toBe(false);
+    });
   });
 });
 

--- a/electron/ipc/pty.test.ts
+++ b/electron/ipc/pty.test.ts
@@ -328,7 +328,7 @@ describe('spawnAgent docker mode', () => {
         spawnAgent(createMockWindow(), buildSpawnArgs({ command, shareDockerAgentAuth: true }));
 
         const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
-        const expectedHostDir = `${home}/.parallel-code/agent-auth/${command}`;
+        const expectedHostDir = `${home}/.parallel-code/agent-auth/${command}/${relDir}`;
         expect(volumeFlags).toContain(`${expectedHostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
       },
     );
@@ -342,7 +342,7 @@ describe('spawnAgent docker mode', () => {
         buildSpawnArgs({ command: 'claude', shareDockerAgentAuth: true }),
       );
 
-      const hostDir = `${home}/.parallel-code/agent-auth/claude`;
+      const hostDir = `${home}/.parallel-code/agent-auth/claude/.claude`;
       expect(fs.existsSync(hostDir)).toBe(true);
     });
 

--- a/electron/ipc/pty.test.ts
+++ b/electron/ipc/pty.test.ts
@@ -358,7 +358,7 @@ describe('spawnAgent docker mode', () => {
       const volumeFlags = getFlagValues(getLastSpawnCall().args, '-v');
       const expectedHostFile = `${home}/.parallel-code/agent-auth/claude/.claude.json`;
       expect(volumeFlags).toContain(`${expectedHostFile}:${DOCKER_CONTAINER_HOME}/.claude.json`);
-      expect(fs.existsSync(expectedHostFile)).toBe(true);
+      expect(fs.readFileSync(expectedHostFile, 'utf8')).toBe('{}');
     });
 
     it('does not mount agent auth directory when shareDockerAgentAuth is disabled', () => {

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -690,8 +690,8 @@ function buildDockerCredentialMounts(agentCommand: string, shareAgentAuth: boole
       try {
         const hostDir = path.dirname(hostFile);
         fs.mkdirSync(hostDir, { recursive: true, mode: 0o700 });
-        if (!fs.existsSync(hostFile)) {
-          fs.writeFileSync(hostFile, '', { mode: 0o600 });
+        if (!fs.existsSync(hostFile) || fs.statSync(hostFile).size === 0) {
+          fs.writeFileSync(hostFile, '{}', { mode: 0o600 });
         }
         mounts.push('-v', `${hostFile}:${DOCKER_CONTAINER_HOME}/${relFile}`);
       } catch {

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -626,6 +626,11 @@ const AGENT_CONFIG_DIRS: Record<string, string[]> = {
   copilot: ['.config/github-copilot'],
 };
 
+// Config files (not directories) each agent CLI uses for auth, relative to HOME.
+const AGENT_CONFIG_FILES: Record<string, string[]> = {
+  claude: ['.claude.json'],
+};
+
 function buildDockerCredentialMounts(agentCommand: string, shareAgentAuth: boolean): string[] {
   const mounts: string[] = [];
   const home = process.env.HOME;
@@ -678,6 +683,19 @@ function buildDockerCredentialMounts(agentCommand: string, shareAgentAuth: boole
         mounts.push('-v', `${hostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
       } catch {
         console.warn(`[docker-auth] Could not create host auth dir ${hostDir}, skipping mount`);
+      }
+    }
+    for (const relFile of AGENT_CONFIG_FILES[baseCommand] ?? []) {
+      const hostFile = path.join(home, '.parallel-code', 'agent-auth', baseCommand, relFile);
+      try {
+        const hostDir = path.dirname(hostFile);
+        fs.mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+        if (!fs.existsSync(hostFile)) {
+          fs.writeFileSync(hostFile, '', { mode: 0o600 });
+        }
+        mounts.push('-v', `${hostFile}:${DOCKER_CONTAINER_HOME}/${relFile}`);
+      } catch {
+        console.warn(`[docker-auth] Could not create host auth file ${hostFile}, skipping mount`);
       }
     }
   }

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -670,10 +670,15 @@ function buildDockerCredentialMounts(agentCommand: string, shareAgentAuth: boole
   // by this process (running as the user), so the containerised agent can
   // write credentials on first login and read them on subsequent runs.
   if (shareAgentAuth) {
-    for (const relDir of AGENT_CONFIG_DIRS[agentCommand] ?? []) {
-      const hostDir = path.join(home, '.parallel-code', 'agent-auth', agentCommand);
-      fs.mkdirSync(hostDir, { recursive: true });
-      mounts.push('-v', `${hostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
+    const baseCommand = path.basename(agentCommand);
+    for (const relDir of AGENT_CONFIG_DIRS[baseCommand] ?? []) {
+      const hostDir = path.join(home, '.parallel-code', 'agent-auth', baseCommand, relDir);
+      try {
+        fs.mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+        mounts.push('-v', `${hostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
+      } catch {
+        console.warn(`[docker-auth] Could not create host auth dir ${hostDir}, skipping mount`);
+      }
     }
   }
 

--- a/electron/ipc/pty.ts
+++ b/electron/ipc/pty.ts
@@ -148,6 +148,7 @@ export function spawnAgent(
     isShell?: boolean;
     dockerMode?: boolean;
     dockerImage?: string;
+    shareDockerAgentAuth?: boolean;
     onOutput: { __CHANNEL_ID__: string };
   },
 ): void {
@@ -264,7 +265,7 @@ export function spawnAgent(
       '-e',
       `HOME=${DOCKER_CONTAINER_HOME}`,
       // Mount SSH and git config read-only for git operations
-      ...buildDockerCredentialMounts(),
+      ...buildDockerCredentialMounts(args.command, args.shareDockerAgentAuth === true),
       image,
       command,
       ...args.args,
@@ -616,7 +617,16 @@ function buildDockerEnvFlags(env: Record<string, string>): string[] {
   return flags;
 }
 
-function buildDockerCredentialMounts(): string[] {
+// Config directories each agent CLI uses for auth/settings, relative to HOME.
+const AGENT_CONFIG_DIRS: Record<string, string[]> = {
+  claude: ['.claude'],
+  codex: ['.codex'],
+  gemini: ['.gemini'],
+  opencode: ['.config/opencode'],
+  copilot: ['.config/github-copilot'],
+};
+
+function buildDockerCredentialMounts(agentCommand: string, shareAgentAuth: boolean): string[] {
   const mounts: string[] = [];
   const home = process.env.HOME;
   if (!home) return mounts;
@@ -651,6 +661,20 @@ function buildDockerCredentialMounts(): string[] {
   const googleCredsFile = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (googleCredsFile) {
     mountIfExists(googleCredsFile, googleCredsFile);
+  }
+
+  // When "Share agent auth across Linux containers" is enabled, bind-mount a
+  // host directory (created here, owned by the current user) into the agent's
+  // config location inside the container. Using a host directory avoids the
+  // root-ownership problem of Docker named volumes: the directory is created
+  // by this process (running as the user), so the containerised agent can
+  // write credentials on first login and read them on subsequent runs.
+  if (shareAgentAuth) {
+    for (const relDir of AGENT_CONFIG_DIRS[agentCommand] ?? []) {
+      const hostDir = path.join(home, '.parallel-code', 'agent-auth', agentCommand);
+      fs.mkdirSync(hostDir, { recursive: true });
+      mounts.push('-v', `${hostDir}:${DOCKER_CONTAINER_HOME}/${relDir}`);
+    }
   }
 
   return mounts;

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -237,6 +237,7 @@ export function registerAllHandlers(win: BrowserWindow): void {
     assertInt(args.rows, 'rows');
     assertOptionalBoolean(args.dockerMode, 'dockerMode');
     assertOptionalString(args.dockerImage, 'dockerImage');
+    assertOptionalBoolean(args.shareDockerAgentAuth, 'shareDockerAgentAuth');
     assertOptionalBoolean(args.stepsEnabled, 'stepsEnabled');
     if (args.cwd) validatePath(args.cwd, 'cwd');
     if (!args.isShell && args.cwd) {

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -902,6 +902,10 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
                   >
                     The agent will run inside a Docker container. Only the project directory is
                     mounted — files outside the project are protected from accidental deletion.
+                    <Show when={store.shareDockerAgentAuth}>
+                      {' '}
+                      Agent credentials are shared across containers.
+                    </Show>
                   </div>
                   <Show when={projectDockerfile()}>
                     <div

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -23,6 +23,7 @@ import {
   setInactiveColumnOpacity,
   setEditorCommand,
   setDockerImage,
+  setShareDockerAgentAuth,
   setAskCodeProvider,
   setMinimaxApiKey,
 } from '../store/store';
@@ -541,6 +542,34 @@ export function SettingsDialog(props: SettingsDialogProps) {
               will use a project-specific image instead.
             </div>
           </div>
+          <label
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '10px',
+              cursor: 'pointer',
+              padding: '8px 12px',
+              'border-radius': '8px',
+              background: theme.bgInput,
+              border: `1px solid ${theme.border}`,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={store.shareDockerAgentAuth}
+              onChange={(e) => setShareDockerAgentAuth(e.currentTarget.checked)}
+              style={{ 'accent-color': theme.accent, cursor: 'pointer' }}
+            />
+            <div style={{ display: 'flex', 'flex-direction': 'column', gap: '2px' }}>
+              <span style={{ 'font-size': '14px', color: theme.fg }}>
+                Share agent auth across Linux containers
+              </span>
+              <span style={{ 'font-size': '12px', color: theme.fgSubtle }}>
+                Persist agent credentials in a user-owned host directory so you only need to sign in
+                once per agent type. Auth on first run is saved automatically for future containers.
+              </span>
+            </div>
+          </label>
         </div>
       </Show>
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -612,6 +612,7 @@ export function TerminalView(props: TerminalViewProps) {
       stepsEnabled: props.stepsEnabled,
       dockerMode: props.dockerMode,
       dockerImage: props.dockerImage,
+      shareDockerAgentAuth: store.shareDockerAgentAuth,
       onOutput,
       // eslint-disable-next-line solid/reactivity -- promise catch handler reads current prop values intentionally
     }).catch((err) => {

--- a/src/store/autosave.ts
+++ b/src/store/autosave.ts
@@ -33,6 +33,7 @@ function persistedSnapshot(): string {
     editorCommand: store.editorCommand,
     customAgents: store.customAgents,
     focusMode: store.focusMode,
+    shareDockerAgentAuth: store.shareDockerAgentAuth,
     tasks: Object.fromEntries(
       [...store.taskOrder, ...store.collapsedTaskOrder]
         .filter((id) => store.tasks[id])

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -51,6 +51,7 @@ export const [store, setStore] = createStore<AppStore>({
   editorCommand: '',
   dockerImage: 'parallel-code-agent:latest',
   dockerAvailable: false,
+  shareDockerAgentAuth: false,
   askCodeProvider: 'claude',
   newTaskDropUrl: null,
   newTaskPrefillPrompt: null,

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -69,6 +69,7 @@ export async function saveState(): Promise<void> {
     keybindingMigrationDismissed: store.keybindingMigrationDismissed || undefined,
     focusMode: store.focusMode || undefined,
     verboseLogging: store.verboseLogging || undefined,
+    shareDockerAgentAuth: store.shareDockerAgentAuth || undefined,
   };
 
   for (const taskId of store.taskOrder) {
@@ -257,6 +258,7 @@ interface LegacyPersistedState {
   keybindingMigrationDismissed?: unknown;
   focusMode?: unknown;
   verboseLogging?: unknown;
+  shareDockerAgentAuth?: unknown;
 }
 
 export async function loadState(): Promise<void> {
@@ -395,6 +397,8 @@ export async function loadState(): Promise<void> {
       s.focusMode = raw.focusMode === true;
 
       s.verboseLogging = typeof raw.verboseLogging === 'boolean' ? raw.verboseLogging : false;
+
+      s.shareDockerAgentAuth = raw.shareDockerAgentAuth === true;
 
       const rawDockerImage = raw.dockerImage;
       s.dockerImage =

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -116,6 +116,7 @@ export {
   setEditorCommand,
   setDockerImage,
   setDockerAvailable,
+  setShareDockerAgentAuth,
   setAskCodeProvider,
   setMinimaxApiKey,
   setWindowState,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -153,6 +153,7 @@ export interface PersistedState {
   inactiveColumnOpacity?: number;
   editorCommand?: string;
   dockerImage?: string;
+  shareDockerAgentAuth?: boolean;
   askCodeProvider?: 'claude' | 'minimax';
   customAgents?: AgentDef[];
   keybindingMigrationDismissed?: boolean;
@@ -230,6 +231,7 @@ export interface AppStore {
   editorCommand: string;
   dockerImage: string;
   dockerAvailable: boolean;
+  shareDockerAgentAuth: boolean;
   askCodeProvider: 'claude' | 'minimax';
   newTaskDropUrl: string | null;
   newTaskPrefillPrompt: { prompt: string; projectId: string | null } | null;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -135,6 +135,10 @@ export function setDockerAvailable(available: boolean): void {
   setStore('dockerAvailable', available);
 }
 
+export function setShareDockerAgentAuth(enabled: boolean): void {
+  setStore('shareDockerAgentAuth', enabled);
+}
+
 export function toggleArena(show?: boolean): void {
   setStore('showArena', show ?? !store.showArena);
 }


### PR DESCRIPTION
## Summary

Docker-mode agents currently start with a fresh writable home each time, so users have to re-sign into Claude, Codex, Gemini, OpenCode, or Copilot for every new Docker container. That repeated authentication overhead makes Docker isolation less appealing, especially when creating multiple worktrees or trying short-lived tasks.

This PR adds an opt-in setting to share agent auth across Linux containers. When enabled, the app creates a user-owned host directory under `~/.parallel-code/agent-auth/<agent>` and bind-mounts it into that agent's config directory inside Docker, such as `/tmp/.codex` or `/tmp/.claude`. Signing in once inside a Docker container then persists for later Docker containers of the same agent type, including containers launched from different worktrees.

## Implementation

- Adds a persisted `shareDockerAgentAuth` setting and a checkbox in Settings.
- Forwards the setting through the terminal spawn IPC path with main-process validation.
- Mounts per-agent auth directories for known agent commands only:
  - `claude` -> `/tmp/.claude`
  - `codex` -> `/tmp/.codex`
  - `gemini` -> `/tmp/.gemini`
  - `opencode` -> `/tmp/.config/opencode`
  - `copilot` -> `/tmp/.config/github-copilot`
- Uses host bind directories instead of Docker named volumes so the container process, which runs as the host UID/GID, can write credentials on first login.
- Covers enabled, disabled, and unknown-agent behavior in the Docker PTY tests.

## Limitations

- This does not copy or seed credentials from existing host config directories like `~/.codex` or `~/.claude`; it persists credentials created inside Docker after the setting is enabled.
- Auth is shared per agent type, not per project or worktree.
- Only the known built-in agent command names get auth mounts. Custom or differently named wrappers are intentionally ignored unless added to the mapping.
- Existing running containers are unaffected; the mount is applied when a Docker agent is spawned.

## Validation

- `npm test -- electron/ipc/pty.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run format:check`
- Commit and push hooks also ran `npm run check`.