### PR TITLE
feat(sidebar): collapsible Projects section

### DIFF
--- a/openspec/changes/add-collapsible-projects-section/proposal.md
+++ b/openspec/changes/add-collapsible-projects-section/proposal.md
@@ -1,0 +1,25 @@
+# Add Collapsible Projects Section
+
+## Why
+
+The sidebar **Projects** section is always expanded and always occupies a
+capped slice of vertical space (`40vh`, or `min(24vh, 180px)` when dense),
+becoming its own scroll area when there are many projects. Users who keep many
+projects but spend most of their time in the tasks list pay that fixed space
+even when they are not switching projects.
+
+## What changes
+
+- Add a collapse/expand toggle to the **Projects** section header: clicking the
+  header (or its chevron) hides the project list entirely and reclaims the
+  space for the tasks section.
+- Show a chevron on the header that reflects collapsed vs. expanded state.
+- Persist the collapsed state via the existing settings persistence so it
+  survives app restarts.
+
+## Impact
+
+- New capability `sidebar`.
+- Updates `src/components/Sidebar.tsx`; adds a persisted `projectsCollapsed`
+  flag to the store (`types`, `core`, `autosave`, `persistence`, `ui`).
+- No backend or IPC change — the flag rides the existing persisted-state file.

--- a/openspec/changes/add-collapsible-projects-section/specs/sidebar/spec.md
+++ b/openspec/changes/add-collapsible-projects-section/specs/sidebar/spec.md
@@ -1,0 +1,37 @@
+# Sidebar Specification
+
+## ADDED Requirements
+
+### Requirement: Projects section can be collapsed
+
+The sidebar Projects section SHALL be collapsible via a toggle on its header.
+When collapsed, the project list is hidden entirely and its vertical space is
+reclaimed by the tasks section. The collapsed state SHALL persist across app
+restarts.
+
+#### Scenario: User collapses the Projects section
+
+- **WHEN** the Projects section is expanded and the user activates the section
+  header toggle
+- **THEN** the project list is hidden
+- **AND** the freed vertical space is given to the tasks section
+- **AND** the header chevron indicates the collapsed state
+
+#### Scenario: User expands the Projects section
+
+- **WHEN** the Projects section is collapsed and the user activates the section
+  header toggle
+- **THEN** the project list is shown again
+- **AND** the header chevron indicates the expanded state
+
+#### Scenario: Collapsed state survives a restart
+
+- **WHEN** the user has collapsed the Projects section
+- **AND** the app is restarted
+- **THEN** the Projects section is still collapsed
+
+#### Scenario: Add-project control stays reachable while collapsed
+
+- **WHEN** the Projects section is collapsed
+- **THEN** the add-project control on the section header remains visible and
+  usable without first expanding the section

--- a/openspec/changes/add-collapsible-projects-section/specs/sidebar/spec.md
+++ b/openspec/changes/add-collapsible-projects-section/specs/sidebar/spec.md
@@ -35,3 +35,10 @@ restarts.
 - **WHEN** the Projects section is collapsed
 - **THEN** the add-project control on the section header remains visible and
   usable without first expanding the section
+
+#### Scenario: Arrow-key navigation skips hidden projects
+
+- **WHEN** the sidebar is focused
+- **AND** the Projects section is collapsed
+- **THEN** pressing `↑` or `↓` does not move focus into the hidden project
+  list — navigation stays within the visible task list

--- a/openspec/changes/add-collapsible-projects-section/tasks.md
+++ b/openspec/changes/add-collapsible-projects-section/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — Add Collapsible Projects Section
+
+- [x] Add a persisted `projectsCollapsed` flag to the store (`types`, `core`,
+      `autosave`, `persistence`) defaulting to expanded.
+- [x] Add a `toggleProjectsCollapsed` store helper and export it.
+- [x] Make the Projects section header a toggle with a chevron indicator, and
+      hide the project list when collapsed.
+- [x] Cover the persisted flag in the persistence test suite.
+- [x] Validate with `npm run typecheck`, `npm test`, and
+      `openspec validate --all --strict`.

