### PR TITLE
fix(coordinator): default coordinator tasks to human control

### DIFF
--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -369,6 +369,48 @@ describe('coordinator control hint persistence', () => {
   });
 });
 
+describe('coordinator control defaults', () => {
+  it('restores coordinator tasks to human control when persisted state omits controlledBy', async () => {
+    mockInvoke.mockResolvedValueOnce(
+      basePayload({
+        taskOrder: ['coord-1'],
+        tasks: {
+          'coord-1': {
+            ...persistedTask(agentDef()),
+            id: 'coord-1',
+            coordinatorMode: true,
+          },
+        },
+        activeTaskId: 'coord-1',
+      }),
+    );
+
+    await loadState();
+
+    expect(store.tasks['coord-1']?.controlledBy).toBe('human');
+  });
+
+  it('restores coordinated child tasks to coordinator control when persisted state omits controlledBy', async () => {
+    mockInvoke.mockResolvedValueOnce(
+      basePayload({
+        taskOrder: ['child-1'],
+        tasks: {
+          'child-1': {
+            ...persistedTask(agentDef()),
+            id: 'child-1',
+            coordinatedBy: 'coord-1',
+          },
+        },
+        activeTaskId: 'child-1',
+      }),
+    );
+
+    await loadState();
+
+    expect(store.tasks['child-1']?.controlledBy).toBe('coordinator');
+  });
+});
+
 describe('projects section collapsed persistence', () => {
   it('defaults to expanded when not in saved state', async () => {
     setStore('projectsCollapsed', true);

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -676,7 +676,8 @@ export async function loadState(): Promise<void> {
           propagateSkipPermissions: pt.propagateSkipPermissions,
           coordinatedBy: pt.coordinatedBy,
           controlledBy:
-            pt.controlledBy ?? (pt.coordinatorMode || pt.coordinatedBy ? 'coordinator' : undefined),
+            pt.controlledBy ??
+            (pt.coordinatedBy ? 'coordinator' : pt.coordinatorMode ? 'human' : undefined),
           // Defer TerminalView spawn until StartMCPServer/hydrateTask complete —
           // the config file has a stale token from the previous session until then.
           mcpStartupStatus:
@@ -777,7 +778,8 @@ export async function loadState(): Promise<void> {
           propagateSkipPermissions: pt.propagateSkipPermissions,
           coordinatedBy: pt.coordinatedBy,
           controlledBy:
-            pt.controlledBy ?? (pt.coordinatorMode || pt.coordinatedBy ? 'coordinator' : undefined),
+            pt.controlledBy ??
+            (pt.coordinatedBy ? 'coordinator' : pt.coordinatorMode ? 'human' : undefined),
           mcpStartupStatus:
             pt.coordinatorMode || pt.coordinatedBy ? ('pending' as const) : undefined,
           mcpConfigPath: pt.mcpConfigPath,

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -281,7 +281,7 @@ export async function createTask(opts: CreateTaskOptions): Promise<string> {
     propagateSkipPermissions: opts.coordinatorMode
       ? (opts.propagateSkipPermissions ?? false)
       : undefined,
-    controlledBy: opts.coordinatorMode ? 'coordinator' : undefined,
+    controlledBy: opts.coordinatorMode ? 'human' : undefined,
     mcpConfigPath,
     mcpLaunchArgs,
     // Coordinator tasks call StartMCPServer before entering the store, so MCP is ready immediately.


### PR DESCRIPTION
## Summary
- initialize newly created coordinator tasks with human control instead of coordinator control
- when restoring persisted tasks without a control owner, default coordinator tasks to human control and coordinated child tasks to coordinator control
- add persistence tests for the missing-controlledBy restore defaults

