### PR TITLE
Fix input handoff notification copy

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -39,6 +39,7 @@ export interface PromptInputHandle {
 
 interface PromptInputProps {
   taskId: string;
+  taskName: string;
   agentId: string;
   coordinatedBy?: string;
   coordinatorMode?: boolean;
@@ -563,8 +564,8 @@ export function PromptInput(props: PromptInputProps) {
   createEffect(
     on(
       // eslint-disable-next-line solid/reactivity
-      [questionActive, () => props.controlledBy] as const,
-      ([active, controlledBy], prev) => {
+      [questionActive, () => props.controlledBy, () => props.taskName] as const,
+      ([active, controlledBy, taskName], prev) => {
         const prevActive = prev?.[0] ?? false;
         // Trigger only when the question becomes newly active (false→true).
         // Do NOT re-take control when coordinator regains it while questionActive
@@ -577,7 +578,9 @@ export function PromptInput(props: PromptInputProps) {
         ) {
           setTaskControl(props.taskId, 'human');
           setTaskFocusedPanel(props.taskId, 'ai-terminal');
-          showNotification('Claude needs input. Answer in the terminal, then Release Control.');
+          showNotification(
+            `${taskName} needs input. Answer in the terminal, then Release Control.`,
+          );
         }
       },
     ),

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -341,6 +341,7 @@ export function TaskPanel(props: TaskPanelProps) {
     >
       <PromptInput
         taskId={props.task.id}
+        taskName={props.task.name}
         agentId={firstAgentId()}
         coordinatedBy={props.task.coordinatedBy}
         coordinatorMode={props.task.coordinatorMode}


### PR DESCRIPTION
## Problem
The coordinator handoff notification was hard-coded to say "Claude needs input" even when the running agent is not Claude.

## Fix
Pass the task name into `PromptInput` and use it in the handoff notification copy so the message is generic to the task being controlled.

## Verification
- `git diff --check`
- `npm run check`
- `npm test`
- Confirmed this branch is rebased on latest `johannesjo/main`
- Confirmed the PR contains one commit touching only:
  - `src/components/PromptInput.tsx`
  - `src/components/TaskPanel.tsx`