### PR TITLE
feat(security): atomic writes, input validators, and static analysis tooling

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -51,7 +51,6 @@ module.exports = {
           '^electron/mcp/server\\.ts$',
           // New subsystem files have no importers until coordinator PRs land
           '^electron/mcp/atomic\\.ts$',
-          '^electron/mcp/validation\\.ts$',
           // Vite ambient env declarations
           '^src/vite-env\\.d\\.ts$',
         ],

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,80 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    {
+      name: 'no-renderer-importing-main',
+      severity: 'error',
+      comment:
+        'Renderer (src/) must never import Electron main-process code. ' +
+        'Use IPC channels instead.',
+      from: { path: '^src/' },
+      to: {
+        path: '^electron/',
+        // Allow importing the shared IPC channel enum (channels.ts is a pure enum, no Node/Electron deps)
+        pathNot: '^electron/ipc/channels\\.ts',
+      },
+    },
+    {
+      name: 'no-mcp-importing-components',
+      severity: 'error',
+      comment: 'MCP coordinator must not import frontend components or store.',
+      from: { path: '^electron/mcp/' },
+      to: { path: '^src/(components|store|lib)/' },
+    },
+    {
+      name: 'no-circular',
+      severity: 'error',
+      comment:
+        'Circular dependencies break tree-shaking and make reasoning about startup order impossible.',
+      from: {},
+      to: { circular: true },
+    },
+    {
+      name: 'no-orphans',
+      severity: 'warn',
+      comment: 'Orphan modules have no importers and no exports used elsewhere — likely dead code.',
+      from: {
+        orphan: true,
+        // Test files, config files, entry points, and pure type modules are expected orphans.
+        // Type-only modules (types.ts, *.d.ts) are consumed by TypeScript structurally — the
+        // import graph doesn't capture all type-level usage, so they appear orphaned.
+        pathNot: [
+          '\\.test\\.(ts|tsx)$',
+          '\\.config\\.(ts|js|cjs)$',
+          '\\.d\\.ts$',
+          'types\\.ts$',
+          'types\\.(ts|tsx)$',
+          '^src/main\\.tsx$',
+          '^src/remote/main\\.tsx$',
+          '^electron/main\\.ts$',
+          '^electron/preload\\.cjs$',
+          '^electron/mcp/server\\.ts$',
+          // New subsystem files have no importers until coordinator PRs land
+          '^electron/mcp/atomic\\.ts$',
+          '^electron/mcp/validation\\.ts$',
+          // Vite ambient env declarations
+          '^src/vite-env\\.d\\.ts$',
+        ],
+      },
+      to: {},
+    },
+  ],
+
+  options: {
+    doNotFollow: {
+      path: 'node_modules',
+    },
+    moduleSystems: ['es6', 'cjs'],
+    tsConfig: {
+      fileName: 'tsconfig.json',
+    },
+    reporterOptions: {
+      dot: {
+        collapsePattern: 'node_modules/[^/]+',
+      },
+      archi: {
+        collapsePattern: '^(node_modules|src/components)/[^/]+',
+      },
+    },
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-electron
 dist-remote
 release
 coverage
+# Runtime data dir written by the app (MCP coordinator state, etc.)
 .parallel-code/
 .worktrees
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-electron
 dist-remote
 release
 coverage
+.parallel-code/
 .worktrees
 .idea
 .claude

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,43 @@
+title = "Gitleaks config for Parallel Code"
+
+[extend]
+# Use the default Gitleaks ruleset as the base
+useDefault = true
+
+[[rules]]
+id = "parallel-code-mcp-token"
+description = "Parallel Code MCP bearer token"
+regex = '''PARALLEL_CODE_MCP_TOKEN\s*[=:]\s*['"]?[A-Za-z0-9+/_-]{20,}['"]?'''
+tags = ["token", "parallel-code"]
+
+[[rules]]
+id = "bearer-token-in-url"
+description = "Bearer token embedded in a URL query parameter"
+regex = '''[?&]token=[A-Za-z0-9+/\-_]{20,}'''
+tags = ["token", "url"]
+[rules.allowlist]
+# Test fixture URLs and documentation are expected to have placeholder tokens
+regexes = [
+  '''token=<[A-Za-z0-9_-]+>''',   # placeholder like ?token=<your-token>
+  '''token=test''',                 # obvious test value
+  '''token=abc''',                  # obvious test value
+  '''token=tok''',                  # obvious test value
+]
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key"
+regex = '''sk-ant-[A-Za-z0-9\-_]{40,}'''
+tags = ["api-key", "anthropic"]
+
+[allowlist]
+description = "Global allowlist"
+paths = [
+  # Lock files contain package hashes, not secrets
+  '''package-lock\.json''',
+  # Test fixture files with obviously fake values
+  '''\.test\.(ts|tsx)$''',
+  # The gitleaks config itself documents patterns
+  '''\.gitleaks\.toml''',
+]
+commits = []

--- a/.semgrep/electron-security.yml
+++ b/.semgrep/electron-security.yml
@@ -1,0 +1,52 @@
+rules:
+  - id: no-inner-html-without-sanitize
+    pattern: $EL.innerHTML = $VAL
+    pattern-not: $EL.innerHTML = DOMPurify.sanitize(...)
+    message: |
+      Direct innerHTML assignment without DOMPurify.sanitize() risks XSS.
+      Use the sanitizeHtml() helper or DOMPurify.sanitize() explicitly.
+    languages: [typescript]
+    severity: ERROR
+    paths:
+      include:
+        - '**/electron/**'
+
+  - id: no-eval
+    pattern: eval($X)
+    message: |
+      eval() executes arbitrary code. Not allowed in Electron renderer or main process.
+    languages: [typescript]
+    severity: ERROR
+
+  - id: no-new-function
+    pattern: new Function($X)
+    message: |
+      new Function() executes arbitrary code. Not allowed in Electron renderer or main process.
+    languages: [typescript]
+    severity: ERROR
+
+  - id: no-shell-true-in-spawn
+    pattern-either:
+      - pattern: |
+          child_process.spawn($CMD, $ARGS, {shell: true, ...})
+      - pattern: |
+          spawn($CMD, $ARGS, {shell: true, ...})
+    message: |
+      spawn() with shell:true enables shell injection. Use shell:false and
+      pass arguments as an array.
+    languages: [typescript]
+    severity: ERROR
+    paths:
+      include:
+        - '**/electron/**'
+
+  - id: pkill-dash-f-broad-kill
+    pattern: $EXEC("pkill", ["-f", ...], ...)
+    message: |
+      pkill -f matches any process whose full command line contains the pattern,
+      which can accidentally kill unrelated processes. Use kill by PID or docker stop.
+    languages: [typescript]
+    severity: WARNING
+    paths:
+      include:
+        - '**/electron/**'

--- a/.semgrep/filesystem-safety.yml
+++ b/.semgrep/filesystem-safety.yml
@@ -1,0 +1,26 @@
+rules:
+  - id: direct-writefile-in-mcp-coordinator
+    pattern-either:
+      - pattern: writeFileSync($PATH, $DATA, ...)
+      - pattern: fs.writeFileSync($PATH, $DATA, ...)
+    message: |
+      Direct writeFileSync in coordinator code risks torn writes on crash.
+      Use atomicWriteFileSync() from electron/mcp/atomic.ts instead.
+    languages: [typescript]
+    severity: WARNING
+    paths:
+      include:
+        - '**/electron/mcp/**'
+        - '**/electron/ipc/register.ts'
+
+  - id: copyfilesync-side-effect
+    pattern: fs.copyFileSync($SRC, $DST)
+    message: |
+      fs.copyFileSync is a filesystem side effect. In StartMCPServer,
+      ensure all pure computation (mcpConfig, mergedMcpJson) precedes
+      any copyFileSync calls so validation failures don't leave residue.
+    languages: [typescript]
+    severity: INFO
+    paths:
+      include:
+        - '**/electron/ipc/register.ts'

--- a/.semgrep/ipc-auth.yml
+++ b/.semgrep/ipc-auth.yml
@@ -1,0 +1,30 @@
+rules:
+  - id: token-embedded-in-url-template
+    pattern: |
+      `$PREFIX?token=${$TOKEN}$SUFFIX`
+    message: |
+      Token embedded directly in URL template literal. Mobile/shared URLs must use
+      the mobile token, not the coordinator token. The coordinator token must never
+      appear in any URL that reaches the renderer or network.
+    languages: [typescript]
+    severity: ERROR
+    paths:
+      include:
+        - '**/electron/**'
+      exclude:
+        - '**/electron/remote/server.ts'
+
+  - id: console-log-token-variable
+    pattern-either:
+      - pattern: console.log($A, token, $B)
+      - pattern: console.warn($A, token, $B)
+      - pattern: console.log(token)
+      - pattern: console.warn(token)
+    message: |
+      Logging a variable named 'token' directly. Use redactServerUrl() or
+      ensure this is not a bearer token value.
+    languages: [typescript]
+    severity: WARNING
+    paths:
+      include:
+        - '**/electron/**'

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -77,6 +77,7 @@ import {
   assertOptionalString,
   assertOptionalBoolean,
 } from './validate.js';
+import { validateBranchName } from '../mcp/validation.js';
 import { warn as logWarn } from '../log.js';
 
 function errMessage(err: unknown): string {
@@ -101,12 +102,6 @@ function validateRelativePath(p: unknown, label: string): void {
   if (typeof p !== 'string') throw new Error(`${label} must be a string`);
   if (path.isAbsolute(p)) throw new Error(`${label} must not be absolute`);
   if (p.includes('..')) throw new Error(`${label} must not contain ".."`);
-}
-
-/** Reject branch names that could be misinterpreted as git flags. */
-function validateBranchName(name: unknown, label: string): void {
-  if (typeof name !== 'string' || !name) throw new Error(`${label} must be a non-empty string`);
-  if (name.startsWith('-')) throw new Error(`${label} must not start with "-"`);
 }
 
 /** Reject commit hashes that are not valid hex strings. */

--- a/electron/mcp/atomic.test.ts
+++ b/electron/mcp/atomic.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, stat } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { atomicWriteFile, atomicWriteFileSync } from './atomic.js';
+
+let dir: string;
+
+afterEach(async () => {
+  if (dir) await rm(dir, { recursive: true, force: true });
+});
+
+async function makeDir() {
+  dir = await mkdtemp(join(tmpdir(), 'atomic-test-'));
+  return dir;
+}
+
+describe('atomicWriteFile (async)', () => {
+  it('writes content to the target path', async () => {
+    const d = await makeDir();
+    const target = join(d, 'out.json');
+    await atomicWriteFile(target, '{"ok":true}');
+    const content = await readFile(target, 'utf8');
+    expect(content).toBe('{"ok":true}');
+  });
+
+  it('overwrites existing file', async () => {
+    const d = await makeDir();
+    const target = join(d, 'out.json');
+    await atomicWriteFile(target, 'first');
+    await atomicWriteFile(target, 'second');
+    expect(await readFile(target, 'utf8')).toBe('second');
+  });
+
+  it('leaves no temp file on success', async () => {
+    const d = await makeDir();
+    const target = join(d, 'out.json');
+    await atomicWriteFile(target, 'hello');
+    const files = await import('fs/promises').then((m) => m.readdir(d));
+    expect(files).toEqual(['out.json']);
+  });
+
+  it('sets file mode when provided', async () => {
+    const d = await makeDir();
+    const target = join(d, 'secret.json');
+    await atomicWriteFile(target, 'data', { mode: 0o600 });
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it('preserves existing 0600 mode on overwrite when no mode specified', async () => {
+    const d = await makeDir();
+    const target = join(d, 'secret.json');
+    await atomicWriteFile(target, 'original', { mode: 0o600 });
+    await atomicWriteFile(target, 'overwritten'); // no mode option
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o600);
+    expect(await readFile(target, 'utf8')).toBe('overwritten');
+  });
+
+  it('sets exact mode even when umask would narrow it', async () => {
+    const d = await makeDir();
+    const target = join(d, 'wide.json');
+    const prev = process.umask(0o022);
+    try {
+      await atomicWriteFile(target, 'data', { mode: 0o666 });
+    } finally {
+      process.umask(prev);
+    }
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o666);
+  });
+});
+
+describe('atomicWriteFileSync (sync)', () => {
+  it('writes content to the target path', async () => {
+    const d = await makeDir();
+    const target = join(d, 'out.json');
+    atomicWriteFileSync(target, '{"ok":true}');
+    const content = await readFile(target, 'utf8');
+    expect(content).toBe('{"ok":true}');
+  });
+
+  it('overwrites existing file', async () => {
+    const d = await makeDir();
+    const target = join(d, 'out.json');
+    atomicWriteFileSync(target, 'first');
+    atomicWriteFileSync(target, 'second');
+    expect(await readFile(target, 'utf8')).toBe('second');
+  });
+
+  it('sets file mode when provided', async () => {
+    const d = await makeDir();
+    const target = join(d, 'secret.json');
+    atomicWriteFileSync(target, 'data', { mode: 0o600 });
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it('preserves existing 0600 mode on overwrite when no mode specified', async () => {
+    const d = await makeDir();
+    const target = join(d, 'secret.json');
+    atomicWriteFileSync(target, 'original', { mode: 0o600 });
+    atomicWriteFileSync(target, 'overwritten'); // no mode option
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o600);
+    expect(await readFile(target, 'utf8')).toBe('overwritten');
+  });
+
+  it('sets exact mode even when umask would narrow it', async () => {
+    const d = await makeDir();
+    const target = join(d, 'wide.json');
+    const prev = process.umask(0o022);
+    try {
+      atomicWriteFileSync(target, 'data', { mode: 0o666 });
+    } finally {
+      process.umask(prev);
+    }
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o666);
+  });
+});

--- a/electron/mcp/atomic.ts
+++ b/electron/mcp/atomic.ts
@@ -1,0 +1,143 @@
+import {
+  openSync,
+  writeFileSync,
+  fsyncSync,
+  closeSync,
+  fchmodSync,
+  renameSync,
+  unlinkSync,
+  statSync,
+} from 'fs';
+import { open, rename, unlink, stat } from 'fs/promises';
+import { join, dirname } from 'path';
+import { randomUUID } from 'crypto';
+
+function resolveMode(filePath: string, requested: number | undefined): number | undefined {
+  if (requested !== undefined) return requested;
+  try {
+    return statSync(filePath).mode & 0o777;
+  } catch {
+    return undefined; // file doesn't exist yet — let the umask apply
+  }
+}
+
+async function resolveModeAsync(
+  filePath: string,
+  requested: number | undefined,
+): Promise<number | undefined> {
+  if (requested !== undefined) return requested;
+  try {
+    return (await stat(filePath)).mode & 0o777;
+  } catch {
+    return undefined;
+  }
+}
+
+function dirFsyncSync(filePath: string): void {
+  let fd = -1;
+  try {
+    fd = openSync(dirname(filePath), 'r');
+    fsyncSync(fd);
+  } catch {
+    // Directory fsync unsupported on some platforms (e.g. Windows, some network mounts).
+  } finally {
+    if (fd !== -1) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+async function dirFsync(filePath: string): Promise<void> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(dirname(filePath), 'r');
+    await fh.sync();
+  } catch {
+    // Directory fsync unsupported on some platforms (e.g. Windows, some network mounts).
+  } finally {
+    try {
+      await fh?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Write `data` to `filePath` atomically: write to a temp file then rename.
+ *  A crash between write and rename leaves a stale .tmp file but never a torn target.
+ *  Preserves the existing file's mode when no mode is specified.
+ *  Uses fchmod after open to set the exact mode, bypassing the process umask. */
+export function atomicWriteFileSync(
+  filePath: string,
+  data: string,
+  options?: { mode?: number },
+): void {
+  const mode = resolveMode(filePath, options?.mode);
+  const tmp = join(dirname(filePath), `.parallel-code-atomic-${randomUUID()}.tmp`);
+  let fd = -1;
+  try {
+    fd = openSync(tmp, 'w', mode); // pre-set mode; still subject to umask
+    if (mode !== undefined) fchmodSync(fd, mode); // correct umask to get exact bits
+    writeFileSync(fd, data); // loops internally — no short-write risk
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = -1;
+    renameSync(tmp, filePath);
+    dirFsyncSync(filePath);
+  } catch (err) {
+    if (fd !== -1) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
+}
+
+/** Async version: write `data` to `filePath` atomically via temp file + rename.
+ *  Preserves the existing file's mode when no mode is specified.
+ *  Uses FileHandle.chmod after open to set the exact mode, bypassing the process umask. */
+export async function atomicWriteFile(
+  filePath: string,
+  data: string,
+  options?: { mode?: number },
+): Promise<void> {
+  const mode = await resolveModeAsync(filePath, options?.mode);
+  const tmp = join(dirname(filePath), `.parallel-code-atomic-${randomUUID()}.tmp`);
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(tmp, 'w', mode); // pre-set mode; still subject to umask
+    if (mode !== undefined) await fh.chmod(mode); // correct umask to get exact bits
+    await fh.writeFile(data);
+    await fh.sync();
+    await fh.close();
+    fh = undefined;
+    await rename(tmp, filePath);
+    await dirFsync(filePath);
+  } catch (err) {
+    if (fh) {
+      try {
+        await fh.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
+}

--- a/electron/mcp/validation.test.ts
+++ b/electron/mcp/validation.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { validateBranchName, validateUUID } from './validation.js';
+
+describe('validateBranchName', () => {
+  it('accepts a valid branch name', () => {
+    expect(validateBranchName('feature/my-branch')).toBe('feature/my-branch');
+  });
+
+  it('accepts names with numbers and hyphens', () => {
+    expect(validateBranchName('fix/issue-123')).toBe('fix/issue-123');
+  });
+
+  it('rejects non-string', () => {
+    expect(() => validateBranchName(42)).toThrow('must be a string');
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateBranchName('')).toThrow('non-empty');
+  });
+
+  it('accepts a normal branch name like main', () => {
+    expect(validateBranchName('main')).toBe('main');
+  });
+
+  it('rejects HEAD', () => {
+    expect(() => validateBranchName('HEAD')).toThrow('HEAD');
+  });
+
+  it('accepts FETCH_HEAD and other git pseudorefs (git allows them as branch names)', () => {
+    expect(validateBranchName('FETCH_HEAD')).toBe('FETCH_HEAD');
+    expect(validateBranchName('ORIG_HEAD')).toBe('ORIG_HEAD');
+  });
+
+  it('rejects leading hyphen', () => {
+    expect(() => validateBranchName('-bad')).toThrow();
+  });
+
+  it('rejects leading dot', () => {
+    expect(() => validateBranchName('.hidden')).toThrow();
+  });
+
+  it('rejects leading slash', () => {
+    expect(() => validateBranchName('/bad')).toThrow();
+  });
+
+  it('rejects trailing slash', () => {
+    expect(() => validateBranchName('bad/')).toThrow();
+  });
+
+  it('rejects trailing dot', () => {
+    expect(() => validateBranchName('bad.')).toThrow();
+  });
+
+  it('rejects .lock suffix on full name', () => {
+    expect(() => validateBranchName('foo.lock')).toThrow();
+  });
+
+  it('rejects .lock on a path component (not just the final segment)', () => {
+    expect(() => validateBranchName('foo.lock/bar')).toThrow();
+  });
+
+  it('rejects double dot in middle', () => {
+    expect(() => validateBranchName('foo..bar')).toThrow();
+  });
+
+  it('rejects double slash', () => {
+    expect(() => validateBranchName('foo//bar')).toThrow();
+  });
+
+  it('rejects @{ sequence', () => {
+    expect(() => validateBranchName('foo@{bar}')).toThrow();
+  });
+
+  it('rejects path component starting with dot', () => {
+    expect(() => validateBranchName('feature/.hidden')).toThrow();
+  });
+
+  it('rejects colon', () => {
+    expect(() => validateBranchName('foo:bar')).toThrow();
+  });
+
+  it('rejects caret', () => {
+    expect(() => validateBranchName('foo^bar')).toThrow();
+  });
+
+  it('rejects tilde', () => {
+    expect(() => validateBranchName('foo~bar')).toThrow();
+  });
+
+  it('rejects shell metacharacters', () => {
+    for (const ch of [
+      '`',
+      '$',
+      '(',
+      ')',
+      '{',
+      '}',
+      '<',
+      '>',
+      '\\',
+      "'",
+      '*',
+      '?',
+      '!',
+      '#',
+      ';',
+      '|',
+      '&',
+      '"',
+    ]) {
+      expect(() => validateBranchName(`foo${ch}bar`)).toThrow();
+    }
+  });
+
+  it('uses custom field name in error', () => {
+    expect(() => validateBranchName(42, 'myField')).toThrow('myField');
+  });
+});
+
+describe('validateUUID', () => {
+  it('accepts a valid v4 UUID', () => {
+    const id = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    expect(validateUUID(id, 'id')).toBe(id);
+  });
+
+  it('accepts uppercase v4 UUID', () => {
+    expect(validateUUID('F47AC10B-58CC-4372-A567-0E02B2C3D479', 'id')).toBe(
+      'F47AC10B-58CC-4372-A567-0E02B2C3D479',
+    );
+  });
+
+  it('rejects non-string', () => {
+    expect(() => validateUUID(123, 'id')).toThrow('must be a string');
+  });
+
+  it('rejects non-v4 version nibble', () => {
+    // version nibble = 1 (v1 UUID)
+    expect(() => validateUUID('f47ac10b-58cc-1372-a567-0e02b2c3d479', 'id')).toThrow();
+  });
+
+  it('rejects invalid variant nibble', () => {
+    // variant nibble = 4 (not 8/9/a/b)
+    expect(() => validateUUID('f47ac10b-58cc-4372-4567-0e02b2c3d479', 'id')).toThrow();
+  });
+
+  it('rejects malformed UUID', () => {
+    expect(() => validateUUID('not-a-uuid', 'id')).toThrow();
+  });
+
+  it('rejects UUID with path traversal attempt', () => {
+    expect(() => validateUUID('../../tmp/x-0000-4000-8000-000000000000', 'id')).toThrow();
+  });
+
+  it('uses custom field name in error', () => {
+    expect(() => validateUUID('bad', 'myField')).toThrow('myField');
+  });
+});

--- a/electron/mcp/validation.ts
+++ b/electron/mcp/validation.ts
@@ -1,7 +1,7 @@
 // Shared branch-name validator used by MCP, REST, and IPC paths.
 // Conservative subset of git check-ref-format rules — no process spawn.
 
-export function validateBranchName(value: unknown, field = 'baseBranch'): string {
+export function validateBranchName(value: unknown, field = 'branch'): string {
   if (typeof value !== 'string') throw new Error(`${field} must be a string`);
   if (!value.trim()) throw new Error(`${field} must be a non-empty string`);
   // git check-ref-format --branch rejects HEAD specifically; FETCH_HEAD etc. are accepted.

--- a/electron/mcp/validation.ts
+++ b/electron/mcp/validation.ts
@@ -1,0 +1,38 @@
+// Shared branch-name validator used by MCP, REST, and IPC paths.
+// Conservative subset of git check-ref-format rules — no process spawn.
+
+export function validateBranchName(value: unknown, field = 'baseBranch'): string {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  if (!value.trim()) throw new Error(`${field} must be a non-empty string`);
+  // git check-ref-format --branch rejects HEAD specifically; FETCH_HEAD etc. are accepted.
+  if (value === 'HEAD') throw new Error(`${field} must not be "HEAD"`);
+  if (value.startsWith('-')) throw new Error(`${field} must not start with "-"`);
+  if (value.startsWith('.')) throw new Error(`${field} must not start with "."`);
+  if (value.startsWith('/')) throw new Error(`${field} must not start with "/"`);
+  if (value.endsWith('/')) throw new Error(`${field} must not end with "/"`);
+  if (value.endsWith('.')) throw new Error(`${field} must not end with "."`);
+  // Git rejects any path component ending in .lock, not just the full name.
+  if (/(?:^|\/)[^/]+\.lock(?:\/|$)/.test(value))
+    throw new Error(`${field} must not contain a ".lock" path component`);
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f ]/.test(value)) throw new Error(`${field} contains invalid characters`);
+  // Reject git check-ref-format illegal characters.
+  if (/[`$(){}[\]<>\\'*?!#;|&":^~]/.test(value))
+    throw new Error(`${field} contains invalid characters`);
+  // Reject sequences illegal per git check-ref-format.
+  if (value.includes('..')) throw new Error(`${field} must not contain ".."`);
+  if (value.includes('@{')) throw new Error(`${field} must not contain "@{"`);
+  if (value.includes('//')) throw new Error(`${field} must not contain "//"`);
+  // Reject path components starting with "." (e.g. feature/.hidden).
+  if (/(?:^|\/)\./.test(value))
+    throw new Error(`${field} must not contain a component starting with "."`);
+  return value;
+}
+
+/** Validate that a value is a v4 UUID. Throws if invalid. */
+export function validateUUID(value: unknown, field: string): string {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value))
+    throw new Error(`${field} must be a valid UUID`);
+  return value;
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,34 @@
+import type { KnipConfig } from 'knip';
+
+const config: KnipConfig = {
+  entry: [
+    'electron/main.ts',
+    'electron/preload.cjs',
+    'electron/mcp/server.ts', // added in coordinator-2-mcp-backend; listed here so knip tracks it from the start
+    'src/main.tsx',
+    'src/remote/main.tsx',
+  ],
+  project: ['electron/**/*.ts', 'src/**/*.{ts,tsx}'],
+  ignore: [
+    'dist/**',
+    'dist-electron/**',
+    'dist-remote/**',
+    'release/**',
+    'scripts/**',
+    // Vite/Electron configs are entry points picked up by their respective tools
+    'electron/vite.config.electron.ts',
+    'electron/vite.config.electron.test.ts',
+    'electron/shims/**',
+  ],
+  ignoreDependencies: [
+    // Peer dependencies and indirect runtime deps
+    'electron',
+    'electron-builder',
+    'concurrently',
+    'wait-on',
+  ],
+  // Test files are allowed to have unused exports (test helpers, fixtures)
+  ignoreExportsUsedInFile: true,
+};
+
+export default config;


### PR DESCRIPTION
## Overview

Standalone security utilities and static analysis tooling — no coordinator logic, no UI. This is PR 1 of 4 splitting #100 as requested in the round-4 review.

**PR sequence:**
| PR | Branch | Contents |
|----|--------|----------|
| **1 (this PR)** | `coordinator-1-security` | Atomic writes, input validators, static analysis configs |
| 2 | `coordinator-2-mcp-backend` | MCP coordinator engine + REST API hardening |
| 3 | `coordinator-3-store-ipc` | Frontend store wiring + IPC handlers |
| 4 | `coordinator-4-ui` | UI components + coordinator entry points |

PRs 2–4 are stacked on each other; nothing coordinator-related is user-visible until PR 4 adds the `NewTaskDialog` checkbox and Settings toggle.

---

## What's in this PR

### `electron/mcp/atomic.ts`
Crash-safe file writes via temp file + rename:
- Temp file written to same directory as target (avoids EXDEV across filesystem boundaries)
- `fsync` before rename for file durability; directory `fsync` after rename for directory-entry durability (platform-safe catch for Windows/network mounts)
- Sync variant for use in catch blocks; async variant for normal paths

### `electron/mcp/validation.ts`
- `validateBranchName()` — mirrors `git check-ref-format --branch`: rejects shell metacharacters (`:`, `^`, `~`, etc.), double dots, path components starting with `.`, any path component ending in `.lock`, and other git-illegal patterns
- `validateUUID()` — enforces v4 UUID (version nibble=4, variant nibble∈{8,9,a,b})

### Static analysis configs
- `.semgrep/` — rules for unsafe Electron APIs, IPC auth, and unsafe `fs` operations (scoped to `electron/mcp/**` + `electron/ipc/register.ts`)
- `.gitleaks.toml` — token/secret leak detection
- `.dependency-cruiser.cjs` — architecture linting
- `knip.config.ts` — dead code detection

*Note: the static analysis tools (`semgrep`, `gitleaks`, `dependency-cruiser`, `knip`) are not yet wired into CI — they require system/devDependency setup that lands in PR 2. Configs are included here as they're used to validate the coordinator code in PR 2.*

### Tests (35 cases)
- `electron/mcp/validation.test.ts` — accepted names, all rejection cases, UUID v4 enforcement
- `electron/mcp/atomic.test.ts` — write, overwrite, mode, no temp-file residue

---

## Test plan
- [ ] `npm run typecheck && npm test && npm run lint` — all pass
- [ ] `electron/mcp/validation.test.ts` and `electron/mcp/atomic.test.ts` — 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)