### PR TITLE
fix(ipc): add missing get_uncommitted_file_diffs to preload allowlist

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -35,6 +35,7 @@ const ALLOWED_CHANNELS = new Set([
   'get_branch_commits',
   'get_commit_changed_files',
   'get_commit_diffs',
+  'get_uncommitted_file_diffs',
   'get_coverage_summary',
   'push_task',
   'rebase_task',


### PR DESCRIPTION
## Summary

Fixes `get_uncommitted_file_diffs` IPC channel being rejected by the preload allowlist. The handler existed on the main process side, but the channel name was missing from `ALLOWED_CHANNELS` in `electron/preload.cjs`, so any frontend call was blocked before reaching the backend and uncommitted file diffs could not be loaded.

Adds `'get_uncommitted_file_diffs'` to the allowlist, alongside the other git diff channels (`get_commit_diffs`, `get_commit_changed_files`, etc.).

## Changes

- `electron/preload.cjs`: add `'get_uncommitted_file_diffs'` to `ALLOWED_CHANNELS`

