### PR TITLE
fix(task-title-bar): show merge target branch in button tooltip

### DIFF
--- a/src/arena/ResultsScreen.tsx
+++ b/src/arena/ResultsScreen.tsx
@@ -268,7 +268,7 @@ export function ResultsScreen() {
                   </div>
                 </div>
 
-                {/* Merge into main */}
+                {/* Merge into the project's detected main branch */}
                 <Show when={competitor.branchName && merge.hasChanges(competitor.id)}>
                   <div class="arena-result-column-merge">
                     <Show
@@ -295,7 +295,7 @@ export function ResultsScreen() {
                           <circle cx="8" cy="13" r="2" />
                           <path d="M4 6v1c0 2 4 4 4 4M12 6v1c0 2-4 4-4 4" />
                         </svg>
-                        {merge.merging() ? 'Merging...' : 'Merge into main'}
+                        {merge.merging() ? 'Merging...' : 'Merge'}
                       </button>
                     </Show>
                   </div>

--- a/src/components/TaskTitleBar.tsx
+++ b/src/components/TaskTitleBar.tsx
@@ -30,10 +30,6 @@ interface TaskTitleBarProps {
   onTitleEditRef: (h: EditableTextHandle) => void;
 }
 
-function getMergeButtonTitle(task: Pick<Task, 'baseBranch'>): string {
-  return `Merge into ${task.baseBranch ?? 'main'}`;
-}
-
 export function TaskTitleBar(props: TaskTitleBarProps) {
   const dockerBadgeLabel = () => getTaskDockerBadgeLabel(props.task.dockerSource);
   const titleLabel = () => {
@@ -130,7 +126,7 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
               </svg>
             }
             onClick={() => props.onMerge()}
-            title={getMergeButtonTitle(props.task)}
+            title={props.task.baseBranch ? `Merge into ${props.task.baseBranch}` : 'Merge'}
           />
           <div style={{ position: 'relative', display: 'inline-flex' }}>
             <Show

--- a/src/components/TaskTitleBar.tsx
+++ b/src/components/TaskTitleBar.tsx
@@ -30,6 +30,10 @@ interface TaskTitleBarProps {
   onTitleEditRef: (h: EditableTextHandle) => void;
 }
 
+function getMergeButtonTitle(task: Pick<Task, 'baseBranch'>): string {
+  return `Merge into ${task.baseBranch ?? 'main'}`;
+}
+
 export function TaskTitleBar(props: TaskTitleBarProps) {
   const dockerBadgeLabel = () => getTaskDockerBadgeLabel(props.task.dockerSource);
   const titleLabel = () => {
@@ -126,7 +130,7 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
               </svg>
             }
             onClick={() => props.onMerge()}
-            title="Merge into main"
+            title={getMergeButtonTitle(props.task)}
           />
           <div style={{ position: 'relative', display: 'inline-flex' }}>
             <Show


### PR DESCRIPTION
## Summary

Show the actual merge target branch (from `task.baseBranch`) in the merge button tooltip, instead of hardcoding "main".

## Changes

- Extract `getMergeButtonTitle()` helper in `TaskTitleBar.tsx`
- Tooltip now displays `Merge into ${baseBranch}` with fallback to "main"

