### PR TITLE
feat: in-app auto-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist-electron
 dist-remote
 release
 coverage
+# Local auto-update test server payload (build artifacts, not source).
+update-test/
 # Runtime data dir written by the app (MCP coordinator state, etc.)
 .parallel-code/
 .worktrees

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -141,6 +141,13 @@ export enum IPC {
   // Logging
   LogFromRenderer = 'log_from_renderer',
 
+  // Auto-update
+  CheckForUpdates = 'check_for_updates',
+  DownloadUpdate = 'download_update',
+  QuitAndInstallUpdate = 'quit_and_install_update',
+  GetUpdateStatus = 'get_update_status',
+  UpdateStatusChanged = 'update_status_changed',
+
   // MCP / Coordinating agent
   SetCoordinatorModeEnabled = 'set_coordinator_mode_enabled',
   StartMCPServer = 'start_mcp_server',

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -72,6 +72,13 @@ import {
   deleteCustomThemeFile,
 } from './persistence.js';
 import { loadKeybindings, saveKeybindings } from './keybindings.js';
+import {
+  initAutoUpdater,
+  getUpdateStatus,
+  checkForUpdates,
+  downloadUpdate,
+  quitAndInstallUpdate,
+} from './updater.js';
 import { spawn } from 'child_process';
 import { askAboutCode, cancelAskAboutCode } from './ask-code.js';
 import { setMinimaxApiKey } from './ask-code-minimax.js';
@@ -86,7 +93,7 @@ import {
   assertOptionalBoolean,
 } from './validate.js';
 import { validateBranchName as sharedValidateBranchName, validateUUID } from '../mcp/validation.js';
-import { warn as logWarn } from '../log.js';
+import { warn as logWarn, errMessage } from '../log.js';
 import { getMCPRemoteServerUrl, detectStaleDockerMCPUrl } from '../mcp/config.js';
 import { redactServerUrl } from '../remote/server.js';
 
@@ -155,16 +162,6 @@ async function startRemoteServerOnFreePort(
     }
   }
   throw new Error(`No free port found in range ${start}–${end}`);
-}
-
-function errMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === 'string') return err;
-  try {
-    return JSON.stringify(err);
-  } catch {
-    return String(err);
-  }
 }
 
 /** Reject paths that are non-absolute or attempt directory traversal. */
