### PR TITLE
feat(ask-code): upgrade MiniMax model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - **See every session in one place** — switch context without losing momentum.
 - **Control everything keyboard-first** — every action has a shortcut, mouse optional.
 - **Monitor progress from your phone** — scan a QR code, watch agents work over Wi-Fi or Tailscale.
-- **Ask about code with any LLM** — the inline code Q&A feature supports [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default) or [MiniMax](https://www.minimax.io/) M2.7 (204K context) — configurable in Settings.
+- **Ask about code with any LLM** — the inline code Q&A feature supports [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default) or [MiniMax](https://www.minimax.io/) M3 (204K context) — configurable in Settings.
 
 <details>
 <summary><strong>How does it compare?</strong></summary>

--- a/electron/ipc/ask-code-minimax.test.ts
+++ b/electron/ipc/ask-code-minimax.test.ts
@@ -164,7 +164,7 @@ describe('askAboutCodeMinimax', () => {
     );
   });
 
-  it('uses MiniMax-M2.7 model', async () => {
+  it('uses MiniMax-M3 model', async () => {
     const { win, messages } = makeMockWin();
 
     mockFetch.mockResolvedValueOnce(makeStreamResponse('data: [DONE]\n\n'));

--- a/electron/ipc/ask-code-minimax.ts
+++ b/electron/ipc/ask-code-minimax.ts
@@ -11,7 +11,7 @@ const MAX_PROMPT_LENGTH = 50_000;
 const MAX_CONCURRENT = 5;
 const TIMEOUT_MS = 120_000;
 const MINIMAX_API_URL = 'https://api.minimax.io/v1/chat/completions';
-export const MINIMAX_MODEL = 'MiniMax-M2.7';
+export const MINIMAX_MODEL = 'MiniMax-M3';
 
 const activeRequests = new Map<string, AbortController>();
 const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -516,7 +516,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   }}
                 >
                   <option value="claude">Claude Code (claude CLI)</option>
-                  <option value="minimax">MiniMax (M2.7)</option>
+                  <option value="minimax">MiniMax (M3)</option>
                 </select>
               </label>
               <Show when={store.askCodeProvider === 'minimax'}>
@@ -551,7 +551,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
               </Show>
               <span style={{ 'font-size': '11px', color: theme.fgSubtle }}>
                 {store.askCodeProvider === 'minimax'
-                  ? 'Uses MiniMax M2.7 (204K context) via the OpenAI-compatible API — no Claude Code CLI required.'
+                  ? 'Uses MiniMax M3 (204K context) via the OpenAI-compatible API — no Claude Code CLI required.'
                   : 'Uses the claude CLI to answer questions about selected code. Requires Claude Code to be installed.'}
               </span>
             </div>


### PR DESCRIPTION
## Summary

Bumps the bundled MiniMax model id from `MiniMax-M2.7` to `MiniMax-M3` in the inline code Q&A backend (`electron/ipc/ask-code-minimax.ts`). M3 is the current Minimax model and is a drop-in replacement on the OpenAI-compatible endpoint at `api.minimax.io` — same 204K context window, same request schema, same temperature constraints, same `MINIMAX_API_KEY` env var, so the rest of the provider code is unchanged.

## Changes

- `electron/ipc/ask-code-minimax.ts` — `MINIMAX_MODEL` constant flipped to `MiniMax-M3`.
- `electron/ipc/ask-code-minimax.test.ts` — model-assertion test renamed to match (still asserts against the exported `MINIMAX_MODEL`, so the test stays semantically equivalent).
- `src/components/SettingsDialog.tsx` — provider dropdown option and the explainer copy below it now read "M3" instead of "M2.7".
- `README.md` — feature blurb in "Why Parallel Code?" mentions M3 instead of M2.7.

No changes to the API URL, temperature range, streaming flow, API key handling, or any non-minimax provider.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npx vitest run electron/ipc/ask-code-minimax.test.ts` — 12/12 pass (including the renamed model-id assertion and the temperature-range assertion).