### PR TITLE
Fix diff viewer related changes

### DIFF
--- a/src/components/ChangedFilesList.tsx
+++ b/src/components/ChangedFilesList.tsx
@@ -489,6 +489,7 @@ export function ChangedFilesList(props: ChangedFilesListProps) {
         'font-family': "'JetBrains Mono', monospace",
         'font-size': sf(12),
         outline: 'none',
+        'user-select': 'none',
       }}
     >
       <div style={{ flex: '1', overflow: 'auto', padding: '4px 0' }}>

--- a/src/components/DiffViewerDialog.tsx
+++ b/src/components/DiffViewerDialog.tsx
@@ -261,6 +261,7 @@ function DiffViewerContent(props: DiffViewerDialogProps) {
           padding: `${headerPaddingTop} 20px 12px`,
           'border-bottom': `1px solid ${theme.border}`,
           'flex-shrink': '0',
+          'user-select': 'none',
         }}
       >
         <div
@@ -426,6 +427,7 @@ function DiffViewerContent(props: DiffViewerDialogProps) {
               display: 'flex',
               'align-items': 'center',
               gap: '6px',
+              'user-select': 'none',
             }}
           >
             Changed Files

--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -575,6 +575,7 @@ function FileSection(props: {
           background: `color-mix(in srgb, ${theme.bgElevated} 96%, white)`,
           'border-bottom': `1px solid ${theme.border}`,
           cursor: 'pointer',
+          'user-select': 'none',
         }}
       >
         {/* Collapse indicator */}


### PR DESCRIPTION
                                                                                                                                                        
 # Summary
                                                                                                                                                                           
  Disable text selection on UI chrome elements in the Diff Viewer to prevent accidental selection of non-content text (headers, filenames, file list items) and improve the
   overall interaction experience.                                                                                                                                         
                                                         
 # Changes                                                                                                                                                                  
                                                         
  - ChangedFilesList.tsx — add user-select: none to the file list container                                                                                                
  - DiffViewerDialog.tsx — add user-select: none to the dialog header title and "Changed Files" label
  - ScrollingDiffView.tsx — add user-select: none to the file section header                                                                                               
                                                                                                                                                                           
 # Test Plan                                                                                                                                                                
                                                                                                                                                                           
  - Open the Diff Viewer and attempt to select header titles, filenames, and file list items — verify they cannot be selected                                              
  - Confirm that diff content areas remain selectable as before