@@ -905,6 +902,13 @@ export function registerAllHandlers(win: BrowserWindow): void {
 
   // --- System ---
   ipcMain.handle(IPC.GetSystemFonts, () => getSystemMonospaceFonts());
+
+  // --- Auto-update ---
+  initAutoUpdater(win);
+  ipcMain.handle(IPC.GetUpdateStatus, () => getUpdateStatus());
+  ipcMain.handle(IPC.CheckForUpdates, () => checkForUpdates());
+  ipcMain.handle(IPC.DownloadUpdate, () => downloadUpdate());
+  ipcMain.handle(IPC.QuitAndInstallUpdate, () => quitAndInstallUpdate());
 
   // --- Notifications (fire-and-forget via ipcMain.on) ---
   const activeNotifications = new Set<Notification>();

--- a/electron/ipc/trace.ts
+++ b/electron/ipc/trace.ts
@@ -5,7 +5,7 @@
 // their args; all others omit them by default (default-deny).
 
 import type { IpcMain, IpcMainInvokeEvent } from 'electron';
-import { debug, getMinLevel, warn } from '../log.js';
+import { debug, getMinLevel, warn, errMessage } from '../log.js';
 import { IPC } from './channels.js';
 
 /**
@@ -49,16 +49,6 @@ const NEVER_SAFE: ReadonlySet<string> = new Set<string>([
 for (const ch of NEVER_SAFE) {
   if (SAFE_FOR_TRACE.has(ch)) {
     throw new Error(`SAFE_FOR_TRACE contains a never-safe channel: ${ch}`);
-  }
-}
-
-function errMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === 'string') return err;
-  try {
-    return JSON.stringify(err);
-  } catch {
-    return String(err);
   }
 }
 

--- a/electron/ipc/updater.ts
+++ b/electron/ipc/updater.ts
@@ -1,0 +1,198 @@
+// Auto-update — wraps electron-updater's `autoUpdater` so the renderer can
+// check GitHub Releases for a newer version, download it, and relaunch onto
+// it without a manual reinstall.
+//
+// Auto-update only works for packaged builds that have an in-place update
+// channel: macOS (signed) and the Linux AppImage. A dev run or the Linux
+// `deb` target has no channel, so we report `unsupported` rather than letting
+// electron-updater throw.
+
+import { app, type BrowserWindow } from 'electron';
+import electronUpdater from 'electron-updater';
+import type { UpdateInfo, ProgressInfo, AppUpdater } from 'electron-updater';
+import { IPC } from './channels.js';
+import { debug, info, warn, error as logError, errMessage } from '../log.js';
+
+// `electronUpdater.autoUpdater` is a lazy getter that instantiates a
+// platform updater (and touches `app`) on first access. Resolve it lazily so
+// importing this module never triggers that — important for unit tests where
+// `electron.app` is not a real instance.
+function getAutoUpdater(): AppUpdater {
+  return electronUpdater.autoUpdater;
+}
+
+const LOG = 'updater';
+
+export type UpdatePhase =
+  | 'unsupported'
+  | 'idle'
+  | 'checking'
+  | 'up-to-date'
+  | 'available'
+  | 'downloading'
+  | 'downloaded'
+  | 'error';
+
+export interface UpdateStatus {
+  phase: UpdatePhase;
+  /** Version this app is currently running. */
+  currentVersion: string;
+  /** Version offered by the latest check, when newer than `currentVersion`. */
+  latestVersion: string | null;
+  /** 0–100 while `phase` is `downloading`. */
+  downloadPercent: number;
+  /** Human-readable message when `phase` is `error`. */
+  error: string | null;
+}
+
+// The Linux AppImage runtime sets APPIMAGE to the mounted image path. Its
+// absence on Linux means a non-updatable target (e.g. an installed `.deb`).
+// `app` is undefined when this module is loaded outside an Electron runtime
+// (e.g. a unit test), so guard every access.
+function isAutoUpdateSupported(): boolean {
+  if (!app?.isPackaged) return false;
+  if (process.platform === 'darwin') return true;
+  if (process.platform === 'linux') return !!process.env.APPIMAGE;
+  return false;
+}
+
+const status: UpdateStatus = {
+  phase: 'idle',
+  currentVersion: '',
+  latestVersion: null,
+  downloadPercent: 0,
+  error: null,
+};
+
+let mainWindow: BrowserWindow | null = null;
+let wired = false;
+let startupCheckTimer: ReturnType<typeof setTimeout> | null = null;
+
+function broadcast(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(IPC.UpdateStatusChanged, { ...status });
+  }
+}
+
+function setPhase(phase: UpdatePhase, patch: Partial<UpdateStatus> = {}): void {
+  status.phase = phase;
+  Object.assign(status, patch);
+  broadcast();
+}
+
+function wireUpdaterEvents(): void {
+  if (wired) return;
+  wired = true;
+
+  const autoUpdater = getAutoUpdater();
+
+  // Downloads are user-initiated; a finished download installs on next quit.
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = true;
+
+  autoUpdater.on('checking-for-update', () => {
+    setPhase('checking', { error: null });
+  });
+
+  autoUpdater.on('update-available', (infoEvt: UpdateInfo) => {
+    info(LOG, 'update available', { version: infoEvt.version });
+    setPhase('available', { latestVersion: infoEvt.version, error: null });
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    debug(LOG, 'no update available');
+    setPhase('up-to-date', { latestVersion: null, error: null });
+  });
+
+  autoUpdater.on('download-progress', (progress: ProgressInfo) => {
+    // Fires many times per second; only broadcast when the rounded percent
+    // (the only value the UI shows) actually moves.
+    const percent = Math.round(progress.percent);
+    if (status.phase === 'downloading' && status.downloadPercent === percent) return;
+    setPhase('downloading', { downloadPercent: percent });
+  });
+
+  autoUpdater.on('update-downloaded', (infoEvt: UpdateInfo) => {
+    info(LOG, 'update downloaded', { version: infoEvt.version });
+    setPhase('downloaded', { latestVersion: infoEvt.version, downloadPercent: 100 });
+  });
+
+  autoUpdater.on('error', (err: Error) => {
+    const message = errMessage(err);
+    warn(LOG, 'updater error', { error: message });
+    setPhase('error', { error: message });
+  });
+}
+
+/**
+ * Wire the updater to a window and run one silent check shortly after launch.
+ * Safe to call when auto-update is unsupported — it becomes a no-op.
+ */
+export function initAutoUpdater(win: BrowserWindow): void {
+  mainWindow = win;
+  status.currentVersion = app?.getVersion?.() ?? '';
+  if (!isAutoUpdateSupported()) {
+    setPhase('unsupported');
+    debug(LOG, 'auto-update unsupported in this build');
+    return;
+  }
+  wireUpdaterEvents();
+  // Delay the first check so it does not compete with app startup work.
+  startupCheckTimer = setTimeout(() => {
+    startupCheckTimer = null;
+    void checkForUpdates();
+  }, 10_000);
+  win.once('closed', () => {
+    if (startupCheckTimer) {
+      clearTimeout(startupCheckTimer);
+      startupCheckTimer = null;
+    }
+    // Detach event handlers so a re-created window re-wires from a clean
+    // slate. `removeAllListeners` is safe because this module is the sole
+    // consumer of the `autoUpdater` singleton.
+    getAutoUpdater().removeAllListeners();
+    wired = false;
+    mainWindow = null;
+  });
+}
+
+/** Check GitHub Releases for a newer version. Resolves with the latest status. */
+export async function checkForUpdates(): Promise<UpdateStatus> {
+  if (!isAutoUpdateSupported()) return { ...status };
+  // A check while downloading/downloaded would clobber that progress.
+  if (status.phase === 'downloading' || status.phase === 'downloaded') return { ...status };
+  try {
+    setPhase('checking', { error: null });
+    await getAutoUpdater().checkForUpdates();
+  } catch (err) {
+    setPhase('error', { error: errMessage(err) });
+  }
+  return { ...status };
+}
+
+/** Download the available update; progress is reported via the status event. */
+export async function downloadUpdate(): Promise<UpdateStatus> {
+  if (status.phase !== 'available') return { ...status };
+  try {
+    setPhase('downloading', { downloadPercent: 0, error: null });
+    await getAutoUpdater().downloadUpdate();
+  } catch (err) {
+    setPhase('error', { error: errMessage(err) });
+  }
+  return { ...status };
+}
+
+/** Relaunch onto a downloaded update. No-op unless an update is downloaded. */
+export function quitAndInstallUpdate(): void {
+  if (status.phase !== 'downloaded') return;
+  try {
+    getAutoUpdater().quitAndInstall();
+  } catch (err) {
+    logError(LOG, 'quitAndInstall failed', err);
+    setPhase('error', { error: errMessage(err) });
+  }
+}
+
+export function getUpdateStatus(): UpdateStatus {
+  return { ...status };
+}