--- a/openspec/changes/add-collapsible-projects-section/tasks.md
+++ b/openspec/changes/add-collapsible-projects-section/tasks.md
@@ -2,9 +2,15 @@
 
 - [x] Add a persisted `projectsCollapsed` flag to the store (`types`, `core`,
       `autosave`, `persistence`) defaulting to expanded.
-- [x] Add a `toggleProjectsCollapsed` store helper and export it.
-- [x] Make the Projects section header a toggle with a chevron indicator, and
-      hide the project list when collapsed.
-- [x] Cover the persisted flag in the persistence test suite.
+- [x] Add a `setProjectsCollapsed(boolean)` helper in `store/ui` that also
+      drops `sidebarFocusedProjectId` when collapsing, and export it from the
+      store barrel.
+- [x] Make the Projects section header a toggle (chevron + label) that
+      animates the list collapse smoothly via a CSS grid-rows transition, with
+      hover and focus-visible styles on the toggle button.
+- [x] Skip "project mode" in sidebar arrow-key navigation while collapsed so
+      `↑/↓` does not walk through invisible items.
+- [x] Cover the persisted flag in the persistence test suite (including
+      rejection of non-boolean values).
 - [x] Validate with `npm run typecheck`, `npm test`, and
       `openspec validate --all --strict`.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -442,6 +442,7 @@ export function Sidebar() {
           >
             <button
               type="button"
+              class="projects-toggle"
               onClick={() => setProjectsCollapsed(!store.projectsCollapsed)}
               aria-expanded={!store.projectsCollapsed}
               aria-controls="sidebar-projects-list"
@@ -454,7 +455,7 @@ export function Sidebar() {
                 'min-width': '0',
                 background: 'transparent',
                 border: 'none',
-                padding: '2px 0',
+                padding: '2px 4px',
                 margin: '0',
                 cursor: 'pointer',
                 color: theme.fgMuted,
@@ -496,114 +497,120 @@ export function Sidebar() {
             />
           </div>
 
-          {/* Scrollable project list */}
-          <Show when={!store.projectsCollapsed}>
-            <div
-              id="sidebar-projects-list"
-              style={{
-                display: 'flex',
-                'flex-direction': 'column',
-                gap: '6px',
-                flex: '0 1 auto',
-                'min-height': '0',
-                'max-height': projectListMaxHeight(),
-                'overflow-y': 'auto',
-              }}
-            >
-              <For each={store.projects}>
-                {(project) => (
-                  <div
-                    role="button"
-                    tabIndex={0}
-                    data-project-id={project.id}
-                    onClick={() => setEditingProject(project)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') setEditingProject(project);
-                    }}
-                    style={{
-                      display: 'flex',
-                      'align-items': 'center',
-                      gap: '6px',
-                      padding: '4px 6px',
-                      'border-radius': '6px',
-                      background: isProjectMissing(project.id)
-                        ? `color-mix(in srgb, ${theme.warning} 8%, ${theme.bgInput})`
-                        : theme.bgInput,
-                      'font-size': sf(12),
-                      cursor: 'pointer',
-                      border:
-                        store.sidebarFocused && store.sidebarFocusedProjectId === project.id
-                          ? `1.5px solid var(--border-focus)`
-                          : '1.5px solid transparent',
-                      'flex-shrink': '0',
-                    }}
-                  >
+          {/* Scrollable project list — outer grid-rows wrapper animates the
+              collapse smoothly without needing a measured height. */}
+          <div
+            class="projects-collapser"
+            classList={{ 'is-collapsed': store.projectsCollapsed }}
+            aria-hidden={store.projectsCollapsed}
+          >
+            <div class="projects-clip">
+              <div
+                id="sidebar-projects-list"
+                style={{
+                  display: 'flex',
+                  'flex-direction': 'column',
+                  gap: '6px',
+                  'min-height': '0',
+                  'max-height': projectListMaxHeight(),
+                  'overflow-y': 'auto',
+                }}
+              >
+                <For each={store.projects}>
+                  {(project) => (
                     <div
-                      style={{
-                        width: '8px',
-                        height: '8px',
-                        'border-radius': '50%',
-                        background: project.color,
-                        'flex-shrink': '0',
+                      role="button"
+                      tabIndex={0}
+                      data-project-id={project.id}
+                      onClick={() => setEditingProject(project)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') setEditingProject(project);
                       }}
-                    />
-                    <div style={{ flex: '1', 'min-width': '0', overflow: 'hidden' }}>
-                      <div
-                        style={{
-                          color: theme.fg,
-                          'font-weight': '500',
-                          'white-space': 'nowrap',
-                          overflow: 'hidden',
-                          'text-overflow': 'ellipsis',
-                        }}
-                      >
-                        {project.name}
-                      </div>
-                      <div
-                        style={{
-                          color: isProjectMissing(project.id) ? theme.warning : theme.fgSubtle,
-                          'font-size': sf(11),
-                          'white-space': 'nowrap',
-                          overflow: 'hidden',
-                          'text-overflow': 'ellipsis',
-                        }}
-                      >
-                        {isProjectMissing(project.id)
-                          ? 'Folder not found'
-                          : abbreviatePath(project.path)}
-                      </div>
-                    </div>
-                    <button
-                      class="icon-btn"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setConfirmRemove(project.id);
-                      }}
-                      title="Remove project"
                       style={{
-                        background: 'transparent',
-                        border: 'none',
-                        color: theme.fgSubtle,
+                        display: 'flex',
+                        'align-items': 'center',
+                        gap: '6px',
+                        padding: '4px 6px',
+                        'border-radius': '6px',
+                        background: isProjectMissing(project.id)
+                          ? `color-mix(in srgb, ${theme.warning} 8%, ${theme.bgInput})`
+                          : theme.bgInput,
+                        'font-size': sf(12),
                         cursor: 'pointer',
-                        'font-size': sf(13),
-                        'line-height': '1',
-                        padding: '0 2px',
+                        border:
+                          store.sidebarFocused && store.sidebarFocusedProjectId === project.id
+                            ? `1.5px solid var(--border-focus)`
+                            : '1.5px solid transparent',
                         'flex-shrink': '0',
                       }}
                     >
-                      &times;
-                    </button>
-                  </div>
-                )}
-              </For>
+                      <div
+                        style={{
+                          width: '8px',
+                          height: '8px',
+                          'border-radius': '50%',
+                          background: project.color,
+                          'flex-shrink': '0',
+                        }}
+                      />
+                      <div style={{ flex: '1', 'min-width': '0', overflow: 'hidden' }}>
+                        <div
+                          style={{
+                            color: theme.fg,
+                            'font-weight': '500',
+                            'white-space': 'nowrap',
+                            overflow: 'hidden',
+                            'text-overflow': 'ellipsis',
+                          }}
+                        >
+                          {project.name}
+                        </div>
+                        <div
+                          style={{
+                            color: isProjectMissing(project.id) ? theme.warning : theme.fgSubtle,
+                            'font-size': sf(11),
+                            'white-space': 'nowrap',
+                            overflow: 'hidden',
+                            'text-overflow': 'ellipsis',
+                          }}
+                        >
+                          {isProjectMissing(project.id)
+                            ? 'Folder not found'
+                            : abbreviatePath(project.path)}
+                        </div>
+                      </div>
+                      <button
+                        class="icon-btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setConfirmRemove(project.id);
+                        }}
+                        title="Remove project"
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          color: theme.fgSubtle,
+                          cursor: 'pointer',
+                          'font-size': sf(13),
+                          'line-height': '1',
+                          padding: '0 2px',
+                          'flex-shrink': '0',
+                        }}
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  )}
+                </For>
 
