### PR TITLE
fix(release): publish auto-update metadata via electron-builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,11 @@ jobs:
           cache: npm
 
       - run: npm ci
-      - run: npm run build -- --publish never
 
-      - name: Upload artifacts
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: |
-            release/*.AppImage
-            release/*.deb
-          draft: true
+      - name: Build and publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build -- --publish always
 
   build-macos:
     needs: create-release
@@ -89,20 +84,14 @@ jobs:
 
       - run: npm ci
 
-      - name: Build and sign
+      - name: Build, sign, and publish
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           APPLE_API_KEY: ${{ runner.temp }}/private_keys/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: npm run build -- --universal --publish never
-
-      - name: Upload artifacts
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: release/*.dmg
-          draft: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build -- --universal --publish always
 
       - name: Cleanup signing artifacts
         if: always()


### PR DESCRIPTION
## Summary
- Switch both build jobs in `.github/workflows/release.yml` from `electron-builder --publish never` to `--publish always` so electron-builder's GitHubPublisher uploads `latest-mac.yml`, `latest-linux.yml`, the macOS `.zip`, and `.blockmap` files alongside the binaries.
- Drop the now-redundant `softprops/action-gh-release` upload steps; their globs only matched `*.dmg`/`*.AppImage`/`*.deb` and silently dropped the updater metadata.
- Keep the upfront `create-release` job so auto-generated release notes still land first; electron-builder finds the existing draft by tag and reuses it.

## Why
In-app auto-update on macOS 404s on `https://github.com/johannesjo/parallel-code/releases/download/v<ver>/latest-mac.yml` (#168). The `electron-updater` client (`electron/ipc/updater.ts`) and `build.publish` config in `package.json` are both correct — only the workflow was dropping the metadata. Verified by listing v1.10.0 assets: only `*.deb`, `*.dmg`, `*.AppImage` were uploaded; no `latest-*.yml`, no `*-mac.zip`, no `*.blockmap`.

The new pattern is what the electron-builder docs recommend and is forward-compatible with v27 (which deprecates implicit `--publish`).

## Notes for shipping
- This PR fixes v1.10.1+ onwards. Existing v1.10.0 installs will keep 404'ing until users manually upgrade — uploading a hand-crafted `latest-mac.yml` retroactively requires byte-identical artifacts that we no longer have.
- Token: uses the default `secrets.GITHUB_TOKEN`. `permissions: contents: write` is already set on the workflow.

## Test plan
- [ ] Tag a release candidate (e.g. `v1.10.1-rc.1`) and confirm `latest-mac.yml`, `latest-linux.yml`, `*-mac.zip`, and `*.blockmap` all appear in the release assets.
- [ ] Install the previous version locally, then trigger the in-app update check and confirm it no longer 404s and offers the new version.
- [ ] Confirm the auto-generated release notes from the `create-release` job are still present (electron-builder should reuse the draft, not overwrite the body).