### PR TITLE
fix(progress): count only merged tasks today

### DIFF
--- a/openspec/changes/fix-progress-merged-metrics/proposal.md
+++ b/openspec/changes/fix-progress-merged-metrics/proposal.md
@@ -1,0 +1,47 @@
+# Fix Progress "Completed today" to count merges, not closures
+
+## Why
+
+The sidebar Progress panel's "Completed today" counter increments on **any**
+task removal, because `recordTaskCompleted()` is called unconditionally inside
+`removeTaskFromStore()` (`src/store/tasks.ts:504`) - the convergence point for
+all UI task-removal paths. Closing an empty or unmerged task therefore inflates
+a counter that users read as "work I finished today."
+
+The panel also pairs two metrics on different time axes: "Completed today"
+(daily, resets) sits beside "Merged to main/master" (lifetime cumulative line
+totals). Side by side, both read as "today," which misrepresents the cumulative
+number.
+
+## What changes
+
+- Move the daily-counter increment from `removeTaskFromStore()` onto the UI
+  merge path: increment only inside `mergeTask()` when `cleanup === true` and
+  the merge succeeded. Closing a task no longer increments it.
+- Rename the counter API to match its real meaning: `recordTaskCompleted` ->
+  `recordTaskMerged`, `getCompletedTasksTodayCount` -> `getMergedTasksTodayCount`.
+  Daily-reset logic is unchanged.
+- Relabel the UI: "Completed today" -> "Merged today".
+- Relabel the second card "Merged to main/master" -> "Merged (total)" to
+  disambiguate the time axis. **No data-model change** - it stays a lifetime
+  cumulative line total; no persisted-state migration.
+
+## Out of scope (known limitations, stated deliberately)
+
+- **Coordinator subtask merges** flow through the backend coordinator merge
+  (`electron/mcp/coordinator.ts`) -> `MCP_TaskClosed`, which removes the subtask
+  via an inline path that never touches the renderer `mergeTask()`. They are
+  uncounted today and remain uncounted. No regression; not addressed here.
+- **Arena merges** call `IPC.MergeTask` directly, bypassing renderer
+  `mergeTask()`. Also uncounted today and after.
+- Re-axising "Merged (total)" to a daily tally (the issue's secondary proposal)
+  is deferred - it requires a date key on the line totals plus a migration of
+  existing users' cumulative values.
+- The contribution-calendar enhancement is a separate future proposal.
+
+## Impact
+
+- New capability `progress-metrics`.
+- Files: `src/store/completion.ts`, `src/store/tasks.ts`,
+  `src/components/SidebarFooter.tsx`. Test mocks in `src/store/tasks.test.ts`
+  and `src/store/notifications.test.ts` reference the renamed function.

--- a/openspec/changes/fix-progress-merged-metrics/specs/progress-metrics/spec.md
+++ b/openspec/changes/fix-progress-merged-metrics/specs/progress-metrics/spec.md
@@ -1,0 +1,44 @@
+# Progress Metrics Specification
+
+## ADDED Requirements
+
+### Requirement: "Merged today" counts only tasks merged with cleanup today
+
+The sidebar Progress panel SHALL display a "Merged today" count that increments
+only when a task is successfully merged through the UI merge path with cleanup
+enabled. The count SHALL reset to zero at the start of each local calendar day.
+
+#### Scenario: Merging a task with cleanup increments the count
+
+- **WHEN** the user merges the active task through the UI and cleanup is enabled
+- **AND** the merge succeeds
+- **THEN** the "Merged today" count increases by one
+
+#### Scenario: Closing an empty or unmerged task does not increment the count
+
+- **WHEN** the user closes a task that was not merged (including an empty task,
+  an unmerged task, or a current-branch-mode task)
+- **THEN** the "Merged today" count is unchanged
+
+#### Scenario: Merging without cleanup does not increment the count
+
+- **WHEN** the user merges a task but does not enable cleanup
+- **THEN** the task remains and the "Merged today" count is unchanged
+
+#### Scenario: Count resets on a new day
+
+- **WHEN** the local calendar day has changed since the count was last recorded
+- **THEN** the displayed "Merged today" count is zero until the next merge
+
+### Requirement: "Merged (total)" shows lifetime merged line totals
+
+The Progress panel SHALL display a "Merged (total)" card showing the cumulative
+lines added and removed across all UI merges, persisted across sessions. The
+label SHALL make the lifetime (non-daily) scope distinguishable from the
+"Merged today" count.
+
+#### Scenario: Merged line totals accumulate across sessions
+
+- **WHEN** a task is merged through the UI with a non-zero diff
+- **THEN** the added and removed line totals increase by that diff
+- **AND** the totals persist across app restarts

--- a/openspec/changes/fix-progress-merged-metrics/tasks.md
+++ b/openspec/changes/fix-progress-merged-metrics/tasks.md
@@ -1,0 +1,19 @@
+# Tasks - Fix Progress "Completed today" to count merges, not closures
+
+- [x] Rename `recordTaskCompleted` -> `recordTaskMerged` and
+      `getCompletedTasksTodayCount` -> `getMergedTasksTodayCount` in
+      `src/store/completion.ts`; keep the daily-reset logic unchanged.
+- [x] Remove the unconditional `recordTaskCompleted()` call from
+      `removeTaskFromStore()` in `src/store/tasks.ts`.
+- [x] Call `recordTaskMerged()` inside `mergeTask()` only when `cleanup === true`
+      and after the merge has succeeded (i.e. in the existing `cleanup` block,
+      paired with the successful merge result).
+- [x] Update the renamed import in `src/store/tasks.ts` and update the function
+      mocks in `src/store/tasks.test.ts` and `src/store/notifications.test.ts`.
+- [x] Relabel the Progress panel in `src/components/SidebarFooter.tsx`:
+      "Completed today" -> "Merged today", "Merged to main/master" ->
+      "Merged (total)"; update the memo name to `getMergedTasksTodayCount`.
+- [x] Add/adjust a unit test asserting that closing an empty/unmerged task does
+      NOT increment the counter, and merging with cleanup does.
+- [x] Validate with `npm run typecheck`, `npm test`, and
+      `openspec validate --all --strict`.

--- a/src/components/SidebarFooter.tsx
+++ b/src/components/SidebarFooter.tsx
@@ -1,7 +1,7 @@
 import { createMemo, createEffect, onCleanup, Show } from 'solid-js';
 import {
   store,
-  getCompletedTasksTodayCount,
+  getMergedTasksTodayCount,
   getMergedLineTotals,
   toggleHelpDialog,
   toggleArena,
@@ -14,7 +14,7 @@ import { sf } from '../lib/fontScale';
 import { alt, mod } from '../lib/platform';
 
 export function SidebarFooter() {
-  const completedTasksToday = createMemo(() => getCompletedTasksTodayCount());
+  const mergedTasksToday = createMemo(() => getMergedTasksTodayCount());
   const mergedLines = createMemo(() => getMergedLineTotals());
   const hasCoordinator = createMemo(() => hasAnyCoordinatorTask());
 
@@ -97,7 +97,7 @@ export function SidebarFooter() {
               color: theme.fgMuted,
             }}
           >
-            <span>Completed today</span>
+            <span>Merged today</span>
             <span
               style={{
                 color: theme.fg,
@@ -105,7 +105,7 @@ export function SidebarFooter() {
                 'font-variant-numeric': 'tabular-nums',
               }}
             >
-              {completedTasksToday()}
+              {mergedTasksToday()}
             </span>
           </div>
           <div
@@ -121,7 +121,7 @@ export function SidebarFooter() {
               color: theme.fgMuted,
             }}
           >
-            <span>Merged to main/master</span>
+            <span>Merged (total)</span>
             <span
               style={{
                 color: theme.fg,

--- a/src/store/completion.ts
+++ b/src/store/completion.ts
@@ -2,7 +2,7 @@ import { produce } from 'solid-js/store';
 import { getLocalDateKey } from '../lib/date';
 import { store, setStore } from './core';
 
-export function recordTaskCompleted(): void {
+export function recordTaskMerged(): void {
   const today = getLocalDateKey();
   setStore(
     produce((s) => {
@@ -16,7 +16,7 @@ export function recordTaskCompleted(): void {
   );
 }
 
-export function getCompletedTasksTodayCount(): number {
+export function getMergedTasksTodayCount(): number {
   return store.completedTaskDate === getLocalDateKey() ? store.completedTaskCount : 0;
 }
 

--- a/src/store/notifications.test.ts
+++ b/src/store/notifications.test.ts
@@ -83,7 +83,7 @@ vi.mock('./taskStatus', () => ({
 }));
 vi.mock('./completion', () => ({
   recordMergedLines: vi.fn(),
-  recordTaskCompleted: vi.fn(),
+  recordTaskMerged: vi.fn(),
 }));
 vi.mock('../lib/log', () => ({ warn: vi.fn() }));
 vi.mock('../lib/clean-task-name', () => ({ cleanTaskName: vi.fn() }));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -174,7 +174,7 @@ export {
 export type { TaskAttentionState, TaskDotStatus } from './taskStatus';
 export { showNotification, clearNotification } from './notification';
 export { startPrChecksSubscription, getPrChecks, type PrChecksState } from './pr-checks';
-export { getCompletedTasksTodayCount, getMergedLineTotals } from './completion';
+export { getMergedTasksTodayCount, getMergedLineTotals } from './completion';
 export {
   createTerminal,
   closeTerminal,

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -105,7 +105,7 @@ vi.mock('./taskStatus', () => ({
 }));
 vi.mock('./completion', () => ({
   recordMergedLines: vi.fn(),
-  recordTaskCompleted: vi.fn(),
+  recordTaskMerged: vi.fn(),
 }));
 vi.mock('../lib/log', () => ({ warn: vi.fn() }));
 vi.mock('../lib/clean-task-name', () => ({ cleanTaskName: vi.fn() }));
@@ -133,6 +133,7 @@ import {
   setTaskControl,
   collapseTask,
   closeTask,
+  mergeTask,
   sendPrompt,
   pasteDelayMs,
   markTaskUserActivity,
@@ -147,6 +148,7 @@ import {
   clearTaskLandingReview,
 } from './tasks';
 import { getCoordinatorChildren } from './sidebar-order';
+import { recordTaskMerged } from './completion';
 import { markAgentSpawned, rescheduleTaskStatusPolling } from './taskStatus';
 import { saveState } from './persistence';
 import { getProjectBranchPrefix, getProjectPath, isProjectMissing } from './projects';
@@ -984,6 +986,72 @@ describe('closeTask — IPC cleanup ordering', () => {
     expect(mockTasks['child-1'].mcpStartupError).toBeUndefined();
     expect(mockTasks['child-1'].signalDoneReceived).toBe(true);
     expect(mockTasks['child-1'].needsReview).toBe(true);
+  });
+});
+
+describe('recordTaskMerged counts merges with cleanup, not closures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetStore.mockImplementation((...args: unknown[]) => applySetStore(...args));
+    mockInvoke.mockResolvedValue(undefined);
+    vi.mocked(getProjectPath).mockReturnValue('/repo');
+  });
+
+  it('closing an unmerged task does NOT increment the counter', async () => {
+    mockTasks['task-1'] = {
+      agentIds: [],
+      shellAgentIds: [],
+      gitIsolation: 'direct',
+      projectId: 'proj-1',
+    };
+
+    await closeTask('task-1');
+
+    expect(recordTaskMerged).not.toHaveBeenCalled();
+  });
+
+  it('merging with cleanup increments the counter once', async () => {
+    mockTasks['task-1'] = {
+      agentIds: [],
+      shellAgentIds: [],
+      gitIsolation: 'worktree',
+      projectId: 'proj-1',
+      branchName: 'task/task-1',
+      worktreePath: '/repo/.worktrees/task-1',
+      baseBranch: 'main',
+    };
+    mockInvoke.mockImplementation((channel: string) => {
+      if (channel === IPC.MergeTask) {
+        return Promise.resolve({ lines_added: 10, lines_removed: 2 });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await mergeTask('task-1', { cleanup: true });
+
+    expect(recordTaskMerged).toHaveBeenCalledTimes(1);
+  });
+
+  it('merging without cleanup does NOT increment the counter', async () => {
+    mockTasks['task-1'] = {
+      agentIds: [],
+      shellAgentIds: [],
+      gitIsolation: 'worktree',
+      projectId: 'proj-1',
+      branchName: 'task/task-1',
+      worktreePath: '/repo/.worktrees/task-1',
+      baseBranch: 'main',
+    };
+    mockInvoke.mockImplementation((channel: string) => {
+      if (channel === IPC.MergeTask) {
+        return Promise.resolve({ lines_added: 10, lines_removed: 2 });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await mergeTask('task-1', { cleanup: false });
+
+    expect(recordTaskMerged).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -15,7 +15,7 @@ import {
   isAgentIdle,
   rescheduleTaskStatusPolling,
 } from './taskStatus';
-import { recordMergedLines, recordTaskCompleted } from './completion';
+import { recordMergedLines, recordTaskMerged } from './completion';
 import { warn as logWarn } from '../lib/log';
 import { cleanTaskName } from '../lib/clean-task-name';
 import type {
@@ -501,8 +501,6 @@ const REMOVE_ANIMATION_MS = 300;
 const RESTORED_AGENT_SPAWN_STAGGER_MS = 1_000;
 
 function removeTaskFromStore(taskId: string, agentIds: string[]): void {
-  recordTaskCompleted();
-
   // Stop the plan file watcher (fs.FSWatcher + poll interval) on the backend.
   // This is the single convergence point for all task removal paths (close,
   // merge+cleanup, current-branch-mode close), so placing it here prevents leaks
@@ -600,6 +598,7 @@ export async function mergeTask(
   recordMergedLines(mergeResult.lines_added, mergeResult.lines_removed);
 
   if (cleanup) {
+    recordTaskMerged();
     await Promise.allSettled(
       [...agentIds, ...shellAgentIds].map((id) => invoke(IPC.KillAgent, { agentId: id })),
     );


### PR DESCRIPTION
Fixes #151

## Summary

- Rename the daily sidebar counter from "Completed today" to "Merged today".
- Increment that counter only after a successful UI merge with cleanup enabled.
- Relabel the cumulative line totals as "Merged (total)" so the lifetime scope is clear.
- Add OpenSpec coverage and unit tests for close vs merge cleanup behavior.

## Root Cause

`recordTaskCompleted()` was called from `removeTaskFromStore()`, the shared path for closing tasks, merge cleanup, and current-branch task removal. That made plain closes look like completed work in the Progress panel.

## Validation

- `npx prettier --check src/components/SidebarFooter.tsx src/store/completion.ts src/store/notifications.test.ts src/store/store.ts src/store/tasks.test.ts src/store/tasks.ts openspec/changes/fix-progress-merged-metrics/proposal.md openspec/changes/fix-progress-merged-metrics/tasks.md openspec/changes/fix-progress-merged-metrics/specs/progress-metrics/spec.md`
- `npm run typecheck`
- `npm test` (67 files passed, 2 skipped; 1300 tests passed, 24 skipped)
- `openspec validate fix-progress-merged-metrics --strict`
- pre-commit hook: `npm run check`
- pre-push hook: `npm run check` and `npm test`
