### PR TITLE
fix(prompt): scale bracketed-paste delay by line count to prevent stuck initial prompts

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -74,7 +74,7 @@ vi.mock('../lib/log', () => ({
   warn: vi.fn(),
 }));
 
-import { sendPrompt } from './tasks';
+import { pasteDelayMs, sendPrompt } from './tasks';
 
 function writePayloads(): string[] {
   return mockInvoke.mock.calls
@@ -178,5 +178,21 @@ describe('sendPrompt', () => {
 
     expect(writePayloads()[1]).toContain('manual replacement');
     expect(writePayloads()[1]).toContain('IMPORTANT: Maintain .claude/steps.json');
+  });
+});
+
+describe('pasteDelayMs', () => {
+  it('returns 50ms for a short single-line prompt', () => {
+    expect(pasteDelayMs('hello')).toBe(50);
+  });
+
+  it('scales by line count for a ~31-line prompt', () => {
+    const text = Array.from({ length: 31 }, (_, i) => `line ${i + 1}`).join('\n');
+    expect(pasteDelayMs(text)).toBe(Math.min(500, Math.max(50, 31 * 15)));
+  });
+
+  it('caps at 500ms for a very large prompt', () => {
+    const text = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join('\n');
+    expect(pasteDelayMs(text)).toBe(500);
   });
 });

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -13,6 +13,7 @@ import {
   clearTaskGitStatusTracking,
   isAgentBracketedPasteEnabled,
   isAgentIdle,
+  isAgentBracketedPasteEnabled,
   rescheduleTaskStatusPolling,
 } from './taskStatus';
 import { recordMergedLines, recordTaskCompleted } from './completion';
@@ -58,6 +59,20 @@ const BRACKETED_PASTE_END = '\x1b[201~';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
+
+// Delay between writing pasted text and the Enter key.  Claude Code (and other
+// TUI agents) process bracketed paste asynchronously — if \r arrives before
+// the paste is fully consumed, it gets absorbed into the input buffer instead
+// of submitting it.  We scale the delay by line count so large prompts (e.g.
+// initial task prompts of 30+ lines) reliably submit.  Cap at 500ms to avoid
+// noticeable lag on normal sends.
+function pasteDelayMs(text: string): number {
+  const lines = text.split('\n').length;
+  return Math.min(500, Math.max(50, lines * 15));
 }
 
 function isAgentNotFoundError(err: unknown): boolean {
@@ -496,13 +511,12 @@ export async function sendPrompt(taskId: string, agentId: string, text: string):
   // bracketed paste, wrap only the prompt text; this avoids Codex's paste-burst
   // guard treating rapid synthetic keystrokes plus Enter as a paste.
   setTaskLastInputAt(taskId);
+  const useBracketed = isAgentBracketedPasteEnabled(agentId);
   await writeToAgentWhenReady(
     agentId,
-    isAgentBracketedPasteEnabled(agentId)
-      ? `${BRACKETED_PASTE_START}${effectiveText}${BRACKETED_PASTE_END}`
-      : effectiveText,
+    useBracketed ? `${BRACKETED_PASTE_START}${effectiveText}${BRACKETED_PASTE_END}` : effectiveText,
   );
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => setTimeout(r, pasteDelayMs(effectiveText)));
   await writeToAgentWhenReady(agentId, '\r');
   setStore('tasks', taskId, 'lastPrompt', text);
   if (task && !hasPromptedAgent) {

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -13,7 +13,6 @@ import {
   clearTaskGitStatusTracking,
   isAgentBracketedPasteEnabled,
   isAgentIdle,
-  isAgentBracketedPasteEnabled,
   rescheduleTaskStatusPolling,
 } from './taskStatus';
 import { recordMergedLines, recordTaskCompleted } from './completion';
@@ -61,16 +60,13 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const BRACKETED_PASTE_START = '\x1b[200~';
-const BRACKETED_PASTE_END = '\x1b[201~';
-
 // Delay between writing pasted text and the Enter key.  Claude Code (and other
 // TUI agents) process bracketed paste asynchronously — if \r arrives before
 // the paste is fully consumed, it gets absorbed into the input buffer instead
 // of submitting it.  We scale the delay by line count so large prompts (e.g.
 // initial task prompts of 30+ lines) reliably submit.  Cap at 500ms to avoid
 // noticeable lag on normal sends.
-function pasteDelayMs(text: string): number {
+export function pasteDelayMs(text: string): number {
   const lines = text.split('\n').length;
   return Math.min(500, Math.max(50, lines * 15));
 }


### PR DESCRIPTION
## Summary

- Track bracketed paste mode (CSI `?2004h/l`) per agent in `AgentTrackingState` via `updateBracketedPasteMode()`, called on each PTY data chunk
- Export `isAgentBracketedPasteEnabled()` so `sendPrompt` can conditionally wrap text in `\x1b[200~...\x1b[201~` (matches what Codex expects to avoid its paste-burst guard)
- Replace the fixed 50ms pre-Enter delay with `pasteDelayMs(text)`: `max(50ms, lines × 15ms)` capped at 500ms

## Problem

When an agent enables bracketed paste mode, synthetic prompt sends wrap the text in `\x1b[200~...\x1b[201~`. TUI agents like Claude Code process this paste asynchronously — if `\r` arrives while the paste is still being consumed (within the fixed 50ms window), it is absorbed into the input buffer as a newline rather than submitting the prompt.

The symptom: the agent sits in `-- INSERT --` mode showing `[Pasted text #1 +N lines]`, waiting indefinitely for Enter. Reproduces reliably with initial task prompts of 30+ lines.

## Test plan

- [ ] Create a task with a multi-line initial prompt (30+ lines) targeting a Claude Code agent — prompt should auto-send and not get stuck in INSERT mode
- [ ] Create a task with a short (1-line) initial prompt — still sends within ~50ms, no noticeable lag
- [ ] Create a Codex task — bracketed paste still wraps correctly, no paste-burst guard regression
- [ ] Manual sends from the PromptInput textarea still work for all agent types

🤖 Generated with [Claude Code](https://claude.com/claude-code)