### PR TITLE
Fix new-task panel UI interactions

### DIFF
--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -605,6 +605,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     >
       <form
         ref={formRef}
+        class="new-task-dialog-form"
         onSubmit={handleSubmit}
         style={{
           display: 'flex',

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -815,7 +815,10 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
             >
               {/* On a load failure the combobox is unmounted, so only point
                   the label at it while it is actually rendered. */}
-              <label for={branchesError() ? undefined : branchInputId} style={sectionLabelStyle}>
+              <label
+                for={branchesError() ? undefined : branchInputId}
+                style={{ ...sectionLabelStyle, 'align-self': 'flex-start' }}
+              >
                 {gitIsolation() === 'worktree' ? 'Base branch' : 'Branch'}
                 <Show when={branchesLoading()}>
                   {' '}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1366,6 +1366,14 @@ textarea::placeholder {
   animation: slideUp 0.22s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
+.new-task-dialog-form {
+  user-select: none;
+}
+
+.new-task-dialog-form :is(input, textarea) {
+  user-select: text;
+}
+
 .file-row:hover {
   background: color-mix(in srgb, var(--accent) 8%, var(--bg-hover));
 }


### PR DESCRIPTION
## Summary

Small fixes for the new-task dialog panel:

- Prevent accidental text selection in the dialog
- Prevent the base-branch label from stretching and triggering the dropdown when clicked outside the intended area