### PR TITLE
fix(autosend): block auto-send during mid-frame redraw; fix plural MCP pattern; fix Codex args fixture

### DIFF
--- a/src/components/prompt-autosend-readiness.test.ts
+++ b/src/components/prompt-autosend-readiness.test.ts
@@ -22,4 +22,26 @@ describe('isStartupBlockingAutoSend', () => {
     const tail = 'Starting MCP servers (0/2): parallel-code\x1b[2J\x1b[H›';
     expect(isStartupBlockingAutoSend(tail)).toBe(false);
   });
+
+  it('blocks while Codex is booting multiple MCP servers (plural form)', () => {
+    expect(isStartupBlockingAutoSend('Booting MCP servers: parallel-code\n›')).toBe(true);
+  });
+
+  it('blocks during mid-redraw: screen-clear issued but new frame not yet drawn', () => {
+    // Codex emits \x1b[2J\x1b[H to start a new frame, but no content has arrived yet.
+    // normalizeCurrentFrame returns '' in this window — treat as blocking so we
+    // don't start stability checks against an empty snapshot.
+    const tail = 'model: loading...\x1b[2J\x1b[H';
+    expect(isStartupBlockingAutoSend(tail)).toBe(true);
+  });
+
+  it('blocks during cursor-home-only mid-redraw (no screen clear)', () => {
+    const tail = 'Starting MCP servers (1/2)\x1b[H';
+    expect(isStartupBlockingAutoSend(tail)).toBe(true);
+  });
+
+  it('does not block when the current frame has visible non-startup content', () => {
+    // A screen clear followed by something unrelated to startup is ready.
+    expect(isStartupBlockingAutoSend('\x1b[2J\x1b[H›')).toBe(false);
+  });
 });

--- a/src/components/prompt-autosend-readiness.ts
+++ b/src/components/prompt-autosend-readiness.ts
@@ -2,12 +2,16 @@ import { normalizeCurrentFrame } from '../store/taskStatus';
 
 const STARTUP_BLOCKING_PATTERNS: RegExp[] = [
   /\bmodel:\s*loading\b/i,
-  /\bBooting\s+MCP\s+server\b/i,
+  /\bBooting\s+MCP\s+servers?\b/i,
   /\bStarting\s+MCP\s+servers?\b/i,
 ];
 
 export function isStartupBlockingAutoSend(tail: string): boolean {
   const frame = normalizeCurrentFrame(tail);
-  if (!frame) return false;
+  // An empty frame means a screen-clear or cursor-home was just emitted but
+  // the new frame content hasn't arrived yet (mid-redraw).  Treat this as
+  // blocking so we don't start stability checks against an empty snapshot
+  // that will immediately fail once real content fills in.
+  if (!frame) return true;
   return STARTUP_BLOCKING_PATTERNS.some((re) => re.test(frame));
 }

--- a/src/lib/agent-args.test.ts
+++ b/src/lib/agent-args.test.ts
@@ -7,7 +7,7 @@ const codexAgent = {
   name: 'Codex',
   description: 'Codex agent',
   command: 'codex',
-  args: ['resume', '--last'],
+  args: [],
   resume_args: ['resume', '--last'],
   skip_permissions_args: ['--dangerously-bypass-approvals-and-sandbox'],
 };
