### PR TITLE
Fix sidebar selection when jumping with Cmd-number

### DIFF
--- a/src/store/navigation.test.ts
+++ b/src/store/navigation.test.ts
@@ -9,6 +9,9 @@ type MockStore = {
   collapsedTaskOrder: string[];
   projects: Array<{ id: string }>;
   focusedPanel: Record<string, string>;
+  sidebarFocused: boolean;
+  sidebarFocusedProjectId: string | null;
+  sidebarFocusedTaskId: string | null;
 };
 
 let mockStore: MockStore;
@@ -54,6 +57,9 @@ beforeEach(() => {
     collapsedTaskOrder: [],
     projects: [],
     focusedPanel: {},
+    sidebarFocused: false,
+    sidebarFocusedProjectId: null,
+    sidebarFocusedTaskId: null,
   };
 });
 
@@ -127,5 +133,18 @@ describe('jumpToTask', () => {
     mockStore.collapsedTaskOrder = ['task-3'];
     jumpToTask(2);
     expect(mockStore.activeTaskId).toBe(null);
+  });
+
+  it('moves the sidebar focus outline when jumping while the sidebar is focused', () => {
+    mockStore.activeTaskId = 'task-1';
+    mockStore.sidebarFocused = true;
+    mockStore.sidebarFocusedTaskId = 'task-1';
+    mockStore.sidebarFocusedProjectId = 'project-1';
+
+    jumpToTask(2);
+
+    expect(mockStore.activeTaskId).toBe('task-3');
+    expect(mockStore.sidebarFocusedTaskId).toBe('task-3');
+    expect(mockStore.sidebarFocusedProjectId).toBe(null);
   });
 });

--- a/src/store/navigation.ts
+++ b/src/store/navigation.ts
@@ -76,7 +76,12 @@ export function jumpToTask(index: number): void {
   // Index against taskOrder so Cmd+N matches the left-to-right tile order
   // shown in the main area (and the order Cmd+Left/Right cycles through).
   const id = store.taskOrder[index];
-  if (id) setActiveTask(id);
+  if (!id) return;
+  setActiveTask(id);
+  if (store.sidebarFocused) {
+    setStore('sidebarFocusedTaskId', id);
+    setStore('sidebarFocusedProjectId', null);
+  }
 }
 
 export function toggleNewTaskDialog(show?: boolean): void {


### PR DESCRIPTION
## Problem
When a task is selected with the mouse, the sidebar keeps focus and renders the selection outline from `sidebarFocusedTaskId`. Using Cmd-1 through Cmd-9 changed the active task, but left `sidebarFocusedTaskId` pointing at the last mouse-selected row, so the outline stayed on the wrong task.

## Fix
Update `jumpToTask()` so Cmd-number jumps also synchronize the sidebar focused task when the sidebar currently owns focus. The change clears project focus and moves the sidebar outline to the jumped task.

## Verification
- `npm run check`
- `npm test`
- Confirmed the PR branch contains one commit on top of latest `johannesjo/main`, touching only `src/store/navigation.ts` and `src/store/navigation.test.ts`.