### PR TITLE
feat(coordinator): frontend store wiring, IPC lifecycle, and session restore (PR 3/4)

### DIFF
--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -1309,6 +1309,10 @@ export function retryTaskMcpStartup(taskId: string): Promise<void> {
       markTaskMcpError(taskId, 'Coordinator MCP failed — retry the coordinator task first');
       return Promise.resolve();
     }
+    if (coordinator?.mcpStartupStatus === 'pending') {
+      markTaskMcpError(taskId, 'Coordinator is still starting — wait for it to finish, then retry');
+      return Promise.resolve();
+    }
     return invoke(IPC.MCP_HydrateCoordinatedTask, {
       id: task.id,
       name: task.name,


### PR DESCRIPTION
## Overview

This is **PR 3 of 4** in the coordinator series splitting #100 as requested in the round-4 review. It is stacked on [PR 2 (#120)](https://github.com/johannesjo/parallel-code/pull/120) (`coordinator-2-mcp-backend`) and **must be merged after that one**. The diff shown here includes PRs 1–2's content; the meaningful delta for this PR is the frontend store wiring and IPC lifecycle described below.

**PR sequence:**
| PR | Branch | Status | Contents |
|----|--------|--------|----------|
| [1 (#118)](https://github.com/johannesjo/parallel-code/pull/118) | `coordinator-1-security` | Open | Atomic writes, input validators, static analysis configs |
| [2 (#120)](https://github.com/johannesjo/parallel-code/pull/120) | `coordinator-2-mcp-backend` | Open | MCP coordinator engine + REST API hardening |
| **3 (this PR)** | `coordinator-3-store-ipc` | Open | Frontend store wiring + IPC handlers |
| 4 | `coordinator-4-ui` | Pending | UI components + coordinator entry points |

Nothing coordinator-related is user-visible until PR 4 adds the `NewTaskDialog` checkbox and Settings toggle (`coordinatorModeEnabled` defaults to `false`).

---

## What's in this PR (delta over PR 2)

### Task model extensions (`src/store/types.ts`)

New fields on `Task`/`CollapsedTask`:
- `coordinatorMode`, `coordinatedBy`, `controlledBy` (`'coordinator' | 'human'`), `propagateSkipPermissions`
- `mcpConfigPath`, `mcpStartupStatus` (`'pending' | 'ready' | 'error'`), `mcpStartupError`
- `signalDoneReceived`, `signalDoneAt`, `signalDoneConsumed`, `needsReview`, `initialPrompt`
- `stagedNotification: StagedNotification` — pending coordinator batch notification
- Global store: `coordinatorModeEnabled`, `coordinatorNotificationDelayMs`, `coordinatorControlHintDismissed`
- `MCPStatus` type for frontend polling

### MCP lifecycle (`src/store/tasks.ts`)

New store functions wired to IPC:
- `initMCPListeners()` — subscribes to 7 MCP push events (`MCP_TaskCreated`, `MCP_TaskClosed`, `MCP_TaskCleanupFailed`, `MCP_CoordinatorNotificationStaged/Cleared/Orphaned`, `MCP_TaskStateSync`, `MCP_TaskHydrated`)
- `markTaskMcpPending/Ready/Error()` — MCP startup state transitions
- `retryTaskMcpStartup()` — retry after error, with coordinator-dependency guard
- `setTaskControl()` — toggles `controlledBy` between `'coordinator'` and `'human'`
- `clearStagedNotification()`, `setStagedNotificationUserEdited()`
- `getCoordinatorCloseWarning()` — warning text when closing a coordinator with active children
- `reorderTaskVisually()` — drag-reorder respecting coordinator group boundaries
- `collapseTask()` guard — no-op for coordinated children (prevents orphaning from coordinator group)
- `closeTask()` — calls `MCP_CoordinatedTaskClosed` / `MCP_CoordinatorDeregistered` on close; errors swallowed so the task is always removed

### Session restore (`src/App.tsx`)

On startup, iterates all persisted tasks with `coordinatorMode === true` and calls `StartMCPServer` for each, rewriting `.mcp.json` config with the new session's port and token. Child tasks start with `mcpStartupStatus: 'pending'` (terminal spawn deferred) until `MCP_HydrateCoordinatedTask` returns.

### Persistence (`src/store/persistence.ts`)

`saveState()`/`loadState()` now round-trips all coordinator fields: `coordinatorMode`, `coordinatedBy`, `controlledBy`, `propagateSkipPermissions`, `mcpConfigPath`, `signalDone*`, `needsReview`. Global fields `coordinatorModeEnabled`, `coordinatorNotificationDelayMs`, `coordinatorControlHintDismissed` also persisted. Tasks with `coordinatorMode` or `coordinatedBy` load with `mcpStartupStatus: 'pending'` to defer terminal spawn until the session's MCP server is ready.

### Coordinator preamble (`src/store/coordinator-preamble.ts`)

System preamble prepended to the coordinator agent's initial prompt. Documents all 10 MCP tools and operating rules.

### MCP status polling (`src/store/mcpStatus.ts`)

Polls `GetMCPStatus` IPC every 3 s; stores result in `store.mcpStatus`. Returns `{ running: false, ... }` when no coordinator is active — no user-visible effect until a coordinator task exists.

### Staged notification store (`src/store/taskStatus.ts`)

`getTaskStatus()` / `getTaskDotStatus()` return `'review'` for tasks with `needsReview` set. Replace-on-arrival: new batch replaces the previous one before it fires; `userEdited` resets per-notification (not sticky).

### Backend fix (`electron/mcp/coordinator.ts`)

In `deregisterCoordinator`, child tasks that never received their prompt (`assignedPromptDelivered` false) have `reviewNotificationQueued` set — suppresses a spurious "needs review" notification for tasks the user never saw.

### IPC preload (`electron/preload.cjs`)

New channels exposed: `set_coordinator_mode_enabled`, `mcp_hydrate_coordinated_task`, `mcp_task_hydrated`, `mcp_coordinated_task_closed`, `mcp_task_cleanup_failed`.

---

## Tests

| File | New / updated cases |
|------|---------------------|
| `src/store/tasks.test.ts` | ~35 new — `controlledBy` state machine, `MCP_TaskCreated` handler, `collapseTask` child guard, `hasActiveCoordinator`, MCP startup transitions (pending/ready/error/retry/child-failure), `MCP_TaskCleanupFailed`, `closeTask` IPC ordering |
| `src/store/notifications.test.ts` | 3 new — staged notification replace-on-arrival, `userEdited` per-notification reset, `clearStagedNotification` |
| `src/store/taskStatus.test.ts` | 4 new — `getTaskStatus`/`getTaskDotStatus` return `'review'` for `needsReview`; busy overrides review |
| `src/store/persistence.test.ts` | Pruned stale cases; updated for coordinator fields |
| `electron/mcp/docker.integration.test.ts` | UUID fix: `coordinatorTaskId` changed from `'coord-1'` to a valid UUID constant |

---

## Assumptions and important notes

1. **PR 2 prerequisite** — coordinator-3 removed its own copies of `getCoordinatorChildren`/`isCoordinatedChild` from `sidebar-order.ts` because PR 2 provides them. Without PR 2, the app will not typecheck.
2. **MCP polling side effect** — `mcpStatus.ts` polls every 3 s as soon as this lands, but returns empty status until a coordinator task exists.
3. **Session restore timing** — `StartMCPServer` calls fire in parallel for all coordinator tasks on startup. Each child stays `mcpStartupStatus: 'pending'` until hydration completes. The UI for that state lives in PR 4.
4. **Docker coordinator restore** — Container names are reconstructed from `agentId` (`parallel-code-{agentId.slice(0,12)}`). The container is likely dead after restart; wiring exists so the user can manually restart the coordinator agent.
5. **Feature is dark** — `coordinatorModeEnabled` defaults to `false`. No user-visible change until PR 4 adds the Settings checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)