### PR TITLE
fix(worktree): prevent symlinked dirs from being committed via .git/info/exclude

### DIFF
--- a/electron/ipc/git-symlink-excludes.test.ts
+++ b/electron/ipc/git-symlink-excludes.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockExecFileSync, mockReadFileSync, mockAppendFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockAppendFileSync: vi.fn(),
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFileSync: mockExecFileSync,
+    execFile: vi.fn(),
+    spawn: vi.fn(() => ({
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readFileSync: mockReadFileSync,
+      appendFileSync: mockAppendFileSync,
+      promises: actual.promises,
+    },
+  };
+});
+
+import { ensureSymlinkExcludes } from './git.js';
+
+function makeEnoentError(): NodeJS.ErrnoException {
+  return Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+}
+
+describe('ensureSymlinkExcludes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing when symlinkNames is empty', () => {
+    ensureSymlinkExcludes('/worktree', []);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('adds header and root-anchored entry on first call', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('# parallel-code: worktree symlinks');
+    expect(appended).toContain('/node_modules');
+  });
+
+  it('uses root-anchored patterns without trailing slash so symlinks are matched', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules', '.env']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/node_modules\n');
+    expect(appended).toContain('/.env\n');
+    // No trailing slash — must match symlinks, not just directories
+    expect(appended).not.toContain('/node_modules/');
+    expect(appended).not.toContain('/.env/');
+  });
+
+  it('writes to the info/exclude file inside --git-common-dir', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    const [excludePath] = mockAppendFileSync.mock.calls[0] as [string];
+    expect(excludePath).toMatch(/\.git[/\\]info[/\\]exclude$/);
+  });
+
+  it('resolves an absolute commonDir returned by git rev-parse', () => {
+    mockExecFileSync.mockReturnValueOnce('/abs/repo/.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    const [excludePath] = mockAppendFileSync.mock.calls[0] as [string];
+    expect(excludePath).toBe('/abs/repo/.git/info/exclude');
+  });
+
+  it('resolves a relative commonDir against the worktree path', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    const [excludePath] = mockAppendFileSync.mock.calls[0] as [string];
+    expect(excludePath).toBe('/worktree/.git/info/exclude');
+  });
+
+  it('appends without repeating the header when it is already present', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('# parallel-code: worktree symlinks\n/existing\n');
+
+    ensureSymlinkExcludes('/worktree', ['.env']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).not.toContain('# parallel-code: worktree symlinks');
+    expect(appended).toContain('/.env');
+  });
+
+  it('skips names that are already present in the exclude file', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/node_modules\n');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('adds only the missing entries when some names are already excluded', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/node_modules\n');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules', '.env']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).not.toContain('/node_modules');
+    expect(appended).toContain('/.env');
+  });
+
+  it('handles ENOENT on the exclude file and still writes the block', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw makeEnoentError();
+    });
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/node_modules');
+  });
+
+  it('is a no-op when git rev-parse fails (not a git repo)', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('not a git repository');
+    });
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('adds a newline prefix when the existing file does not end with one', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('# some existing content');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended.startsWith('\n')).toBe(true);
+  });
+
+  it('does not add a redundant newline prefix when file already ends with one', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('# some existing content\n');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended.startsWith('\n')).toBe(false);
+  });
+
+  it('adds multiple names in a single appendFileSync call', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['node_modules', '.env', '.cursor']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/node_modules');
+    expect(appended).toContain('/.env');
+    expect(appended).toContain('/.cursor');
+  });
+});

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -165,6 +165,13 @@ const SANDBOX_EXCLUDE_PATTERNS = [
 const SANDBOX_EXCLUDE_HEADER = '# parallel-code: sandbox bind-mount artifacts';
 const seededSandboxExcludes = new Set<string>();
 
+/**
+ * Header written once per repo when symlink excludes are first added. Each
+ * symlinked name is appended individually on subsequent calls so new names
+ * added in later worktrees are also covered.
+ */
+const SYMLINK_EXCLUDE_HEADER = '# parallel-code: worktree symlinks';
+
 // --- Internal helpers ---
 
 async function detectMainBranch(repoRoot: string): Promise<string> {
@@ -749,6 +756,7 @@ export async function createWorktree(
   // Symlink selected directories. `.claude` is handled separately below — it
   // can't be a symlink because Claude Code's bwrap sandbox binds specific
   // entries inside it, and bwrap refuses to bind-mount at symlink paths.
+  const createdSymlinks: string[] = [];
   for (const name of symlinkDirs) {
     if (name === '.claude') continue;
     // Reject names that could escape the worktree directory
@@ -759,6 +767,7 @@ export async function createWorktree(
       if (!fs.existsSync(source)) continue;
       if (fs.existsSync(target)) continue;
       fs.symlinkSync(source, target);
+      createdSymlinks.push(name);
     } catch (err) {
       console.warn(`Failed to symlink directory '${name}' into worktree:`, err);
     }
@@ -766,6 +775,7 @@ export async function createWorktree(
 
   ensureClaudeSandboxFiles(worktreePath, repoRoot);
   ensureSandboxExcludes(worktreePath);
+  ensureSymlinkExcludes(worktreePath, createdSymlinks);
 
   return { path: worktreePath, branch: branchName };
 }
@@ -898,6 +908,61 @@ export function ensureSandboxExcludes(worktreePath: string): void {
   try {
     fs.appendFileSync(excludePath, block);
     seededSandboxExcludes.add(commonDir);
+  } catch (err) {
+    console.warn(`Failed to append to ${excludePath}:`, err);
+  }
+}
+
+/**
+ * Add root-anchored exclude entries for symlinked directory names to
+ * `.git/info/exclude`. This ensures the symlink is invisible to git even when
+ * the project's `.gitignore` uses a trailing-slash form (e.g. `node_modules/`)
+ * which only matches real directories, not symlinks. Entries are added
+ * incrementally — new names from later worktrees are appended without
+ * duplicating already-present entries.
+ */
+export function ensureSymlinkExcludes(worktreePath: string, symlinkNames: string[]): void {
+  if (symlinkNames.length === 0) return;
+
+  let commonDir: string;
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: worktreePath,
+      encoding: 'utf8',
+      timeout: 3000,
+    }).trim();
+    commonDir = path.isAbsolute(out) ? out : path.join(worktreePath, out);
+  } catch {
+    return;
+  }
+
+  const excludePath = path.join(commonDir, 'info', 'exclude');
+  let existing = '';
+  try {
+    existing = fs.readFileSync(excludePath, 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`Failed to read ${excludePath}:`, err);
+      return;
+    }
+  }
+
+  // Root-anchored, no trailing slash — matches the symlink file itself, not
+  // just directories, so `node_modules/` gitignore entries can't sneak through.
+  const toAdd = symlinkNames
+    .map((name) => `/${name}`)
+    .filter((pattern) => !existing.includes(pattern));
+
+  if (toAdd.length === 0) return;
+
+  const needsHeader = !existing.includes(SYMLINK_EXCLUDE_HEADER);
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const header = needsHeader ? SYMLINK_EXCLUDE_HEADER + '\n' : '';
+  const block = prefix + header + toAdd.join('\n') + '\n';
+
+  try {
+    fs.appendFileSync(excludePath, block);
   } catch (err) {
     console.warn(`Failed to append to ${excludePath}:`, err);
   }


### PR DESCRIPTION
## Problem

When a task is created with symlinked directories (e.g. `node_modules`),
git may treat the symlink as an untracked file and accidentally commit it.

**Root cause:** Many projects gitignore `node_modules` with a trailing slash
(`node_modules/`). Git's trailing-slash pattern only matches real
*directories* — a symlink named `node_modules` is a special file, not a
directory, so it doesn't match. When the agent runs `git add -A` during
normal work, the symlink is included and committed. On close/merge, the user
sees an unexpected outstanding commit containing `node_modules`.

**Why the `.gitignore` check doesn't catch it:** `getGitIgnoredDirs()` uses
`git check-ignore -q <name>` on the real directory in the main repo, which
correctly returns "ignored". But in the *worktree*, the same name refers to a
symlink, which the trailing-slash pattern doesn't match.

## Fix

After creating each symlink in `createWorktree()`, call the new
`ensureSymlinkExcludes()` function, which appends root-anchored patterns
without a trailing slash (e.g. `/node_modules`) to `.git/info/exclude`.

Root-anchored patterns without a trailing slash match **both symlinks and
directories**, so the exclusion holds regardless of how the project
`.gitignore` is written. This is the same mechanism already used by
`ensureSandboxExcludes()` for bwrap bind-mount artifacts.

The function is incremental: entries already present are not duplicated, and
new symlink names from later worktrees are added in subsequent calls (unlike
the all-at-once sandbox approach).

## Changes

**`electron/ipc/git.ts`**
- Added `SYMLINK_EXCLUDE_HEADER` constant
- Added `ensureSymlinkExcludes(worktreePath, symlinkNames)` — mirrors the
  structure of `ensureSandboxExcludes` but appends entries incrementally
- Updated `createWorktree()` to track which symlinks were successfully created
  and pass them to `ensureSymlinkExcludes`

## Tests

**`electron/ipc/git-symlink-excludes.test.ts`** — 14 new cases covering:

| Test | What it verifies |
|---|---|
| empty list | no-ops without touching git or fs |
| first call | writes header + root-anchored entry |
| no trailing slash | `/node_modules\n` not `/node_modules/\n` (symlink invariant) |
| correct file path | writes to `<commonDir>/info/exclude` |
| absolute commonDir | uses path as-is when git returns an absolute path |
| relative commonDir | joins against worktreePath |
| header already present | appends entry without duplicating header |
| name already present | skips entirely — no appendFileSync call |
| partial add | only appends the missing names |
| ENOENT on exclude file | treats as empty file, still writes |
| git rev-parse failure | silent no-op |
| newline prefix | adds `\n` when file doesn't end with one |
| no redundant prefix | no leading `\n` when file already ends with one |
| multiple names | single appendFileSync call for all new entries |

All 1118 tests pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)