### PR TITLE
fix(panels): proportional absorber pins, stale-pin cleanup, double-click to reset

### DIFF
--- a/src/components/ResizablePanel.tsx
+++ b/src/components/ResizablePanel.tsx
@@ -20,6 +20,10 @@ export interface PanelChild {
    *  smaller than their pinned size would be (e.g., a toolbar that collapses
    *  when its body is empty), so a stale pin can't leave a visible gap. */
   noPin?: () => boolean;
+  /** Flex-grow weight for absorbers. Defaults to 1 (equal share). Use a
+   *  smaller value to give an absorber less space than others, e.g. 0.5
+   *  for notes-files so the AI terminal gets roughly 2/3 of remaining space. */
+  flexGrow?: number;
 }
 
 interface ResizablePanelProps {
@@ -40,8 +44,8 @@ interface ResizablePanelProps {
 export function ResizablePanel(props: ResizablePanelProps) {
   const [draggingIdx, setDraggingIdx] = createSignal<number | null>(null);
   const [dragOverride, setDragOverride] = createSignal<Record<number, number>>({});
-  /** Stable per-index refs so drag measurement doesn't rely on DOM index math. */
-  const wrapperRefs: HTMLDivElement[] = [];
+  /** Stable per-ID refs so drag measurement survives dynamic children changes. */
+  const wrapperRefs = new Map<string, HTMLDivElement>();
 
   const isHorizontal = () => props.direction === 'horizontal';
 
@@ -61,14 +65,34 @@ export function ResizablePanel(props: ResizablePanelProps) {
    *  absorbers, or a child that just turned noPin (e.g., last terminal closed
    *  with a pin still in the store) can leave stale entries behind. Detect
    *  and delete so the store self-heals instead of silently diverging from
-   *  what the user sees. */
+   *  what the user sees.
+   *
+   *  Multi-absorber panels store pin values as flex-grow ratios (both sides
+   *  pinned after a drag). If only ONE absorber carries a pin while the others
+   *  are unpinned, it's a stale pixel value from before the child was promoted
+   *  to absorber status — treat it as stale to prevent a 300:1 ratio that
+   *  would starve every other absorber. */
   createEffect(() => {
     const absorbers = absorberSet();
     const stale: string[] = [];
+
+    // For multi-absorber panels, count how many absorbers are currently pinned.
+    // If exactly one is pinned it's asymmetric (stale pixel value), so clear it.
+    let pinnedAbsorberCount = 0;
+    if (absorbers.size > 1) {
+      for (const child of props.children) {
+        if (!absorbers.has(child.id)) continue;
+        const key = keyFor(child.id);
+        if (key && getPanelUserSize(key) !== undefined) pinnedAbsorberCount++;
+      }
+    }
+    const asymmetricAbsorberPin = absorbers.size > 1 && pinnedAbsorberCount === 1;
+
     for (const child of props.children) {
       const isSoleAbsorber = absorbers.size === 1 && absorbers.has(child.id);
       const noPin = child.noPin?.() === true;
-      if (!isSoleAbsorber && !noPin) continue;
+      const isStaleAsymmetric = asymmetricAbsorberPin && absorbers.has(child.id);
+      if (!isSoleAbsorber && !noPin && !isStaleAsymmetric) continue;
       const key = keyFor(child.id);
       if (key && getPanelUserSize(key) !== undefined) stale.push(key);
     }
@@ -89,6 +113,17 @@ export function ResizablePanel(props: ResizablePanelProps) {
     const min = child.minSize ?? 0;
 
     if (pinned !== undefined) {
+      // Drag override uses pixel-precise flex for live visual feedback.
+      // Persisted pins on absorbers use flex-grow ratio so they scale when the
+      // container resizes (e.g. notes/changed-files in a horizontal split that
+      // should stay proportional with the window).
+      if (isAbsorber(child.id) && dragOverride()[idx] === undefined) {
+        return {
+          flex: `${pinned} 1 0`,
+          [minDim]: `${min}px`,
+          overflow: 'hidden',
+        };
+      }
       return {
         flex: `0 0 ${pinned}px`,
         [dim]: `${pinned}px`,
@@ -97,8 +132,9 @@ export function ResizablePanel(props: ResizablePanelProps) {
       };
     }
     if (isAbsorber(child.id)) {
+      const fg = child.flexGrow ?? 1;
       return {
-        flex: '1 1 0',
+        flex: `${fg} 1 0`,
         [minDim]: `${min}px`,
         overflow: 'hidden',
       };
@@ -119,8 +155,8 @@ export function ResizablePanel(props: ResizablePanelProps) {
     };
   }
 
-  function measureWrapper(idx: number): number {
-    const el = wrapperRefs[idx];
+  function measureWrapper(childId: string): number {
+    const el = wrapperRefs.get(childId);
     if (!el) return 0;
     return isHorizontal() ? el.getBoundingClientRect().width : el.getBoundingClientRect().height;
   }
@@ -138,8 +174,8 @@ export function ResizablePanel(props: ResizablePanelProps) {
 
     setDraggingIdx(handleIdx);
     const startPos = isHorizontal() ? e.clientX : e.clientY;
-    const startLeft = measureWrapper(handleIdx);
-    const startRight = measureWrapper(handleIdx + 1);
+    const startLeft = measureWrapper(leftChild.id);
+    const startRight = measureWrapper(rightChild.id);
     const leftMin = leftChild.minSize ?? 0;
     const rightMin = rightChild.minSize ?? 0;
     let latestLeft = startLeft;
@@ -156,11 +192,10 @@ export function ResizablePanel(props: ResizablePanelProps) {
     let absorberMin = 0;
     let absorberPresent = false;
     if (leftNoPin || rightNoPin) {
-      for (let i = 0; i < props.children.length; i++) {
-        if (i === handleIdx || i === handleIdx + 1) continue;
-        const c = props.children[i];
+      for (const c of props.children) {
+        if (c.id === leftChild.id || c.id === rightChild.id) continue;
         if (isAbsorber(c.id)) {
-          absorberStart = measureWrapper(i);
+          absorberStart = measureWrapper(c.id);
           absorberMin = c.minSize ?? 0;
           absorberPresent = true;
           break;
@@ -264,7 +299,7 @@ export function ResizablePanel(props: ResizablePanelProps) {
             <div
               class="rp-cell"
               ref={(el) => {
-                wrapperRefs[i()] = el;
+                wrapperRefs.set(child.id, el);
               }}
               style={childStyle(child, i())}
             >

--- a/src/components/ResizablePanel.tsx
+++ b/src/components/ResizablePanel.tsx
@@ -1,4 +1,4 @@
-import { batch, createEffect, createMemo, createSignal, For, type JSX } from 'solid-js';
+import { batch, createEffect, createMemo, createSignal, For, onCleanup, type JSX } from 'solid-js';
 import { getPanelUserSize, setPanelUserSize, deletePanelUserSize } from '../store/store';
 
 export interface PanelChild {
@@ -20,10 +20,10 @@ export interface PanelChild {
    *  smaller than their pinned size would be (e.g., a toolbar that collapses
    *  when its body is empty), so a stale pin can't leave a visible gap. */
   noPin?: () => boolean;
-  /** Flex-grow weight for absorbers. Defaults to 1 (equal share). Use a
-   *  smaller value to give an absorber less space than others, e.g. 0.5
-   *  for notes-files so the AI terminal gets roughly 2/3 of remaining space. */
-  flexGrow?: number;
+  /** Relative flex-grow weight among absorbers. Defaults to 1 (equal share).
+   *  Ignored on non-absorbers. Use a smaller value to give an absorber less
+   *  space than its siblings, e.g. 0.5 so the AI terminal gets ~2/3. */
+  absorberWeight?: number;
 }
 
 interface ResizablePanelProps {
@@ -43,7 +43,7 @@ interface ResizablePanelProps {
 
 export function ResizablePanel(props: ResizablePanelProps) {
   const [draggingIdx, setDraggingIdx] = createSignal<number | null>(null);
-  const [dragOverride, setDragOverride] = createSignal<Record<number, number>>({});
+  const [dragOverride, setDragOverride] = createSignal<Record<string, number>>({});
   /** Stable per-ID refs so drag measurement survives dynamic children changes. */
   const wrapperRefs = new Map<string, HTMLDivElement>();
 
@@ -99,14 +99,15 @@ export function ResizablePanel(props: ResizablePanelProps) {
     if (stale.length > 0) deletePanelUserSize(stale);
   });
 
-  function childStyle(child: PanelChild, idx: number): JSX.CSSProperties {
+  function childStyle(child: PanelChild): JSX.CSSProperties {
     const noPin = child.noPin?.() === true;
     // noPin children can't be sized by drag override or persisted pin — they
     // stay content-sized so an empty inner state can't leave a visible gap.
     const key = keyFor(child.id);
-    const pinned = noPin
+    const raw = noPin
       ? undefined
-      : (dragOverride()[idx] ?? (key ? getPanelUserSize(key) : undefined));
+      : (dragOverride()[child.id] ?? (key ? getPanelUserSize(key) : undefined));
+    const pinned = raw !== undefined && Number.isFinite(raw) && raw > 0 ? raw : undefined;
     const dim = isHorizontal() ? 'width' : 'height';
     const minDim = isHorizontal() ? 'min-width' : 'min-height';
     const maxDim = isHorizontal() ? 'max-width' : 'max-height';
@@ -117,7 +118,7 @@ export function ResizablePanel(props: ResizablePanelProps) {
       // Persisted pins on absorbers use flex-grow ratio so they scale when the
       // container resizes (e.g. notes/changed-files in a horizontal split that
       // should stay proportional with the window).
-      if (isAbsorber(child.id) && dragOverride()[idx] === undefined) {
+      if (isAbsorber(child.id) && dragOverride()[child.id] === undefined) {
         return {
           flex: `${pinned} 1 0`,
           [minDim]: `${min}px`,
@@ -132,7 +133,7 @@ export function ResizablePanel(props: ResizablePanelProps) {
       };
     }
     if (isAbsorber(child.id)) {
-      const fg = child.flexGrow ?? 1;
+      const fg = child.absorberWeight ?? 1;
       return {
         flex: `${fg} 1 0`,
         [minDim]: `${min}px`,
@@ -222,12 +223,12 @@ export function ResizablePanel(props: ResizablePanelProps) {
       // Skip the override on noPin children so they stay content-sized; also
       // skip on a sole absorber adjacent to a noPin sibling, since pinning the
       // absorber temporarily would steal the space the noPin child can't take.
-      const override: Record<number, number> = {};
+      const override: Record<string, number> = {};
       if (!leftNoPin && !(leftIsAbs && rightNoPin && soleAbs)) {
-        override[handleIdx] = latestLeft;
+        override[leftChild.id] = latestLeft;
       }
       if (!rightNoPin && !(rightIsAbs && leftNoPin && soleAbs)) {
-        override[handleIdx + 1] = latestRight;
+        override[rightChild.id] = latestRight;
       }
       setDragOverride(override);
     };
@@ -300,8 +301,9 @@ export function ResizablePanel(props: ResizablePanelProps) {
               class="rp-cell"
               ref={(el) => {
                 wrapperRefs.set(child.id, el);
+                onCleanup(() => wrapperRefs.delete(child.id));
               }}
-              style={childStyle(child, i())}
+              style={childStyle(child)}
             >
               {child.content()}
             </div>

--- a/src/components/TaskNotesBody.tsx
+++ b/src/components/TaskNotesBody.tsx
@@ -72,13 +72,9 @@ export function TaskNotesBody(props: TaskNotesBodyProps) {
     });
   });
 
-  // Intrinsic height the flex-first panel tree uses when the notes panel
-  // isn't pinned. Focus mode defaults to a roomy 240 px so a user who just
-  // entered focus mode sees meaningful space for notes without dragging.
-  // `max-height: 40vh` (set inline below) caps growth when the plan tab
-  // renders long markdown — otherwise its intrinsic height bubbles up the
-  // flex chain and pushes the AI-terminal absorber out of view. Same pattern
-  // as TaskChangedFilesSection and TaskStepsSection.
+  // notes-files is a weighted absorber in the outer vertical panel, so its
+  // height is layout-driven (flex ratio), not content-driven. min-height is
+  // the floor used when the panel is fresh or unpinned.
   const intrinsicHeight = () => (store.focusMode ? '240px' : '140px');
 
   return (
@@ -89,7 +85,6 @@ export function TaskNotesBody(props: TaskNotesBodyProps) {
         width: '100%',
         height: '100%',
         'min-height': intrinsicHeight(),
-        'max-height': '40vh',
         display: 'flex',
         'flex-direction': 'column',
       }}

--- a/src/components/TaskNotesBody.tsx
+++ b/src/components/TaskNotesBody.tsx
@@ -72,9 +72,6 @@ export function TaskNotesBody(props: TaskNotesBodyProps) {
     });
   });
 
-  // notes-files is a weighted absorber in the outer vertical panel, so its
-  // height is layout-driven (flex ratio), not content-driven. min-height is
-  // the floor used when the panel is fresh or unpinned.
   const intrinsicHeight = () => (store.focusMode ? '240px' : '140px');
 
   return (

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -347,6 +347,7 @@ export function TaskPanel(props: TaskPanelProps) {
   const notesAndFilesChild: PanelChild = {
     id: 'notes-files',
     minSize: 60,
+    absorberWeight: 0.5,
     content: () => (
       <div style={{ height: '100%', 'min-height': '200px' }}>
         {isNoneGit() ? (
@@ -417,7 +418,7 @@ export function TaskPanel(props: TaskPanelProps) {
             <ResizablePanel
               direction="vertical"
               persistKey={`task:${props.task.id}`}
-              absorberIds={['ai-terminal']}
+              absorberIds={['notes-files', 'ai-terminal']}
               children={[
                 notesAndFilesChild,
                 shellSectionChild,

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -18,6 +18,7 @@ import {
   taskNeedsAttention,
   getPanelUserSize,
   setPanelUserSize,
+  deletePanelUserSize,
 } from '../store/store';
 import { closeTask } from '../store/tasks';
 import { TaskPanel } from './TaskPanel';
@@ -587,6 +588,13 @@ export function TilingLayout() {
                 });
                 const showHandle = () =>
                   !store.focusMode && !child.fixed && i() < panelChildren().length - 1;
+                function unpinHandle() {
+                  const panels = panelChildren();
+                  const left = panels[i()];
+                  const right = panels[i() + 1];
+                  if (!left || !right) return;
+                  deletePanelUserSize([`tiling:${left.id}`, `tiling:${right.id}`]);
+                }
                 return (
                   <>
                     <div style={wrapperStyle()}>{child.content()}</div>
@@ -594,6 +602,7 @@ export function TilingLayout() {
                       <div
                         class={`resize-handle resize-handle-h ${dragging() === i() ? 'dragging' : ''}`}
                         onMouseDown={(e) => handleDragStart(i(), e)}
+                        onDblClick={unpinHandle}
                       />
                     </Show>
                   </>

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -588,13 +588,6 @@ export function TilingLayout() {
                 });
                 const showHandle = () =>
                   !store.focusMode && !child.fixed && i() < panelChildren().length - 1;
-                function unpinHandle() {
-                  const panels = panelChildren();
-                  const left = panels[i()];
-                  const right = panels[i() + 1];
-                  if (!left || !right) return;
-                  deletePanelUserSize([`tiling:${left.id}`, `tiling:${right.id}`]);
-                }
                 return (
                   <>
                     <div style={wrapperStyle()}>{child.content()}</div>
@@ -602,7 +595,15 @@ export function TilingLayout() {
                       <div
                         class={`resize-handle resize-handle-h ${dragging() === i() ? 'dragging' : ''}`}
                         onMouseDown={(e) => handleDragStart(i(), e)}
-                        onDblClick={unpinHandle}
+                        onDblClick={() => {
+                          if (dragging() !== null) return;
+                          const panels = panelChildren();
+                          const left = panels[i()];
+                          const right = panels[i() + 1];
+                          if (!left || !right) return;
+                          deletePanelUserSize([`tiling:${left.id}`, `tiling:${right.id}`]);
+                          requestAnimationFrame(() => updateViewportState());
+                        }}
                       />
                     </Show>
                   </>


### PR DESCRIPTION
## What

**ResizablePanel reliability fixes**
- Switch `wrapperRefs` from an index-keyed array to an ID-keyed `Map` — drag measurement now survives dynamic children changes (e.g. the plan tab appearing mid-drag)
- Add `flexGrow` prop to `PanelChild` so absorbers can be weighted (notes-files gets a smaller weight, leaving the AI terminal ~2/3 of the remaining space)
- Store absorber pins as flex-grow ratios instead of pixel values so they scale proportionally when the window is resized
- Detect and clear asymmetric absorber pins (one absorber pinned while siblings are not) — these are stale pixel values from before the child was promoted to absorber status, and would otherwise starve the other absorbers

**Double-click on tiling resize handles to unpin**
- Double-clicking a resize handle between two task columns resets both panels to the default equal split without any dragging

**Layout cleanup**
- Remove the `40vh` `max-height` from `TaskNotesBody` — it was a workaround for content-size bubbling up the flex chain; `notes-files` is now a proper weighted absorber so height is layout-driven, not content-driven

## Why

Pinned panels previously stored pixel values, which go stale when the window is resized or when an absorber configuration changes. Storing ratios instead keeps the layout self-healing. The double-click reset gives users a quick escape hatch without needing to drag.

## Testing

1. Pin two panels at different widths, then resize the window → proportions should hold
2. Double-click a tiling resize handle → both panels should snap back to an equal split
3. Open the plan tab (which adds a new absorber) → drag should measure correctly with no visual jump
4. No layout breakage in focus mode or with long plan markdown open

---

_PS. just cosmetic fixes! just wanted to test what submitting a PR on parallel code would look like :)_