### PR TITLE
fix(sidebar): restore status tooltip hit area

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ import { ImportWorktreesDialog } from './ImportWorktreesDialog';
 import { SidebarFooter } from './SidebarFooter';
 import { IconButton } from './IconButton';
 import { UpdateButton } from './UpdateButton';
-import { StatusDot } from './StatusDot';
+import { StatusDot, getDotTooltip } from './StatusDot';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { mod } from '../lib/platform';
@@ -967,6 +967,10 @@ function CoordinatorFolder(props: TaskEntryProps) {
           <div
             class={`task-item${t().closingStatus === 'removing' ? ' task-item-removing' : ' task-item-appearing'}`}
             data-task-index={idx()}
+            title={getDotTooltip(
+              getTaskDotStatus(props.taskId),
+              getTaskAttentionState(props.taskId),
+            )}
             onClick={() => {
               setActiveTask(props.taskId);
               focusSidebar();
@@ -1004,7 +1008,11 @@ function CoordinatorFolder(props: TaskEntryProps) {
           >
             <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
               <CoordinatorIcon />
-              <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" />
+              <StatusDot
+                status={getTaskDotStatus(props.taskId)}
+                size="sm"
+                attention={getTaskAttentionState(props.taskId)}
+              />
               <span style={{ overflow: 'hidden', 'text-overflow': 'ellipsis', flex: '1' }}>
                 {t().name}
               </span>
@@ -1111,7 +1119,11 @@ function CollapsedTaskEntry(props: { taskId: string; indented?: boolean; coordin
               <Show when={isCoordinator()}>
                 <CoordinatorIcon />
               </Show>
-              <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" />
+              <StatusDot
+                status={getTaskDotStatus(props.taskId)}
+                size="sm"
+                attention={getTaskAttentionState(props.taskId)}
+              />
               <Show when={t().gitIsolation === 'direct'}>
                 <span
                   style={{
@@ -1186,6 +1198,10 @@ function TaskRow(props: TaskRowProps) {
           <div
             class={`task-item${t().closingStatus === 'removing' ? ' task-item-removing' : ' task-item-appearing'}`}
             data-task-index={props.indented ? undefined : idx()}
+            title={getDotTooltip(
+              getTaskDotStatus(props.taskId),
+              getTaskAttentionState(props.taskId),
+            )}
             onClick={() => {
               setActiveTask(props.taskId);
               focusSidebar();
@@ -1227,7 +1243,11 @@ function TaskRow(props: TaskRowProps) {
             }}
           >
             <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
-              <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" />
+              <StatusDot
+                status={getTaskDotStatus(props.taskId)}
+                size="sm"
+                attention={getTaskAttentionState(props.taskId)}
+              />
               <Show when={t().gitIsolation === 'direct'}>
                 <span
                   style={{

--- a/src/components/StatusDot.test.ts
+++ b/src/components/StatusDot.test.ts
@@ -23,4 +23,10 @@ describe('StatusDot', () => {
 
     expect(html).toContain('title="Ready for review"');
   });
+
+  it('uses attention state for the rendered tooltip', () => {
+    const html = renderToString(() => StatusDot({ status: 'ready', attention: 'needs_input' }));
+
+    expect(html).toContain('title="Waiting for input"');
+  });
 });


### PR DESCRIPTION
## Problem
Status tooltips were moved from the sidebar task row onto only the 6-8px status dot. The tooltip still existed in the DOM, but users had to hover almost exactly over the tiny dot, so row hover no longer exposed the status explanation shown in the existing screenshot.

## Fix
Restore row-level status tooltip titles for sidebar task rows and coordinator rows, while keeping dot-level titles for compact usages. Sidebar status dots now receive task attention state so tooltip text matches states like waiting for input, active, or error.

## Verification
- `git diff --check`
- `/Users/brooksc/.codex/skills/parallel-code-pr/scripts/run-pr-verification.sh` (`npm run check` and `npm test`)
- Push hook reran `npm run check` and `npm test`
- Confirmed this branch is rebased on latest `johannesjo/main`
- Confirmed the PR contains one commit touching only:
  - `src/components/Sidebar.tsx`
  - `src/components/StatusDot.test.ts`