### PR TITLE
fix(diff): ignore double-click in blank area outside diff lines

### DIFF
--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -895,24 +895,17 @@ export function ScrollingDiffView(props: ScrollingDiffViewProps) {
       // For double-clicks (detail >= 2) outside a diff line, prevent the
       // browser from creating its "snap to nearest text" selection at all,
       // so the user doesn't see a brief blue flash on the last diff line.
+      // Note: this fires on the second mousedown of the sequence — the
+      // first mousedown of a double-click has detail === 1.
       if (e.detail >= 2) {
         const target = e.target as HTMLElement | null;
-        if (!target?.closest('[data-new-line]')) {
+        if (!target?.closest('[data-line-type]')) {
           e.preventDefault();
         }
       }
     }
 
-    function onMouseUp(e: MouseEvent) {
-      // Ignore clicks that didn't land on a diff line. Without this, a
-      // double-click in the blank area below the last file collapses the
-      // browser's "snap to nearest text" selection onto the previous line
-      // and incorrectly opens the inline input.
-      const target = e.target as HTMLElement | null;
-      if (!target?.closest('[data-new-line]')) {
-        if (!pendingInput()) setHighlightedRange(null);
-        return;
-      }
+    function onMouseUp() {
       requestAnimationFrame(() => {
         const sel = getDiffSelection();
         if (!sel) {

--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -897,12 +897,15 @@ export function ScrollingDiffView(props: ScrollingDiffViewProps) {
       // so the user doesn't see a brief blue flash on the last diff line.
       // Note: this fires on the second mousedown of the sequence — the
       // first mousedown of a double-click has detail === 1.
-      if (e.detail >= 2) {
-        const target = e.target as HTMLElement | null;
-        if (!target?.closest('[data-line-type]')) {
-          e.preventDefault();
-        }
-      }
+      if (e.button !== 0 || e.detail < 2) return;
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      )
+        return;
+      if (!target.closest('[data-line-type]')) e.preventDefault();
     }
 
     function onMouseUp() {

--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -891,7 +891,28 @@ export function ScrollingDiffView(props: ScrollingDiffViewProps) {
   });
 
   onMount(() => {
-    function onMouseUp() {
+    function onMouseDown(e: MouseEvent) {
+      // For double-clicks (detail >= 2) outside a diff line, prevent the
+      // browser from creating its "snap to nearest text" selection at all,
+      // so the user doesn't see a brief blue flash on the last diff line.
+      if (e.detail >= 2) {
+        const target = e.target as HTMLElement | null;
+        if (!target?.closest('[data-new-line]')) {
+          e.preventDefault();
+        }
+      }
+    }
+
+    function onMouseUp(e: MouseEvent) {
+      // Ignore clicks that didn't land on a diff line. Without this, a
+      // double-click in the blank area below the last file collapses the
+      // browser's "snap to nearest text" selection onto the previous line
+      // and incorrectly opens the inline input.
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest('[data-new-line]')) {
+        if (!pendingInput()) setHighlightedRange(null);
+        return;
+      }
       requestAnimationFrame(() => {
         const sel = getDiffSelection();
         if (!sel) {
@@ -911,8 +932,12 @@ export function ScrollingDiffView(props: ScrollingDiffViewProps) {
       });
     }
 
+    containerRef?.addEventListener('mousedown', onMouseDown);
     containerRef?.addEventListener('mouseup', onMouseUp);
-    onCleanup(() => containerRef?.removeEventListener('mouseup', onMouseUp));
+    onCleanup(() => {
+      containerRef?.removeEventListener('mousedown', onMouseDown);
+      containerRef?.removeEventListener('mouseup', onMouseUp);
+    });
   });
 
   function handleSubmit(text: string, mode: 'review' | 'ask') {


### PR DESCRIPTION
# Summary                                                

  Double-clicking in the empty area below the last file (or between files) caused two glitches:                                                                 
  
  1. The browser's "snap-to-nearest-text" behavior collapsed the selection onto the last diff line, causing a stray blue highlight flash                        
  2. That ghost selection also incorrectly opened the inline review/ask input