-              <Show when={store.projects.length === 0}>
-                <span style={{ 'font-size': sf(11), color: theme.fgSubtle, padding: '0 2px' }}>
-                  No projects linked yet.
-                </span>
-              </Show>
+                <Show when={store.projects.length === 0}>
+                  <span style={{ 'font-size': sf(11), color: theme.fgSubtle, padding: '0 2px' }}>
+                    No projects linked yet.
+                  </span>
+                </Show>
+              </div>
             </div>
-          </Show>
+          </div>
         </div>
 
         <div style={{ height: '1px', background: theme.border }} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   getPanelUserSize,
   setPanelUserSize,
   toggleSettingsDialog,
+  setProjectsCollapsed,
   uncollapseTask,
   isProjectMissing,
   showNotification,
@@ -439,16 +440,50 @@ export function Sidebar() {
               padding: '0 2px',
             }}
           >
-            <label
+            <button
+              type="button"
+              onClick={() => setProjectsCollapsed(!store.projectsCollapsed)}
+              aria-expanded={!store.projectsCollapsed}
+              aria-controls="sidebar-projects-list"
+              title={store.projectsCollapsed ? 'Expand projects' : 'Collapse projects'}
               style={{
-                'font-size': sf(12),
+                display: 'flex',
+                'align-items': 'center',
+                gap: '4px',
+                flex: '1',
+                'min-width': '0',
+                background: 'transparent',
+                border: 'none',
+                padding: '2px 0',
+                margin: '0',
+                cursor: 'pointer',
                 color: theme.fgMuted,
-                'text-transform': 'uppercase',
-                'letter-spacing': '0.05em',
               }}
             >
