### PR TITLE
fix(panels): make notes-files a weighted absorber so height tracks task panel

### DIFF
--- a/src/components/ResizablePanel.tsx
+++ b/src/components/ResizablePanel.tsx
@@ -20,6 +20,10 @@ export interface PanelChild {
    *  smaller than their pinned size would be (e.g., a toolbar that collapses
    *  when its body is empty), so a stale pin can't leave a visible gap. */
   noPin?: () => boolean;
+  /** Flex-grow weight for absorbers. Defaults to 1 (equal share). Use a
+   *  smaller value to give an absorber less space than others, e.g. 0.5
+   *  for notes-files so the AI terminal gets roughly 2/3 of remaining space. */
+  flexGrow?: number;
 }
 
 interface ResizablePanelProps {
@@ -40,8 +44,8 @@ interface ResizablePanelProps {
 export function ResizablePanel(props: ResizablePanelProps) {
   const [draggingIdx, setDraggingIdx] = createSignal<number | null>(null);
   const [dragOverride, setDragOverride] = createSignal<Record<number, number>>({});
-  /** Stable per-index refs so drag measurement doesn't rely on DOM index math. */
-  const wrapperRefs: HTMLDivElement[] = [];
+  /** Stable per-ID refs so drag measurement survives dynamic children changes. */
+  const wrapperRefs = new Map<string, HTMLDivElement>();
 
   const isHorizontal = () => props.direction === 'horizontal';
 
@@ -89,6 +93,17 @@ export function ResizablePanel(props: ResizablePanelProps) {
     const min = child.minSize ?? 0;
 
     if (pinned !== undefined) {
+      // Drag override uses pixel-precise flex for live visual feedback.
+      // Persisted pins on absorbers use flex-grow ratio so they scale when the
+      // container resizes (e.g. notes/changed-files in a horizontal split that
+      // should stay proportional with the window).
+      if (isAbsorber(child.id) && dragOverride()[idx] === undefined) {
+        return {
+          flex: `${pinned} 1 0`,
+          [minDim]: `${min}px`,
+          overflow: 'hidden',
+        };
+      }
       return {
         flex: `0 0 ${pinned}px`,
         [dim]: `${pinned}px`,
@@ -97,8 +112,9 @@ export function ResizablePanel(props: ResizablePanelProps) {
       };
     }
     if (isAbsorber(child.id)) {
+      const fg = child.flexGrow ?? 1;
       return {
-        flex: '1 1 0',
+        flex: `${fg} 1 0`,
         [minDim]: `${min}px`,
         overflow: 'hidden',
       };
@@ -119,8 +135,8 @@ export function ResizablePanel(props: ResizablePanelProps) {
     };
   }
 
-  function measureWrapper(idx: number): number {
-    const el = wrapperRefs[idx];
+  function measureWrapper(childId: string): number {
+    const el = wrapperRefs.get(childId);
     if (!el) return 0;
     return isHorizontal() ? el.getBoundingClientRect().width : el.getBoundingClientRect().height;
   }
@@ -138,8 +154,8 @@ export function ResizablePanel(props: ResizablePanelProps) {
 
     setDraggingIdx(handleIdx);
     const startPos = isHorizontal() ? e.clientX : e.clientY;
-    const startLeft = measureWrapper(handleIdx);
-    const startRight = measureWrapper(handleIdx + 1);
+    const startLeft = measureWrapper(leftChild.id);
+    const startRight = measureWrapper(rightChild.id);
     const leftMin = leftChild.minSize ?? 0;
     const rightMin = rightChild.minSize ?? 0;
     let latestLeft = startLeft;
@@ -156,11 +172,10 @@ export function ResizablePanel(props: ResizablePanelProps) {
     let absorberMin = 0;
     let absorberPresent = false;
     if (leftNoPin || rightNoPin) {
-      for (let i = 0; i < props.children.length; i++) {
-        if (i === handleIdx || i === handleIdx + 1) continue;
-        const c = props.children[i];
+      for (const c of props.children) {
+        if (c.id === leftChild.id || c.id === rightChild.id) continue;
         if (isAbsorber(c.id)) {
-          absorberStart = measureWrapper(i);
+          absorberStart = measureWrapper(c.id);
           absorberMin = c.minSize ?? 0;
           absorberPresent = true;
           break;
@@ -264,7 +279,7 @@ export function ResizablePanel(props: ResizablePanelProps) {
             <div
               class="rp-cell"
               ref={(el) => {
-                wrapperRefs[i()] = el;
+                wrapperRefs.set(child.id, el);
               }}
               style={childStyle(child, i())}
             >

--- a/src/components/TaskChangedFilesSection.tsx
+++ b/src/components/TaskChangedFilesSection.tsx
@@ -56,7 +56,7 @@ export function TaskChangedFilesSection(props: TaskChangedFilesSectionProps) {
         height: '100%',
         'min-height': '140px',
         'max-height': '40vh',
-        'min-width': '200px',
+        'min-width': '220px',
         background: theme.taskPanelBg,
         display: 'flex',
         'flex-direction': 'column',

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -336,7 +336,7 @@ export function TaskPanel(props: TaskPanelProps) {
 
   const changedFilesChild: PanelChild = {
     id: 'changed-files',
-    minSize: 100,
+    minSize: 220,
     maxAutoSize: CHANGED_FILES_PANEL_AUTO_MAX_PX,
     content: () => changedFilesEl,
   };
@@ -344,9 +344,14 @@ export function TaskPanel(props: TaskPanelProps) {
   // Stack-mode row containing notes (absorbs horizontally) and changed files.
   // The inline 200 px floor prevents the nested horizontal panel from collapsing
   // when the outer flex-first tree asks for content-size.
+  // notes-files is an absorber (flexGrow: 0.5) in the stack-mode vertical panel
+  // so its height tracks the task panel instead of being content-driven —
+  // prevents height instability when the inner notes↔changed-files divider is
+  // moved, while keeping the AI terminal ~2× notes-files.
   const notesAndFilesChild: PanelChild = {
     id: 'notes-files',
-    minSize: 60,
+    minSize: 100,
+    flexGrow: 0.5,
     content: () => (
       <div style={{ height: '100%', 'min-height': '200px' }}>
         {isNoneGit() ? (
@@ -417,7 +422,7 @@ export function TaskPanel(props: TaskPanelProps) {
             <ResizablePanel
               direction="vertical"
               persistKey={`task:${props.task.id}`}
-              absorberIds={['ai-terminal']}
+              absorberIds={['notes-files', 'ai-terminal']}
               children={[
                 notesAndFilesChild,
                 shellSectionChild,

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -18,6 +18,7 @@ import {
   taskNeedsAttention,
   getPanelUserSize,
   setPanelUserSize,
+  deletePanelUserSize,
 } from '../store/store';
 import { closeTask } from '../store/tasks';
 import { TaskPanel } from './TaskPanel';
@@ -587,6 +588,13 @@ export function TilingLayout() {
                 });
                 const showHandle = () =>
                   !store.focusMode && !child.fixed && i() < panelChildren().length - 1;
+                function unpinHandle() {
+                  const panels = panelChildren();
+                  const left = panels[i()];
+                  const right = panels[i() + 1];
+                  if (!left || !right) return;
+                  deletePanelUserSize([`tiling:${left.id}`, `tiling:${right.id}`]);
+                }
                 return (
                   <>
                     <div style={wrapperStyle()}>{child.content()}</div>
@@ -594,6 +602,7 @@ export function TilingLayout() {
                       <div
                         class={`resize-handle resize-handle-h ${dragging() === i() ? 'dragging' : ''}`}
                         onMouseDown={(e) => handleDragStart(i(), e)}
+                        onDblClick={unpinHandle}
                       />
                     </Show>
                   </>


### PR DESCRIPTION
## Summary
- Make notes-files a weighted absorber (flexGrow: 0.5) in stack-mode so its height tracks the task panel instead of being content-driven
- Pinned absorbers now use flex-grow ratio (flex: N 1 0) so persisted splits scale when container resizes
- Raise changed-files minSize to 220px to prevent CommitNavBar button overflow
- Add double-click unpin for tiling layout handles
- Switch wrapperRefs from array to Map for stable child indexing