@@ -23,7 +23,7 @@ const claudeAgent = {
 };
 
 describe('buildTaskAgentArgs', () => {
-  it('uses explicit MCP launch args when provided', () => {
+  it('uses explicit MCP launch args when provided (new task)', () => {
     expect(
       buildTaskAgentArgs(
         codexAgent,
@@ -35,6 +35,24 @@ describe('buildTaskAgentArgs', () => {
         false,
       ),
     ).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--config',
+      'mcp_servers.parallel-code={ command = "node" }',
+    ]);
+  });
+
+  it('uses explicit MCP launch args when provided (resumed task)', () => {
+    expect(
+      buildTaskAgentArgs(
+        codexAgent,
+        {
+          skipPermissions: true,
+          mcpConfigPath: '/tmp/mcp.json',
+          mcpLaunchArgs: ['--config', 'mcp_servers.parallel-code={ command = "node" }'],
+        },
+        true,
+      ),
+    ).toEqual([
       'resume',
       '--last',
       '--dangerously-bypass-approvals-and-sandbox',
@@ -43,7 +61,7 @@ describe('buildTaskAgentArgs', () => {
     ]);
   });
 
-  it('does not fall back to --mcp-config for Codex', () => {
+  it('does not fall back to --mcp-config for Codex (new task, no args)', () => {
     expect(
       buildTaskAgentArgs(
         codexAgent,
@@ -52,6 +70,19 @@ describe('buildTaskAgentArgs', () => {
           mcpConfigPath: '/tmp/mcp.json',
         },
         false,
+      ),
+    ).toEqual([]);
+  });
+
+  it('uses resume_args for Codex when resuming', () => {
+    expect(
+      buildTaskAgentArgs(
+        codexAgent,
+        {
+          skipPermissions: false,
+          mcpConfigPath: '/tmp/mcp.json',
+        },
+        true,
       ),
     ).toEqual(['resume', '--last']);
   });


### PR DESCRIPTION
## Investigation

User reported: initial prompt is not auto-sent to Codex on a simple (non-coordinator) new task.

The auto-send mechanism in `PromptInput` watches for Codex's `›` prompt marker, runs stability checks, then calls `sendPrompt`. There are three related bugs that can cause the prompt to be lost or never sent.

---

## Bug 1 — Premature stability-check start during mid-frame redraw (root cause)

Codex is an Ink/TUI app. When it starts a new screen frame it emits a cursor-home or screen-clear sequence (`\x1b[H`, `\x1b[2J`) **before** writing the new frame content. During this brief window `normalizeCurrentFrame(tail)` returns an empty string — the last frame-start marker has nothing after it yet.

The old `isStartupBlockingAutoSend` treated an empty frame as "not blocking":
```typescript
if (!frame) return false;  // wrong — mid-redraw, not ready
```

Combined with the fact that the **previous** frame's `›` is still in the tail buffer, `tryFireAgentReadyCallback` fires, `onReady()` runs, and `startStabilityChecks()` starts with an **empty snapshot**. After `STABILITY_MAX_FAILURES` (3) instability rounds the check proceeds regardless of `isStable`, eventually reaching `trySend()` while Codex may still be mid-startup-redraw. If the prompt lands in this window Codex can discard it. Since `promptAppearedInOutput`'s timeout result is not checked, `autoSentInitialPrompt` is still set — blocking any retry.

**Fix:** treat an empty normalized frame as blocking (`return true`). The callback re-registers and fires again once the new frame content is actually drawn, at which point a proper stability check can proceed.

---

## Bug 2 — `Booting MCP server` pattern didn't match plural

```typescript
/\bBooting\s+MCP\s+server\b/i  // "server\b" — word boundary prevents matching "servers"
```

Changed to `/\bBooting\s+MCP\s+servers?\b/i` to handle both singular and plural.

---

## Bug 3 — Test fixture for Codex agent had wrong `args`

`codexAgent` in `agent-args.test.ts` had `args: ['resume', '--last']` which is actually the `resume_args` value. The real Codex agent definition has `args: []` — a new task spawns `codex` with no additional arguments. Tests were split into new-task vs resumed-task cases and updated.

---

## Changes

**`src/components/prompt-autosend-readiness.ts`**
- `if (!frame) return false` → `if (!frame) return true` with explanatory comment
- `Booting MCP server\b` → `Booting MCP servers?\b`

**`src/components/prompt-autosend-readiness.test.ts`** — 4 new test cases:
- blocks plural "Booting MCP servers"
- blocks during mid-redraw (screen-clear with nothing after)
- blocks during cursor-home-only mid-redraw
- does not block when current frame has visible non-startup content

**`src/lib/agent-args.test.ts`**
- Fixed `codexAgent.args` from `['resume', '--last']` to `[]`
- Split the MCP-args test into new-task and resumed-task variants
- Added explicit resumed-task test showing `resume_args` are used

All 1110 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)