-              Projects
-            </label>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+                style={{
+                  'flex-shrink': '0',
+                  transform: store.projectsCollapsed ? 'rotate(-90deg)' : 'none',
+                  transition: 'transform 0.15s ease',
+                }}
+              >
+                <path d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+              <span
+                style={{
+                  'font-size': sf(12),
+                  'text-transform': 'uppercase',
+                  'letter-spacing': '0.05em',
+                }}
+              >
+                Projects
+              </span>
+            </button>
             <IconButton
               icon={
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -462,110 +497,113 @@ export function Sidebar() {
           </div>
 
           {/* Scrollable project list */}
-          <div
-            style={{
-              display: 'flex',
-              'flex-direction': 'column',
-              gap: '6px',
-              flex: '0 1 auto',
-              'min-height': '0',
-              'max-height': projectListMaxHeight(),
-              'overflow-y': 'auto',
-            }}
-          >
-            <For each={store.projects}>
-              {(project) => (
-                <div
-                  role="button"
-                  tabIndex={0}
-                  data-project-id={project.id}
-                  onClick={() => setEditingProject(project)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') setEditingProject(project);
-                  }}
-                  style={{
-                    display: 'flex',
-                    'align-items': 'center',
-                    gap: '6px',
-                    padding: '4px 6px',
-                    'border-radius': '6px',
-                    background: isProjectMissing(project.id)
-                      ? `color-mix(in srgb, ${theme.warning} 8%, ${theme.bgInput})`
-                      : theme.bgInput,
-                    'font-size': sf(12),
-                    cursor: 'pointer',
-                    border:
-                      store.sidebarFocused && store.sidebarFocusedProjectId === project.id
-                        ? `1.5px solid var(--border-focus)`
-                        : '1.5px solid transparent',
-                    'flex-shrink': '0',
-                  }}
-                >
+          <Show when={!store.projectsCollapsed}>
+            <div
+              id="sidebar-projects-list"
+              style={{
+                display: 'flex',
+                'flex-direction': 'column',
+                gap: '6px',
+                flex: '0 1 auto',
+                'min-height': '0',
+                'max-height': projectListMaxHeight(),
+                'overflow-y': 'auto',
+              }}
+            >
+              <For each={store.projects}>
+                {(project) => (
                   <div
-                    style={{
-                      width: '8px',
-                      height: '8px',
-                      'border-radius': '50%',
-                      background: project.color,
-                      'flex-shrink': '0',
+                    role="button"
+                    tabIndex={0}
+                    data-project-id={project.id}
+                    onClick={() => setEditingProject(project)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') setEditingProject(project);
                     }}
-                  />
-                  <div style={{ flex: '1', 'min-width': '0', overflow: 'hidden' }}>
-                    <div
-                      style={{
-                        color: theme.fg,
-                        'font-weight': '500',
-                        'white-space': 'nowrap',
-                        overflow: 'hidden',
-                        'text-overflow': 'ellipsis',
-                      }}
-                    >
-                      {project.name}
-                    </div>
-                    <div
-                      style={{
-                        color: isProjectMissing(project.id) ? theme.warning : theme.fgSubtle,
-                        'font-size': sf(11),
-                        'white-space': 'nowrap',
-                        overflow: 'hidden',
-                        'text-overflow': 'ellipsis',
-                      }}
-                    >
-                      {isProjectMissing(project.id)
-                        ? 'Folder not found'
-                        : abbreviatePath(project.path)}
-                    </div>
-                  </div>
-                  <button
-                    class="icon-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConfirmRemove(project.id);
-                    }}
-                    title="Remove project"
                     style={{
-                      background: 'transparent',
-                      border: 'none',
-                      color: theme.fgSubtle,
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '6px',
+                      padding: '4px 6px',
+                      'border-radius': '6px',
+                      background: isProjectMissing(project.id)
+                        ? `color-mix(in srgb, ${theme.warning} 8%, ${theme.bgInput})`
+                        : theme.bgInput,
+                      'font-size': sf(12),
                       cursor: 'pointer',
-                      'font-size': sf(13),
-                      'line-height': '1',
-                      padding: '0 2px',
+                      border:
+                        store.sidebarFocused && store.sidebarFocusedProjectId === project.id
+                          ? `1.5px solid var(--border-focus)`
+                          : '1.5px solid transparent',
                       'flex-shrink': '0',
                     }}
                   >
-                    &times;
-                  </button>
-                </div>
-              )}
-            </For>
+                    <div
+                      style={{
+                        width: '8px',
+                        height: '8px',
+                        'border-radius': '50%',
+                        background: project.color,
+                        'flex-shrink': '0',
+                      }}
+                    />
+                    <div style={{ flex: '1', 'min-width': '0', overflow: 'hidden' }}>
+                      <div
+                        style={{
+                          color: theme.fg,
+                          'font-weight': '500',
+                          'white-space': 'nowrap',
+                          overflow: 'hidden',
+                          'text-overflow': 'ellipsis',
+                        }}
+                      >
+                        {project.name}
+                      </div>
+                      <div
+                        style={{
+                          color: isProjectMissing(project.id) ? theme.warning : theme.fgSubtle,
+                          'font-size': sf(11),
+                          'white-space': 'nowrap',
+                          overflow: 'hidden',
+                          'text-overflow': 'ellipsis',
+                        }}
+                      >
+                        {isProjectMissing(project.id)
+                          ? 'Folder not found'
+                          : abbreviatePath(project.path)}
+                      </div>
+                    </div>
+                    <button
+                      class="icon-btn"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setConfirmRemove(project.id);
+                      }}
+                      title="Remove project"
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        color: theme.fgSubtle,
+                        cursor: 'pointer',
+                        'font-size': sf(13),
+                        'line-height': '1',
+                        padding: '0 2px',
+                        'flex-shrink': '0',
+                      }}
+                    >
+                      &times;
+                    </button>
+                  </div>
+                )}
+              </For>
 