--- a/electron/log.ts
+++ b/electron/log.ts
@@ -72,6 +72,17 @@ export function error(category: string, msg: string, err: unknown, ctx?: LogCont
   emit('error', category, msg, ctx, err);
 }
 
+/** Reduce an unknown thrown value to a human-readable string. */
+export function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
 function emit(
   level: LogLevel,
   category: string,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -126,6 +126,12 @@ const ALLOWED_CHANNELS = new Set([
   'pr_checks_update',
   // Logging
   'log_from_renderer',
+  // Auto-update
+  'check_for_updates',
+  'download_update',
+  'quit_and_install_update',
+  'get_update_status',
+  'update_status_changed',
   // MCP / Coordinating agent
   'set_coordinator_mode_enabled',
   'start_mcp_server',

--- a/openspec/changes/add-auto-update/proposal.md
+++ b/openspec/changes/add-auto-update/proposal.md
@@ -1,0 +1,45 @@
+# Add In-App Auto-Update
+
+## Why
+
+Parallel Code ships as a macOS DMG and a Linux AppImage/deb. Today a user who
+wants a newer version must notice a release exists, download the installer by
+hand, and reinstall over the running app. There is no in-app signal that an
+update is available and no way to apply one without that manual reinstall
+(issue #91).
+
+## What changes
+
+- The app checks GitHub Releases for a newer published version: silently once
+  shortly after launch, and on demand from a new **Updates** section in
+  Settings → Diagnostics.
+- When a newer version exists the Updates section reports it and offers a
+  **Download update** action; download progress is shown.
+- An update control also appears in the **sidebar header** whenever an update
+  is available, downloading, or downloaded — so it is discoverable without
+  opening Settings. It is hidden when the app is up to date, unsupported, or
+  the last check failed.
+- Once downloaded, a **Restart & install** action relaunches the app onto the
+  new version — no manual reinstall. A deferred install is also applied
+  automatically the next time the app quits.
+- The Updates section always shows the current version and the outcome of the
+  last check (up to date / available / error), so the feature is discoverable
+  and its state legible.
+- Auto-update is a packaged-build capability. In dev runs and for the Linux
+  `deb` target (which has no in-place update channel) the section reports that
+  updates are unavailable rather than failing.
+
+## Impact
+
+- New capability `updates`.
+- Adds `electron-updater` and a GitHub `publish` target to the
+  `electron-builder` config; adds a `zip` artifact to the macOS build so
+  `electron-updater` can apply macOS updates.
+- New backend module `electron/ipc/updater.ts`; new IPC channels
+  (`check_for_updates`, `download_update`, `quit_and_install_update`,
+  `get_update_status`, `update_status_changed`) wired through
+  `channels.ts`, `preload.cjs`, and `register.ts`.
+- New renderer store slice `src/store/updates.ts`, an Updates section in
+  `src/components/SettingsDialog.tsx`, and a new `UpdateButton` component in
+  the `Sidebar` header; subscription wired in `src/App.tsx`.
+- No persisted-state or schema change — update status is transient.

--- a/openspec/changes/add-auto-update/specs/updates/spec.md
+++ b/openspec/changes/add-auto-update/specs/updates/spec.md
@@ -1,0 +1,107 @@
+# Updates Specification
+
+## ADDED Requirements
+
+### Requirement: App reports its current version and checks for updates
+
+The app SHALL expose its current version and SHALL check GitHub Releases for a
+newer published version, both on demand and once automatically shortly after
+launch. The result of the most recent check SHALL be observable in the UI.
+
+#### Scenario: Automatic check after launch
+
+- **WHEN** the app finishes launching from a packaged build
+- **THEN** it checks GitHub Releases for a newer version once, without user
+  action
+- **AND** the Updates section reflects the outcome of that check
+
+#### Scenario: User checks for updates manually
+
+- **WHEN** the user activates the check-for-updates control in
+  Settings → Diagnostics
+- **THEN** the app checks GitHub Releases for a newer version
+- **AND** the Updates section shows whether the app is up to date, an update
+  is available, or the check failed
+
+#### Scenario: Already on the latest version
+
+- **WHEN** a check completes and no newer version is published
+- **THEN** the Updates section reports that the app is up to date
+- **AND** shows the current version
+
+### Requirement: User can download and install an available update
+
+When a newer version is available the app SHALL let the user download it and
+then install it by relaunching onto the new version, without a manual
+reinstall. A downloaded-but-not-installed update SHALL also be applied
+automatically the next time the app quits.
+
+#### Scenario: User downloads an available update
+
+- **WHEN** an update is available and the user activates the download control
+- **THEN** the app downloads the update
+- **AND** download progress is shown while the download is in flight
+
+#### Scenario: User installs a downloaded update
+
+- **WHEN** an update has finished downloading and the user activates the
+  install control
+- **THEN** the app relaunches onto the new version
+
+#### Scenario: Deferred update installs on next quit
+
+- **WHEN** an update has finished downloading and the user quits the app
+  without activating the install control
+- **THEN** the update is applied before the next launch
+
+### Requirement: An available update is signalled in the sidebar toolbar
+
+So an available update is discoverable without opening Settings, the app SHALL
+show a control in the sidebar header whenever a newer version is available,
+downloading, or downloaded. The control SHALL be hidden when the app is up to
+date, when auto-update is unsupported, and when the last check failed —
+those states remain observable only in Settings → Diagnostics → Updates.
+Activating the control SHALL perform the single action the current phase
+allows.
+
+#### Scenario: Available update surfaces in the toolbar
+
+- **WHEN** a check finds a newer version
+- **THEN** an update control appears in the sidebar header
+- **AND** activating it starts the download
+
+#### Scenario: Toolbar control reflects download progress
+
+- **WHEN** the update is downloading
+- **THEN** the toolbar control shows download progress and takes no action when
+  activated
+
+#### Scenario: Toolbar control installs a downloaded update
+
+- **WHEN** the update has finished downloading
+- **THEN** the toolbar control offers to restart and install
+- **AND** activating it relaunches onto the new version
+
+#### Scenario: No toolbar control when up to date
+
+- **WHEN** the app is up to date, auto-update is unsupported, or the last
+  check failed
+- **THEN** no update control is shown in the sidebar header
+
+### Requirement: Auto-update degrades gracefully when unsupported
+
+The app SHALL NOT fail or error when run in a context that cannot auto-update —
+a development run, or a packaged target with no in-place update channel. In
+those contexts it SHALL report that updates are unavailable.
+
+#### Scenario: Development run
+
+- **WHEN** the app is run from a development build
+- **THEN** the Updates section reports that auto-update is unavailable
+- **AND** no update check is attempted
+
+#### Scenario: Check failure is surfaced, not crashed on
+
+- **WHEN** an update check fails (e.g. no network or GitHub is unreachable)
+- **THEN** the Updates section reports that the check failed
+- **AND** the app continues to run normally

--- a/openspec/changes/add-auto-update/tasks.md
+++ b/openspec/changes/add-auto-update/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — Add In-App Auto-Update
+
+- [x] Add `electron-updater` dependency, a GitHub `publish` target, and a `zip`
+      macOS artifact to the `electron-builder` config in `package.json`.
+- [x] Add `updates` IPC channels to the `IPC` enum in
+      `electron/ipc/channels.ts` and mirror them into the `preload.cjs`
+      allowlist.
+- [x] Add a backend `electron/ipc/updater.ts` module wrapping `autoUpdater`:
+      init/check/download/quit-and-install, broadcasting an
+      `update_status_changed` event to the renderer; degrade gracefully when
+      the build is not auto-updatable (dev run, unsupported target).
+- [x] Register the updater IPC handlers in `electron/ipc/register.ts`, init
+      the updater on window creation, and run one silent check after launch.
+- [x] Add the `UpdateStatus` payload type to `src/ipc/types.ts`.
+- [x] Add a renderer store slice `src/store/updates.ts` (status signal +
+      `update_status_changed` subscription + check/download/install helpers)
+      and export it from the store barrel.
+- [x] Add an Updates section to the Diagnostics tab of
+      `src/components/SettingsDialog.tsx` (current version, check button,
+      status line, download progress, restart-and-install button).
+- [x] Wire the update subscription in `src/App.tsx`.
+- [x] Add an `UpdateButton` component to the `Sidebar` header that appears only
+      when an update is available/downloading/downloaded and performs the
+      phase-appropriate action (download / restart & install).
+- [x] Validate with `npm run typecheck`, `npm test`, and
+      `openspec validate --all --strict`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@xterm/xterm": "^6.1.0-beta.195",
         "colord": "^2.9.3",
         "dompurify": "^3.4.3",
+        "electron-updater": "^6.8.3",
         "marked": "^17.0.3",
         "mermaid": "^11.15.0",
         "monaco-editor": "^0.55.1",
@@ -4553,7 +4554,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -4938,7 +4938,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6763,6 +6762,69 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -8130,7 +8192,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/hachure-fill": {
@@ -8864,7 +8925,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9071,7 +9131,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -9320,6 +9379,19 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -11705,7 +11777,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -12507,6 +12578,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@xterm/xterm": "^6.1.0-beta.195",
     "colord": "^2.9.3",
     "dompurify": "^3.4.3",
+    "electron-updater": "^6.8.3",
     "marked": "^17.0.3",
     "mermaid": "^11.15.0",
     "monaco-editor": "^0.55.1",
@@ -93,6 +94,13 @@
       "buildResources": "build",
       "output": "release"
     },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "johannesjo",
+        "repo": "parallel-code"
+      }
+    ],
     "files": [
       "dist/**/*",
       "dist-electron/**/*",
@@ -127,7 +135,10 @@
       }
     },
     "mac": {
-      "target": "dmg",
+      "target": [
+        "dmg",
+        "zip"
+      ],
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
       "extendInfo": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import { createCtrlWheelZoomHandler } from './lib/wheelZoom';
 import { ArenaOverlay } from './arena/ArenaOverlay';
 import { startDesktopNotificationWatcher } from './store/desktopNotifications';
 import { startPrChecksSubscription } from './store/pr-checks';
+import { startUpdateSubscription } from './store/updates';
 
 const MIN_WINDOW_DIMENSION = 100;
 
@@ -493,6 +494,7 @@ function App() {
     const stopMCPListeners = initMCPListeners();
     const stopNotificationWatcher = startDesktopNotificationWatcher(windowFocused);
     const stopPrChecksSubscription = startPrChecksSubscription();
+    const stopUpdateSubscription = startUpdateSubscription();
 
     // Listen for plan content pushed from backend plan watcher
     const offPlanContent = window.electron.ipcRenderer.on(IPC.PlanContent, (data: unknown) => {
@@ -684,6 +686,7 @@ function App() {
       stopMCPListeners();
       stopNotificationWatcher();
       stopPrChecksSubscription();
+      stopUpdateSubscription();
       offPlanContent();
       offStepsContent();
       unlistenFocusChanged?.();

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal, createEffect, createUniqueId, on } from 'solid-js';
+import { For, Show, Switch, Match, createSignal, createEffect, createUniqueId, on } from 'solid-js';
 import { Dialog } from './Dialog';
 import { CustomThemeDialog } from './CustomThemeDialog';
 import {
@@ -33,6 +33,8 @@ import {
   setDarkTheme,
   setCoordinatorModeEnabled,
   setCoordinatorNotificationDelayMs,
+  updateStatus,
+  checkForUpdates,
 } from '../store/store';
 import { CustomAgentEditor } from './CustomAgentEditor';
 import { mod } from '../lib/platform';
@@ -65,6 +67,30 @@ export function SettingsDialog(props: SettingsDialogProps) {
     setEditingThemeId(null);
     setCustomThemeDialogOpen(true);
   }
+
+  // Styles shared across the Updates section's rows, buttons and messages.
+  const updateRowStyle = {
+    display: 'flex',
+    'align-items': 'center',
+    'justify-content': 'space-between',
+    gap: '12px',
+  };
+  const updateSecondaryButtonStyle = (disabled: boolean) => ({
+    padding: '6px 12px',
+    'border-radius': '6px',
+    border: `1px solid ${theme.border}`,
+    background: theme.bgElevated,
+    color: theme.fg,
+    'font-size': '13px',
+    cursor: disabled ? 'default' : 'pointer',
+    opacity: disabled ? '0.6' : '1',
+  });
+  const updateMessageStyle = (color: string) => ({ 'font-size': '12px', color });
+
+  // Phases that permit a manual check. An allow-list keeps a future phase
+  // from defaulting to "shown" the way excluding non-checkable phases would.
+  const canCheckForUpdates = () =>
+    ['idle', 'checking', 'up-to-date', 'available', 'error'].includes(updateStatus().phase);
 
   // Fetch system fonts when the dialog opens
   createEffect(
@@ -774,6 +800,101 @@ export function SettingsDialog(props: SettingsDialogProps) {
                 </span>
               </div>
             </label>
+          </div>
+
+          <div style={{ display: 'flex', 'flex-direction': 'column', gap: '10px' }}>
+            <div style={{ ...sectionLabelStyle, 'font-weight': '600' }}>Updates</div>
+            <div
+              style={{
+                display: 'flex',
+                'flex-direction': 'column',
+                gap: '10px',
+                padding: '12px',
+                'border-radius': '8px',
+                background: theme.bgInput,
+                border: `1px solid ${theme.border}`,
+              }}
+            >
+              <div style={updateRowStyle}>
+                <span style={{ 'font-size': '14px', color: theme.fg }}>
+                  Current version
+                  <Show when={updateStatus().currentVersion}>
+                    {' '}
+                    <span style={{ color: theme.fgMuted }}>v{updateStatus().currentVersion}</span>
+                  </Show>
+                </span>
+                <Show when={canCheckForUpdates()}>
+                  <button
+                    type="button"
+                    disabled={updateStatus().phase === 'checking'}
+                    onClick={() => void checkForUpdates()}
+                    style={updateSecondaryButtonStyle(updateStatus().phase === 'checking')}
+                  >
+                    {updateStatus().phase === 'checking' ? 'Checking…' : 'Check for updates'}
+                  </button>
+                </Show>
+              </div>
+
+              <Switch>
+                <Match when={updateStatus().phase === 'unsupported'}>
+                  <span style={updateMessageStyle(theme.fgSubtle)}>
+                    Automatic updates are not available for this build. Download the latest release
+                    from GitHub to update.
+                  </span>
+                </Match>
+
+                <Match when={updateStatus().phase === 'up-to-date'}>
+                  <span style={updateMessageStyle(theme.fgSubtle)}>
+                    You are on the latest version.
+                  </span>
+                </Match>
+
+                <Match when={updateStatus().phase === 'available'}>
+                  <span style={updateMessageStyle(theme.fg)}>
+                    Version {updateStatus().latestVersion} is available. Use the update button in
+                    the sidebar to install.
+                  </span>
+                </Match>
+
+                <Match when={updateStatus().phase === 'downloading'}>
+                  <div style={{ display: 'flex', 'flex-direction': 'column', gap: '6px' }}>
+                    <span style={updateMessageStyle(theme.fgSubtle)}>
+                      Downloading update… {updateStatus().downloadPercent}%
+                    </span>
+                    <div
+                      style={{
+                        height: '6px',
+                        'border-radius': '3px',
+                        background: theme.bgElevated,
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <div
+                        style={{
+                          height: '100%',
+                          width: `${updateStatus().downloadPercent}%`,
+                          background: theme.accent,
+                          transition: 'width 0.2s',
+                        }}
+                      />
+                    </div>
+                  </div>
+                </Match>
+
+                <Match when={updateStatus().phase === 'downloaded'}>
+                  <span style={updateMessageStyle(theme.fg)}>
+                    Version {updateStatus().latestVersion} is downloaded. Use the update button in
+                    the sidebar to restart &amp; install.
+                  </span>
+                </Match>
+
+                <Match when={updateStatus().phase === 'error'}>
+                  <span style={updateMessageStyle(theme.error)}>
+                    Update check failed: {updateStatus().error}
+                  </span>
+                </Match>
+              </Switch>
+            </div>
           </div>
         </div>
       </Show>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,6 +38,7 @@ import { EditProjectDialog } from './EditProjectDialog';
 import { ImportWorktreesDialog } from './ImportWorktreesDialog';
 import { SidebarFooter } from './SidebarFooter';
 import { IconButton } from './IconButton';
+import { UpdateButton } from './UpdateButton';
 import { StatusDot } from './StatusDot';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
@@ -401,6 +402,7 @@ export function Sidebar() {
             </span>
           </div>
           <div style={{ display: 'flex', gap: '6px' }}>
+            <UpdateButton />
             <IconButton
               icon={
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">

--- a/src/components/UpdateButton.tsx
+++ b/src/components/UpdateButton.tsx
@@ -1,0 +1,106 @@
+// Sidebar-header update affordance. Stays hidden until the backend updater
+// reports a newer version, then surfaces the one action that phase allows:
+// download when available, restart-and-install once downloaded. While a
+// download is in flight it shows percent and is non-interactive.
+//
+// The detailed status (current version, manual check, "up to date", errors)
+// still lives in Settings → Diagnostics → Updates; this button is only the
+// at-a-glance signal so an available update is discoverable without opening
+// Settings.
+
+import { Show } from 'solid-js';
+import { theme } from '../lib/theme';
+import { updateStatus, downloadUpdate, installUpdate } from '../store/store';
+
+const DownloadIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M8 2v8" />
+    <path d="M4.5 7 8 10.5 11.5 7" />
+    <path d="M3 13h10" />
+  </svg>
+);
+
+const RestartIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M13 8a5 5 0 1 1-1.46-3.54" />
+    <path d="M13 2v3h-3" />
+  </svg>
+);
+
+export function UpdateButton() {
+  const phase = () => updateStatus().phase;
+  const version = () => updateStatus().latestVersion;
+  const visible = () =>
+    phase() === 'available' || phase() === 'downloading' || phase() === 'downloaded';
+
+  const title = () => {
+    const v = version() ? ` ${version()}` : '';
+    if (phase() === 'downloading') return `Downloading update… ${updateStatus().downloadPercent}%`;
+    if (phase() === 'downloaded') return `Restart & install update${v}`;
+    return `Download update${v}`;
+  };
+
+  const handleClick = () => {
+    if (phase() === 'available') downloadUpdate();
+    else if (phase() === 'downloaded') installUpdate();
+    // 'downloading' — no action; the button is a progress indicator.
+  };
+
+  return (
+    <Show when={visible()}>
+      <button
+        class="icon-btn"
+        title={title()}
+        aria-label={title()}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleClick();
+        }}
+        style={{
+          background: phase() === 'downloading' ? 'transparent' : theme.accent,
+          border: `1px solid ${theme.accent}`,
+          color: phase() === 'downloading' ? theme.accent : theme.accentText,
+          cursor: phase() === 'downloading' ? 'default' : 'pointer',
+          'border-radius': '6px',
+          padding: '4px',
+          'font-size': '13px',
+          'line-height': '1',
+          'flex-shrink': '0',
+          display: 'inline-flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+          'min-width': '24px',
+        }}
+      >
+        <Show
+          when={phase() === 'downloading'}
+          fallback={phase() === 'downloaded' ? <RestartIcon /> : <DownloadIcon />}
+        >
+          <span style={{ 'font-size': '10px', 'font-weight': '600' }}>
+            {updateStatus().downloadPercent}%
+          </span>
+        </Show>
+      </button>
+    </Show>
+  );
+}

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -135,6 +135,10 @@ export interface StopPrChecksWatcherArgs {
   taskId: string;
 }
 
+// The main-process updater owns these types; re-exported so the renderer
+// shares one source of truth and cannot drift from it.
+export type { UpdatePhase, UpdateStatus } from '../../electron/ipc/updater';
+
 export interface StepEntry {
   summary: string;
   detail?: string;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -176,6 +176,13 @@ export {
 } from './terminals';
 export { startRemoteAccess, stopRemoteAccess, refreshRemoteStatus } from './remote';
 export {
+  updateStatus,
+  startUpdateSubscription,
+  checkForUpdates,
+  downloadUpdate,
+  installUpdate,
+} from './updates';
+export {
   resolvedBindings,
   allBindings,
   loadKeybindings,

--- a/src/store/updates.ts
+++ b/src/store/updates.ts
@@ -1,0 +1,76 @@
+// Auto-update store slice — tracks the backend updater's status and exposes
+// check / download / install actions to the Settings UI. Status is transient
+// (not persisted): it is re-derived from the main process on every launch.
+
+import { createSignal } from 'solid-js';
+import { invoke, fireAndForget } from '../lib/ipc';
+import { IPC } from '../../electron/ipc/channels';
+import { error } from '../lib/log';
+import type { UpdateStatus } from '../ipc/types';
+
+const INITIAL: UpdateStatus = {
+  phase: 'idle',
+  currentVersion: '',
+  latestVersion: null,
+  downloadPercent: 0,
+  error: null,
+};
+
+// Backend pushes can repeat (e.g. progress events that round to the same
+// percent); a field-wise `equals` keeps the signal from notifying on no-ops.
+function statusEquals(a: UpdateStatus, b: UpdateStatus): boolean {
+  return (
+    a.phase === b.phase &&
+    a.currentVersion === b.currentVersion &&
+    a.latestVersion === b.latestVersion &&
+    a.downloadPercent === b.downloadPercent &&
+    a.error === b.error
+  );
+}
+
+const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>(INITIAL, {
+  equals: statusEquals,
+});
+
+export { updateStatus };
+
+function isUpdateStatus(value: unknown): value is UpdateStatus {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.phase === 'string' && typeof v.currentVersion === 'string';
+}
+
+/** Subscribe to backend update-status pushes and pull the current status.
+ *  Returns a cleanup that detaches the listener. */
+export function startUpdateSubscription(): () => void {
+  const off = window.electron.ipcRenderer.on(IPC.UpdateStatusChanged, (data: unknown) => {
+    if (isUpdateStatus(data)) setUpdateStatus(data);
+  });
+  // The main process runs a silent check after launch — pull whatever it has.
+  invoke<UpdateStatus>(IPC.GetUpdateStatus)
+    .then((s) => {
+      if (isUpdateStatus(s)) setUpdateStatus(s);
+    })
+    .catch((err: unknown) => error('updates', 'failed to load update status', err));
+  return off;
+}
+
+/** Ask the main process to check GitHub Releases for a newer version. */
+export async function checkForUpdates(): Promise<void> {
+  try {
+    const s = await invoke<UpdateStatus>(IPC.CheckForUpdates);
+    if (isUpdateStatus(s)) setUpdateStatus(s);
+  } catch (err) {
+    error('updates', 'check failed', err);
+  }
+}
+
+/** Start downloading the available update. Progress arrives via the subscription. */
+export function downloadUpdate(): void {
+  fireAndForget(IPC.DownloadUpdate);
+}
+
+/** Relaunch the app onto a downloaded update. */
+export function installUpdate(): void {
+  fireAndForget(IPC.QuitAndInstallUpdate);
+}


### PR DESCRIPTION
## What

In-app auto-update — users move to a newer version without deleting and reinstalling the app (#91).

- Silent update check ~10s after launch; manual **Check for updates** in Settings → Diagnostics → Updates.
- A **sidebar header button** appears whenever an update is available / downloading / downloaded — the single apply path: one click downloads, then becomes restart & install. Hidden when up to date, unsupported, or the last check failed.
- The Settings Updates section shows the current version, a manual check, and the last-check outcome (up to date / available / error). It no longer carries its own apply buttons — applying happens via the sidebar button, so there is one apply path.
- Auto-update is a packaged-build capability. Dev runs and the Linux `deb` target (no in-place update channel) report "unavailable" instead of failing.
- Once downloaded, **Restart & install** relaunches onto the new version; a deferred install also applies automatically on next quit.

## How

- New backend module `electron/ipc/updater.ts` wraps `electron-updater`'s `autoUpdater` behind new IPC channels: `check_for_updates`, `download_update`, `quit_and_install_update`, `get_update_status`, and a pushed `update_status_changed` event.
- Renderer store slice `src/store/updates.ts` (status signal + subscription + check/download/install helpers); new `UpdateButton` component in the `Sidebar` header; Updates section in `SettingsDialog`.
- `electron-builder` config: GitHub `publish` target + a macOS `zip` artifact (electron-updater requires `zip` to apply macOS updates).
- No persisted-state or schema change — update status is transient, re-derived from the main process each launch.

## Testing

Verified locally against a generic update server: a packaged build detected a newer published version, downloaded it with progress, and relaunched onto the new version via Restart & install.

## Screenshots

<img width="394" height="161" alt="Screenshot 2026-05-22 at 06 15 31" src="https://github.com/user-attachments/assets/0c4a3bcb-ff76-430d-b22f-9f75f62965bb" />
