### PR TITLE
feat(inline-input): add cancel button and global Esc to dismiss

### DIFF
--- a/src/components/InlineInput.tsx
+++ b/src/components/InlineInput.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount } from 'solid-js';
+import { createSignal, onCleanup, onMount } from 'solid-js';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import type { DiffInteractionMode } from './review-types';
@@ -15,6 +15,15 @@ export function InlineInput(props: InlineInputProps) {
 
   onMount(() => {
     requestAnimationFrame(() => inputRef?.focus());
+    const onGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        props.onDismiss();
+      }
+    };
+    document.addEventListener('keydown', onGlobalKeyDown, true);
+    onCleanup(() => document.removeEventListener('keydown', onGlobalKeyDown, true));
   });
 
   const borderColor = () => (mode() === 'review' ? theme.warning : theme.accent);
@@ -127,6 +136,26 @@ export function InlineInput(props: InlineInputProps) {
         }}
       >
         {mode() === 'review' ? 'Comment' : 'Ask'}
+      </button>
+
+      {/* Cancel button */}
+      <button
+        onClick={() => props.onDismiss()}
+        title="Cancel (Esc)"
+        aria-label="Cancel"
+        style={{
+          background: 'transparent',
+          border: `1px solid ${theme.borderSubtle}`,
+          color: theme.fgMuted,
+          cursor: 'pointer',
+          padding: '4px 8px',
+          'border-radius': '4px',
+          'font-size': sf(14),
+          'line-height': '1',
+          'align-self': 'center',
+        }}
+      >
+        &times;
       </button>
     </div>
   );


### PR DESCRIPTION
# Summary                                                                                                                                                       
                                                                                                                                                                
The InlineInput.tsx component shown after selecting code in the diff viewer could not be cancelled once the input lost focus. This PR makes it always  dismissable.
                                                                                                                                                                
  - Add a global Escape keydown listener (on document, capture phase) so users can dismiss the popup at any time                                                
  - Add an explicit cancel button (×) next to the submit button for mouse users
  - Clean up the keydown listener on unmount   