-            <Show when={store.projects.length === 0}>
-              <span style={{ 'font-size': sf(11), color: theme.fgSubtle, padding: '0 2px' }}>
-                No projects linked yet.
-              </span>
-            </Show>
-          </div>
+              <Show when={store.projects.length === 0}>
+                <span style={{ 'font-size': sf(11), color: theme.fgSubtle, padding: '0 2px' }}>
+                  No projects linked yet.
+                </span>
+              </Show>
+            </div>
+          </Show>
         </div>
 
         <div style={{ height: '1px', background: theme.border }} />

--- a/src/store/autosave.ts
+++ b/src/store/autosave.ts
@@ -28,6 +28,7 @@ function persistedSnapshot(): string {
     showSteps: store.showSteps,
     showSidebarTips: store.showSidebarTips,
     showSidebarProgress: store.showSidebarProgress,
+    projectsCollapsed: store.projectsCollapsed,
     desktopNotificationsEnabled: store.desktopNotificationsEnabled,
     inactiveColumnOpacity: store.inactiveColumnOpacity,
     editorCommand: store.editorCommand,

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -51,6 +51,7 @@ export const [store, setStore] = createStore<AppStore>({
   showSteps: false,
   showSidebarTips: true,
   showSidebarProgress: true,
+  projectsCollapsed: false,
   desktopNotificationsEnabled: false,
   inactiveColumnOpacity: 0.6,
   editorCommand: '',

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -307,8 +307,11 @@ export function navigateRow(direction: 'up' | 'down'): void {
   if (store.sidebarFocused) {
     const { projects, sidebarFocusedProjectId, sidebarFocusedTaskId } = store;
     const allTasks = computeSidebarTaskOrder();
+    // When the Projects section is collapsed, hidden items aren't a navigable
+    // axis — ↑/↓ stays in task mode regardless of any leftover project focus.
+    const projectsNavigable = !store.projectsCollapsed && projects.length > 0;
 
-    if (sidebarFocusedProjectId !== null) {
+    if (projectsNavigable && sidebarFocusedProjectId !== null) {
       // Project mode: navigate within projects
       const projectIdx = projects.findIndex((p) => p.id === sidebarFocusedProjectId);
       if (direction === 'up') {
@@ -329,10 +332,10 @@ export function navigateRow(direction: 'up' | 'down'): void {
     }
 
     // Task mode: navigate within tasks (highlight only, don't activate)
-    if (allTasks.length === 0 && projects.length === 0) return;
+    if (allTasks.length === 0 && !projectsNavigable) return;
     const currentIdx = sidebarFocusedTaskId ? allTasks.indexOf(sidebarFocusedTaskId) : -1;
     if (direction === 'up') {
-      if (currentIdx <= 0 && projects.length > 0) {
+      if (currentIdx <= 0 && projectsNavigable) {
         // At first task (or no task): enter project mode at last project
         setStore('sidebarFocusedTaskId', null);
         setStore('sidebarFocusedProjectId', projects[projects.length - 1].id);

--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -387,9 +387,14 @@ describe('projects section collapsed persistence', () => {
     expect(store.projectsCollapsed).toBe(true);
   });
 
-  it('ignores a non-boolean projectsCollapsed value', async () => {
+  it.each([
+    ['string', 'yes'],
+    ['number', 1],
+    ['null', null],
+    ['object', { collapsed: true }],
+  ])('ignores a non-boolean projectsCollapsed value (%s)', async (_label, value) => {
     setStore('projectsCollapsed', true);
-    mockInvoke.mockResolvedValueOnce(basePayload({ projectsCollapsed: 'yes' }));
+    mockInvoke.mockResolvedValueOnce(basePayload({ projectsCollapsed: value }));
 
     await loadState();
 

--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -368,3 +368,41 @@ describe('coordinator control hint persistence', () => {
     expect(store.coordinatorControlHintDismissed).toBe(false);
   });
 });
+
+describe('projects section collapsed persistence', () => {
+  it('defaults to expanded when not in saved state', async () => {
+    setStore('projectsCollapsed', true);
+    mockInvoke.mockResolvedValueOnce(basePayload());
+
+    await loadState();
+
+    expect(store.projectsCollapsed).toBe(false);
+  });
+
+  it('restores projectsCollapsed=true from saved state', async () => {
+    mockInvoke.mockResolvedValueOnce(basePayload({ projectsCollapsed: true }));
+
+    await loadState();
+
+    expect(store.projectsCollapsed).toBe(true);
+  });
+
+  it('ignores a non-boolean projectsCollapsed value', async () => {
+    setStore('projectsCollapsed', true);
+    mockInvoke.mockResolvedValueOnce(basePayload({ projectsCollapsed: 'yes' }));
+
+    await loadState();
+
+    expect(store.projectsCollapsed).toBe(false);
+  });
+
+  it('persists the collapsed flag through saveState', async () => {
+    setStore('projectsCollapsed', true);
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    await saveState();
+
+    const saved = JSON.parse(mockInvoke.mock.calls[0][1].json);
+    expect(saved.projectsCollapsed).toBe(true);
+  });
+});

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -135,6 +135,7 @@ export async function saveState(): Promise<void> {
     showSteps: store.showSteps,
     showSidebarTips: store.showSidebarTips,
     showSidebarProgress: store.showSidebarProgress,
+    projectsCollapsed: store.projectsCollapsed,
     desktopNotificationsEnabled: store.desktopNotificationsEnabled,
     inactiveColumnOpacity: store.inactiveColumnOpacity,
     editorCommand: store.editorCommand || undefined,
@@ -376,6 +377,7 @@ interface LegacyPersistedState {
   showSteps?: unknown;
   showSidebarTips?: unknown;
   showSidebarProgress?: unknown;
+  projectsCollapsed?: unknown;
   desktopNotificationsEnabled?: unknown;
   inactiveColumnOpacity?: unknown;
   editorCommand?: unknown;
@@ -518,6 +520,8 @@ export async function loadState(): Promise<void> {
       s.showSidebarTips = typeof raw.showSidebarTips === 'boolean' ? raw.showSidebarTips : true;
       s.showSidebarProgress =
         typeof raw.showSidebarProgress === 'boolean' ? raw.showSidebarProgress : true;
+      s.projectsCollapsed =
+        typeof raw.projectsCollapsed === 'boolean' ? raw.projectsCollapsed : false;
       s.desktopNotificationsEnabled =
         typeof raw.desktopNotificationsEnabled === 'boolean'
           ? raw.desktopNotificationsEnabled

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -128,6 +128,7 @@ export {
   setShowPromptInput,
   setShowSidebarTips,
   setShowSidebarProgress,
+  setProjectsCollapsed,
   setFontSmoothing,
   setDesktopNotificationsEnabled,
   setVerboseLogging,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -206,6 +206,7 @@ export interface PersistedState {
   showSteps?: boolean;
   showSidebarTips?: boolean;
   showSidebarProgress?: boolean;
+  projectsCollapsed?: boolean;
   desktopNotificationsEnabled?: boolean;
   inactiveColumnOpacity?: number;
   editorCommand?: string;
@@ -299,6 +300,7 @@ export interface AppStore {
   showSteps: boolean;
   showSidebarTips: boolean;
   showSidebarProgress: boolean;
+  projectsCollapsed: boolean;
   desktopNotificationsEnabled: boolean;
   inactiveColumnOpacity: number;
   editorCommand: string;

--- a/src/store/ui.test.ts
+++ b/src/store/ui.test.ts
@@ -6,6 +6,8 @@ type MockStore = {
   tasks: Record<string, { id: string }>;
   focusedPanel: Record<string, string>;
   panelUserSize: Record<string, number>;
+  projectsCollapsed: boolean;
+  sidebarFocusedProjectId: string | null;
 };
 
 let mockStore: MockStore;
@@ -79,7 +81,13 @@ vi.mock('../../electron/ipc/channels', () => ({
   IPC: {},
 }));
 
-import { toggleTaskFocusMode, getPanelUserSize, setPanelUserSize, deletePanelUserSize } from './ui';
+import {
+  toggleTaskFocusMode,
+  getPanelUserSize,
+  setPanelUserSize,
+  deletePanelUserSize,
+  setProjectsCollapsed,
+} from './ui';
 
 beforeEach(() => {
   mockStore = {
@@ -91,6 +99,8 @@ beforeEach(() => {
     },
     focusedPanel: {},
     panelUserSize: {},
+    projectsCollapsed: false,
+    sidebarFocusedProjectId: null,
   };
 
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
@@ -174,5 +184,37 @@ describe('panelUserSize', () => {
     setPanelUserSize('keep', 42);
     expect(() => deletePanelUserSize([])).not.toThrow();
     expect(getPanelUserSize('keep')).toBe(42);
+  });
+});
+
+describe('setProjectsCollapsed', () => {
+  it('clears sidebarFocusedProjectId when collapsing', () => {
+    mockStore.projectsCollapsed = false;
+    mockStore.sidebarFocusedProjectId = 'project-1';
+
+    setProjectsCollapsed(true);
+
+    expect(mockStore.projectsCollapsed).toBe(true);
+    expect(mockStore.sidebarFocusedProjectId).toBeNull();
+  });
+
+  it('leaves sidebarFocusedProjectId untouched when expanding', () => {
+    mockStore.projectsCollapsed = true;
+    mockStore.sidebarFocusedProjectId = null;
+
+    setProjectsCollapsed(false);
+
+    expect(mockStore.projectsCollapsed).toBe(false);
+    expect(mockStore.sidebarFocusedProjectId).toBeNull();
+  });
+
+  it('is a no-op for focus when collapsing with no project highlighted', () => {
+    mockStore.projectsCollapsed = false;
+    mockStore.sidebarFocusedProjectId = null;
+
+    setProjectsCollapsed(true);
+
+    expect(mockStore.projectsCollapsed).toBe(true);
+    expect(mockStore.sidebarFocusedProjectId).toBeNull();
   });
 });

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -179,7 +179,14 @@ export function setShowSidebarProgress(show: boolean): void {
 }
 
 export function setProjectsCollapsed(collapsed: boolean): void {
-  setStore('projectsCollapsed', collapsed);
+  batch(() => {
+    setStore('projectsCollapsed', collapsed);
+    // Drop any project highlight when the section hides — keeping it would let
+    // ↑/↓ walk through invisible items with no visual feedback.
+    if (collapsed && store.sidebarFocusedProjectId !== null) {
+      setStore('sidebarFocusedProjectId', null);
+    }
+  });
 }
 
 export function setShowPromptInput(show: boolean): void {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -178,6 +178,10 @@ export function setShowSidebarProgress(show: boolean): void {
   setStore('showSidebarProgress', show);
 }
 
+export function setProjectsCollapsed(collapsed: boolean): void {
+  setStore('projectsCollapsed', collapsed);
+}
+
 export function setShowPromptInput(show: boolean): void {
   setStore('showPromptInput', show);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -932,6 +932,55 @@ textarea::placeholder {
   transform: translateY(1px);
 }
 
+/* Projects-section header toggle (collapsed/expanded). Subtle hover so the
+   whole row reads as clickable, plus a focus ring matching other sidebar
+   controls. */
+.projects-toggle {
+  border-radius: 4px;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.projects-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+.projects-toggle:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 1px;
+}
+
+/* CSS-only collapse animation. The grid-rows trick lets the row collapse from
+   1fr → 0fr without measuring the children. The intermediate `.projects-clip`
+   provides the `overflow: hidden` clip without stealing scroll from the inner
+   list (which needs its own overflow-y: auto). */
+.projects-collapser {
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transition:
+    grid-template-rows 0.18s ease,
+    opacity 0.15s ease;
+}
+
+.projects-collapser.is-collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+.projects-clip {
+  min-height: 0;
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .projects-collapser {
+    transition: none;
+  }
+}
+
 .tiling-layout-shell {
   position: relative;
   flex: 1;


### PR DESCRIPTION
## Summary

Makes the sidebar **Projects** section collapsible. The section is currently always expanded and always occupies a capped slice of vertical space (`40vh`, or `min(24vh, 180px)` when dense). Users who keep many projects but spend most of their time in the tasks list pay that fixed space even when not switching projects.

## What changed

- The Projects section header is now a toggle button with a chevron that reflects collapsed vs. expanded state. Activating it hides the project list and reclaims the space for the tasks section;
- The add-project control stays visible and usable while the section is collapsed;
- Collapsed state persists across app restarts via the existing settings persistence (`projectsCollapsed` flag — no backend/IPC change, rides the existing persisted-state file);
- Header toggle exposes `aria-expanded` / `aria-controls` for accessibility;

## Implementation

- `src/components/Sidebar.tsx` — header `<label>` → toggle `<button>` with chevron; project list wrapped in `<Show when={!projectsCollapsed}>`;
- `src/store/` — persisted `projectsCollapsed` flag wired through `types`, `core`, `autosave`, `persistence`; `setProjectsCollapsed` setter in `ui.ts`;
- `openspec/changes/add-collapsible-projects-section/` — proposal, spec, tasks;

## Testing

- `npm run lint` — pass
- `npm test` — 1007 passed (4 new tests cover the persisted flag)
- `npm run typecheck` — pass
- `openspec validate --type change add-collapsible-projects-section --strict` — pass

## Demo


https://github.com/user-attachments/assets/87400d2b-78c2-4469-beaa-efc4a197a881


