### PR TITLE
fix(audit): resolve issue #157 — coordinator replay, store cycles, CI gates

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -10,8 +10,10 @@ module.exports = {
       from: { path: '^src/' },
       to: {
         path: '^electron/',
-        // Allow importing the shared IPC channel enum (channels.ts is a pure enum, no Node/Electron deps)
-        pathNot: '^electron/ipc/channels\\.ts',
+        // Allow importing pure shared modules with no Node/Electron deps:
+        //   - electron/ipc/channels.ts — IPC channel enum
+        //   - electron/mcp/prompt-detect.ts — regex-only prompt detector reused by the renderer task-status pipeline
+        pathNot: ['^electron/ipc/channels\\.ts', '^electron/mcp/prompt-detect\\.ts'],
       },
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,14 @@ jobs:
 
       - run: npm ci
 
-      - name: Typecheck
-        run: npm run typecheck
+      - name: Check (compile + typecheck + lint + format)
+        run: npm run check
 
-      - name: Lint
-        run: npm run lint
+      - name: Lint (architecture)
+        run: npm run lint:arch
 
-      - name: Format check
-        run: npm run format:check
+      - name: Lint (dead code)
+        run: npm run lint:dead
+
+      - name: Test
+        run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,2 @@
-onlyBuiltDependencies:
-  - esbuild
-
 ; Use a conventional-commit message for `npm version` so the commit-msg hook accepts it
 message=chore(release): %s

--- a/electron/mcp/coordinator.test.ts
+++ b/electron/mcp/coordinator.test.ts
@@ -5525,6 +5525,24 @@ describe('Coordinator waitForSignalDone — requestId replay after transport fai
     expect(result.taskId).toBe('task-1');
   });
 
+  it('same requestId returns cached timed-out result after a timeout (no second live wait)', async () => {
+    await coordinator.createTask({ name: 'test', prompt: 'do', coordinatorTaskId: 'coord-1' });
+
+    const requestId = 'replay-timeout-id';
+    // First call times out — no unconsumed signal, short timeout.
+    const result1 = await coordinator.waitForSignalDone('coord-1', 25, requestId);
+    expect(result1.timedOut).toBe(true);
+
+    // Retry with the same requestId must replay the cached timed-out result
+    // instead of registering a fresh waiter — otherwise a stale HTTP retry
+    // would inflate activeSignalWaitCounts and re-block the coordinator.
+    const beforeRetry = Date.now();
+    const result2 = await coordinator.waitForSignalDone('coord-1', 10_000, requestId);
+    const elapsed = Date.now() - beforeRetry;
+    expect(result2).toEqual(result1);
+    expect(elapsed).toBeLessThan(100);
+  });
+
   it('cached result for coord-A does not replay for coord-B with the same requestId', async () => {
     coordinator.registerCoordinator('coord-2', 'proj-1');
 

--- a/electron/mcp/coordinator.ts
+++ b/electron/mcp/coordinator.ts
@@ -229,6 +229,8 @@ export class Coordinator {
             this.suppressPendingNotificationForTask(task);
             task.reviewNotificationQueued = true;
             const remaining = this.countRemaining(coordinatorId);
+            // The resolver IS `complete` from waitForSignalDone — it handles
+            // finishSignalWait, replay-cache write, and timer cleanup itself.
             firstAnyResolver({
               taskId: task.id,
               name: task.name,
@@ -236,7 +238,6 @@ export class Coordinator {
               signalDoneAt: new Date().toISOString(),
               remaining,
             });
-            this.finishSignalWait(coordinatorId);
           }
           this.maybeQueueReviewNotification(task, 'exited', exitCode ?? null);
           break;
@@ -1926,6 +1927,7 @@ export class Coordinator {
       this.suppressPendingNotificationForTask(task);
       task.reviewNotificationQueued = true;
       const remaining = this.countRemaining(coordinatorId);
+      // Resolver `complete` from waitForSignalDone handles finishSignalWait.
       firstAnyResolver({
         taskId: task.id,
         name: task.name,
@@ -1933,7 +1935,6 @@ export class Coordinator {
         signalDoneAt: new Date().toISOString(),
         remaining,
       });
-      this.finishSignalWait(coordinatorId);
     }
     this.clearAgentBuffers(task.agentId);
     // Delete per-task MCP config tmp file
@@ -2227,7 +2228,11 @@ export class Coordinator {
         signalDoneAt: new Date().toISOString(),
         remaining: 0,
       };
-      for (const resolve of anyResolvers) resolve(syntheticResult);
+      // Snapshot first — each resolver is `complete` from waitForSignalDone,
+      // which splices itself out of the array, and mutating during iteration
+      // would skip waiters.
+      const snapshot = [...anyResolvers];
+      for (const resolve of snapshot) resolve(syntheticResult);
     }
     this.anySignalResolvers.delete(coordinatorTaskId);
     this.activeSignalWaitCounts.delete(coordinatorTaskId);
@@ -2376,6 +2381,7 @@ export class Coordinator {
       // Suppress before finishSignalWait so it doesn't re-stage
       this.suppressPendingNotificationForTask(task);
       const remaining = this.countRemaining(coordinatorId);
+      // Resolver `complete` from waitForSignalDone handles finishSignalWait.
       firstAnyResolver({
         taskId,
         name: task.name,
@@ -2383,7 +2389,6 @@ export class Coordinator {
         signalDoneAt: (task.signalDoneAt ?? new Date()).toISOString(),
         remaining,
       });
-      this.finishSignalWait(coordinatorId);
       // Tell renderer — coordinator already gets result via MCP return value, no UI notification needed
       this.notifyRenderer(IPC.MCP_TaskStateSync, {
         taskId,
@@ -2529,20 +2534,28 @@ export class Coordinator {
 
     return new Promise((resolve) => {
       const timerRef = { value: undefined as ReturnType<typeof setTimeout> | undefined };
+      let settled = false;
 
-      const wrapped = (result: WaitForSignalDoneResult) => {
+      // Single termination path: timer cleanup, resolver removal, active-wait
+      // bookkeeping, replay-cache write, and promise resolution all happen here
+      // regardless of whether the result came from a signal, an exit, a
+      // coordinator close, or the timeout. Idempotent — repeated calls are a
+      // no-op so external callers can shift the resolver out before invoking.
+      const complete = (result: WaitForSignalDoneResult) => {
+        if (settled) return;
+        settled = true;
         if (timerRef.value !== undefined) clearTimeout(timerRef.value);
+        const resolvers = this.anySignalResolvers.get(coordinatorTaskId);
+        if (resolvers) {
+          const idx = resolvers.indexOf(complete);
+          if (idx >= 0) resolvers.splice(idx, 1);
+        }
+        this.finishSignalWait(coordinatorTaskId);
         if (requestId) this.recentlyDelivered.set(coordinatorTaskId, requestId, result);
         resolve(result);
       };
 
       timerRef.value = setTimeout(() => {
-        const resolvers = this.anySignalResolvers.get(coordinatorTaskId);
-        if (resolvers) {
-          const idx = resolvers.indexOf(wrapped);
-          if (idx >= 0) resolvers.splice(idx, 1);
-        }
-        this.finishSignalWait(coordinatorTaskId);
         logWarn('coordinator.signal_wait', `wait_for_signal_done timed out after ${timeoutMs}ms`, {
           coordinatorTaskId,
           reason: 'timeout',
@@ -2550,7 +2563,7 @@ export class Coordinator {
           activeWaitCount: this.activeSignalWaitCounts.get(coordinatorTaskId) ?? 0,
         });
         const remaining = this.countRemaining(coordinatorTaskId);
-        resolve({ remaining, timedOut: true });
+        complete({ remaining, timedOut: true });
       }, timeoutMs);
 
       let resolvers = this.anySignalResolvers.get(coordinatorTaskId);
@@ -2558,7 +2571,7 @@ export class Coordinator {
         resolvers = [];
         this.anySignalResolvers.set(coordinatorTaskId, resolvers);
       }
-      resolvers.push(wrapped);
+      resolvers.push(complete);
     });
   }
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,6 +27,11 @@ const config: KnipConfig = {
     'concurrently',
     'wait-on',
   ],
+  ignoreBinaries: [
+    // Optional security tooling invoked from npm scripts; installed on demand
+    'semgrep',
+    'gitleaks',
+  ],
   // Test files are allowed to have unused exports (test helpers, fixtures)
   ignoreExportsUsedInFile: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.3",
-        "@types/dompurify": "^3.0.5",
         "@types/node": "^25.3.0",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.18.1",
@@ -3457,16 +3456,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/dompurify": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3585,8 +3574,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
-    "@types/dompurify": "^3.0.5",
     "@types/node": "^25.3.0",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.18.1",

--- a/scripts/test-semgrep-filesystem-safety.mjs
+++ b/scripts/test-semgrep-filesystem-safety.mjs
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 /* global console, process */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const probe = spawnSync('semgrep', ['--version'], { stdio: 'ignore' });
+if (probe.error?.code === 'ENOENT' || probe.status !== 0) {
+  console.error(
+    'semgrep not installed — install with `brew install semgrep` or `pip install semgrep`',
+  );
+  process.exit(1);
+}
 
 const tmp = mkdtempSync(join(tmpdir(), 'parallel-code-semgrep-'));
 

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -3,22 +3,32 @@ import { store, setStore } from './core';
 import { setActiveTask } from './navigation';
 import { computeSidebarTaskOrder } from './sidebar-order';
 import { uncollapseTask } from './tasks';
+import {
+  AI_TERMINAL_PANEL,
+  aiTerminalPanels,
+  defaultPanelFor,
+  getTaskFocusedPanel,
+  isAiTerminalPanel,
+  setTaskFocusedPanel,
+  triggerFocus,
+} from './focused-panel';
 
-// Imperative focus registry: components register focus callbacks on mount
-const focusRegistry = new Map<string, () => void>();
+// Re-export panel/focus-registry helpers from their new home so existing
+// importers of './focus' keep working without a cycle through focused-panel.
+export {
+  AI_TERMINAL_PANEL,
+  aiTerminalPanels,
+  defaultPanelFor,
+  getTaskFocusedPanel,
+  isAiTerminalPanel,
+  registerFocusFn,
+  setTaskFocusedPanel,
+  triggerFocus,
+  unregisterFocusFn,
+} from './focused-panel';
+export { isPanelFocused, isPanelFocusedPrefix } from './focused-panel';
+
 const actionRegistry = new Map<string, () => void>();
-
-export function registerFocusFn(key: string, fn: () => void): void {
-  focusRegistry.set(key, fn);
-}
-
-export function unregisterFocusFn(key: string): void {
-  focusRegistry.delete(key);
-}
-
-export function triggerFocus(key: string): void {
-  focusRegistry.get(key)?.();
-}
 
 export function registerAction(key: string, fn: () => void): void {
   actionRegistry.set(key, fn);
@@ -38,27 +48,8 @@ export function triggerAction(key: string): void {
 //    left, changed-files/notes/steps/shell anchor the right, and AI panes are
 //    repeated down the left columns so left/right crossings stay consistent.
 
-const AI_TERMINAL_PANEL = 'ai-terminal';
 const SHELL_PANEL_PREFIX = 'shell:';
 const SHELL_TOOLBAR_PANEL_PREFIX = 'shell-toolbar:';
-
-function aiTerminalPanelId(agentId: string): string {
-  return `${AI_TERMINAL_PANEL}:${agentId}`;
-}
-
-function isAiTerminalPanel(panel: string): boolean {
-  return panel === AI_TERMINAL_PANEL || panel.startsWith(`${AI_TERMINAL_PANEL}:`);
-}
-
-function agentIdFromAiTerminalPanel(panel: string): string | null {
-  return panel.startsWith(`${AI_TERMINAL_PANEL}:`)
-    ? panel.slice(AI_TERMINAL_PANEL.length + 1)
-    : null;
-}
-
-function aiTerminalPanels(task: { agentIds: string[] }): string[] {
-  return task.agentIds.length > 0 ? task.agentIds.map(aiTerminalPanelId) : [AI_TERMINAL_PANEL];
-}
 
 function shellToolbarPanels(task: { projectId: string }): string[] {
   const bookmarkCount =
@@ -100,16 +91,6 @@ function pickTargetTerminalFamilyPanel(
   }
 
   return null;
-}
-
-function normalizeTaskPanel(taskId: string, panel: string): string {
-  if (panel !== AI_TERMINAL_PANEL) return panel;
-  const task = store.tasks[taskId];
-  if (!task) return panel;
-  const activeAgentId = store.activeAgentId;
-  const agentId =
-    activeAgentId && task.agentIds.includes(activeAgentId) ? activeAgentId : task.agentIds[0];
-  return agentId ? aiTerminalPanelId(agentId) : panel;
 }
 
 /** Cells that belong to the left column in split mode. */
@@ -178,12 +159,6 @@ function pickTopRightColumnTarget(grid: string[][]): string | null {
   return null;
 }
 
-/** The panel to focus when navigating into a task or terminal. */
-function defaultPanelFor(panelId: string): string {
-  const task = store.tasks[panelId];
-  return task ? aiTerminalPanels(task)[0] : 'terminal';
-}
-
 interface GridPos {
   row: number;
   col: number;
@@ -195,48 +170,6 @@ function findInGrid(grid: string[][], cell: string): GridPos | null {
     if (col !== -1) return { row, col };
   }
   return null;
-}
-
-export function getTaskFocusedPanel(taskId: string): string {
-  return normalizeTaskPanel(taskId, store.focusedPanel[taskId] ?? defaultPanelFor(taskId));
-}
-
-/**
- * Whether a panel within a task should render its focus border. Returns false
- * when focus has moved to the sidebar/placeholder, even though the previously
- * focused panel is still recorded in `focusedPanel[taskId]`.
- */
-export function isPanelFocused(taskId: string, panel: string): boolean {
-  if (store.sidebarFocused || store.placeholderFocused) return false;
-  if (store.activeTaskId !== taskId) return false;
-  return store.focusedPanel[taskId] === panel;
-}
-
-export function isPanelFocusedPrefix(taskId: string, prefix: string): boolean {
-  if (store.sidebarFocused || store.placeholderFocused) return false;
-  if (store.activeTaskId !== taskId) return false;
-  return store.focusedPanel[taskId]?.startsWith(prefix) ?? false;
-}
-
-export function setTaskFocusedPanel(taskId: string, panel: string): void {
-  const normalizedPanel = normalizeTaskPanel(taskId, panel);
-  setStore('focusedPanel', taskId, normalizedPanel);
-  const agentId = agentIdFromAiTerminalPanel(normalizedPanel);
-  if (agentId && store.tasks[taskId]?.agentIds.includes(agentId)) {
-    setStore('activeAgentId', agentId);
-    setStore('tasks', taskId, 'selectedAgentId', agentId);
-  }
-  setStore('sidebarFocused', false);
-  setStore('placeholderFocused', false);
-  triggerFocus(`${taskId}:${normalizedPanel}`);
-  scrollTaskIntoView(taskId);
-}
-
-function scrollTaskIntoView(taskId: string): void {
-  requestAnimationFrame(() => {
-    const el = document.querySelector<HTMLElement>(`[data-task-id="${CSS.escape(taskId)}"]`);
-    el?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'instant' });
-  });
 }
 
 export function focusSidebar(): void {

--- a/src/store/focused-panel.ts
+++ b/src/store/focused-panel.ts
@@ -1,0 +1,93 @@
+import { store, setStore } from './core';
+
+// Imperative focus registry: components register focus callbacks on mount.
+const focusRegistry = new Map<string, () => void>();
+
+export function registerFocusFn(key: string, fn: () => void): void {
+  focusRegistry.set(key, fn);
+}
+
+export function unregisterFocusFn(key: string): void {
+  focusRegistry.delete(key);
+}
+
+export function triggerFocus(key: string): void {
+  focusRegistry.get(key)?.();
+}
+
+export const AI_TERMINAL_PANEL = 'ai-terminal';
+
+export function aiTerminalPanelId(agentId: string): string {
+  return `${AI_TERMINAL_PANEL}:${agentId}`;
+}
+
+export function isAiTerminalPanel(panel: string): boolean {
+  return panel === AI_TERMINAL_PANEL || panel.startsWith(`${AI_TERMINAL_PANEL}:`);
+}
+
+function agentIdFromAiTerminalPanel(panel: string): string | null {
+  return panel.startsWith(`${AI_TERMINAL_PANEL}:`)
+    ? panel.slice(AI_TERMINAL_PANEL.length + 1)
+    : null;
+}
+
+export function aiTerminalPanels(task: { agentIds: string[] }): string[] {
+  return task.agentIds.length > 0 ? task.agentIds.map(aiTerminalPanelId) : [AI_TERMINAL_PANEL];
+}
+
+function normalizeTaskPanel(taskId: string, panel: string): string {
+  if (panel !== AI_TERMINAL_PANEL) return panel;
+  const task = store.tasks[taskId];
+  if (!task) return panel;
+  const activeAgentId = store.activeAgentId;
+  const agentId =
+    activeAgentId && task.agentIds.includes(activeAgentId) ? activeAgentId : task.agentIds[0];
+  return agentId ? aiTerminalPanelId(agentId) : panel;
+}
+
+export function defaultPanelFor(panelId: string): string {
+  const task = store.tasks[panelId];
+  return task ? aiTerminalPanels(task)[0] : 'terminal';
+}
+
+export function getTaskFocusedPanel(taskId: string): string {
+  return normalizeTaskPanel(taskId, store.focusedPanel[taskId] ?? defaultPanelFor(taskId));
+}
+
+/**
+ * Whether a panel within a task should render its focus border. Returns false
+ * when focus has moved to the sidebar/placeholder, even though the previously
+ * focused panel is still recorded in `focusedPanel[taskId]`.
+ */
+export function isPanelFocused(taskId: string, panel: string): boolean {
+  if (store.sidebarFocused || store.placeholderFocused) return false;
+  if (store.activeTaskId !== taskId) return false;
+  return store.focusedPanel[taskId] === panel;
+}
+
+export function isPanelFocusedPrefix(taskId: string, prefix: string): boolean {
+  if (store.sidebarFocused || store.placeholderFocused) return false;
+  if (store.activeTaskId !== taskId) return false;
+  return store.focusedPanel[taskId]?.startsWith(prefix) ?? false;
+}
+
+export function setTaskFocusedPanel(taskId: string, panel: string): void {
+  const normalizedPanel = normalizeTaskPanel(taskId, panel);
+  setStore('focusedPanel', taskId, normalizedPanel);
+  const agentId = agentIdFromAiTerminalPanel(normalizedPanel);
+  if (agentId && store.tasks[taskId]?.agentIds.includes(agentId)) {
+    setStore('activeAgentId', agentId);
+    setStore('tasks', taskId, 'selectedAgentId', agentId);
+  }
+  setStore('sidebarFocused', false);
+  setStore('placeholderFocused', false);
+  triggerFocus(`${taskId}:${normalizedPanel}`);
+  scrollTaskIntoView(taskId);
+}
+
+function scrollTaskIntoView(taskId: string): void {
+  requestAnimationFrame(() => {
+    const el = document.querySelector<HTMLElement>(`[data-task-id="${CSS.escape(taskId)}"]`);
+    el?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'instant' });
+  });
+}

--- a/src/store/navigation.ts
+++ b/src/store/navigation.ts
@@ -1,5 +1,5 @@
 import { store, setStore } from './core';
-import { getTaskFocusedPanel, setTaskFocusedPanel } from './focus';
+import { getTaskFocusedPanel, setTaskFocusedPanel } from './focused-panel';
 import { showNotification } from './notification';
 import { pickAndAddProject } from './projects';
 import { reorderTask } from './tasks';

--- a/src/store/project-cleanup.ts
+++ b/src/store/project-cleanup.ts
@@ -1,0 +1,30 @@
+import { store } from './core';
+import { removeProject } from './projects';
+import { closeTask } from './tasks';
+
+/**
+ * Close every task that belongs to `projectId` (coordinators last so children
+ * are gone first), then remove the project itself. If any close fails, the
+ * project is kept so the user can retry without losing project metadata.
+ */
+export async function removeProjectWithTasks(projectId: string): Promise<void> {
+  const taskIds = store.taskOrder.filter((tid) => store.tasks[tid]?.projectId === projectId);
+  const collapsedTaskIds = store.collapsedTaskOrder.filter(
+    (tid) => store.tasks[tid]?.projectId === projectId,
+  );
+
+  // Close tasks sequentially to avoid concurrent git operations on the same repo.
+  // Must happen before removeProject() since closeTask needs the project path.
+  const allIds = [...taskIds, ...collapsedTaskIds];
+  const isCoordinator = (tid: string) => store.tasks[tid]?.coordinatorMode === true;
+  const ordered = [...allIds.filter((tid) => !isCoordinator(tid)), ...allIds.filter(isCoordinator)];
+  for (const tid of ordered) {
+    // closeTask handles and stores its own errors, so this should not throw.
+    await closeTask(tid);
+  }
+
+  const hasRemainingTasks = allIds.some((tid) => store.tasks[tid]?.projectId === projectId);
+  if (hasRemainingTasks) return;
+
+  removeProject(projectId);
+}

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -3,7 +3,6 @@ import { openDialog } from '../lib/dialog';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { store, setStore } from './core';
-import { closeTask } from './tasks';
 import type { Project } from './types';
 import { sanitizeBranchPrefix } from '../lib/branch-name';
 
@@ -100,32 +99,6 @@ export function getProjectBranchPrefix(projectId: string): string {
 
 export function getProjectPath(projectId: string): string | undefined {
   return store.projects.find((p) => p.id === projectId)?.path;
-}
-
-export async function removeProjectWithTasks(projectId: string): Promise<void> {
-  // Collect task IDs belonging to this project BEFORE removing anything
-  const taskIds = store.taskOrder.filter((tid) => store.tasks[tid]?.projectId === projectId);
-  const collapsedTaskIds = store.collapsedTaskOrder.filter(
-    (tid) => store.tasks[tid]?.projectId === projectId,
-  );
-
-  // Close tasks sequentially to avoid concurrent git operations on the same repo.
-  // Must happen before removeProject() since closeTask needs the project path.
-  // Coordinators must come last so their children are already closed first.
-  const allIds = [...taskIds, ...collapsedTaskIds];
-  const isCoordinator = (tid: string) => store.tasks[tid]?.coordinatorMode === true;
-  const ordered = [...allIds.filter((tid) => !isCoordinator(tid)), ...allIds.filter(isCoordinator)];
-  for (const tid of ordered) {
-    // closeTask handles and stores its own errors, so this should not throw.
-    await closeTask(tid);
-  }
-
-  // If any tasks failed to close, keep the project so users can retry.
-  const hasRemainingTasks = allIds.some((tid) => store.tasks[tid]?.projectId === projectId);
-  if (hasRemainingTasks) return;
-
-  // Now remove the project itself
-  removeProject(projectId);
 }
 
 export function projectIsGitRepo(projectId: string): boolean {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -4,7 +4,6 @@ export {
   getProject,
   addProject,
   removeProject,
-  removeProjectWithTasks,
   updateProject,
   getProjectPath,
   getProjectBranchPrefix,
@@ -15,6 +14,7 @@ export {
   projectIsGitRepo,
   PASTEL_HUES,
 } from './projects';
+export { removeProjectWithTasks } from './project-cleanup';
 export {
   loadAgents,
   addAgentToTask,

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -4,7 +4,7 @@ import { IPC } from '../../electron/ipc/channels';
 import { store, setStore, cleanupPanelEntries } from './core';
 import { effectiveAgentId } from './agent-select';
 import { saveState } from './persistence';
-import { setTaskFocusedPanel } from './focus';
+import { setTaskFocusedPanel } from './focused-panel';
 import { getProject, getProjectPath, getProjectBranchPrefix, isProjectMissing } from './projects';
 import { setPendingShellCommand } from '../lib/bookmarks';
 import {

--- a/src/store/terminals.ts
+++ b/src/store/terminals.ts
@@ -4,7 +4,7 @@ import { IPC } from '../../electron/ipc/channels';
 import { store, setStore, cleanupPanelEntries } from './core';
 import { effectiveAgentId } from './agent-select';
 import { clearAgentActivity } from './taskStatus';
-import { triggerFocus, getTaskFocusedPanel } from './focus';
+import { triggerFocus, getTaskFocusedPanel } from './focused-panel';
 import type { Terminal } from './types';
 import { warn as logWarn } from '../lib/log';
 

--- a/src/store/ui.test.ts
+++ b/src/store/ui.test.ts
@@ -69,7 +69,7 @@ vi.mock('./navigation', () => ({
   setActiveTask: mocks.setActiveTask,
 }));
 
-vi.mock('./focus', () => ({
+vi.mock('./focused-panel', () => ({
   setTaskFocusedPanel: mocks.setTaskFocusedPanel,
 }));
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -2,7 +2,7 @@ import { batch } from 'solid-js';
 import { produce } from 'solid-js/store';
 import { store, setStore } from './core';
 import { setActiveTask } from './navigation';
-import { setTaskFocusedPanel } from './focus';
+import { setTaskFocusedPanel } from './focused-panel';
 import type { LookPreset, AppearanceMode } from '../lib/look';
 import { osIsDark } from '../lib/os-appearance';
 import type { CustomTheme } from '../lib/custom-theme';


### PR DESCRIPTION
Closes the highest-priority correctness and quality-gate items from issue #157. Each commit maps to one finding; tests, typecheck, lint, lint:arch, lint:dead, and format:check all pass locally.

## Summary

- **Finding 1 — `wait_for_signal_done` timeout bypassed the replay cache.** Collapsed the two terminal paths (resolver and timeout) into a single idempotent `complete(result)` so timer cleanup, replay-cache write, `anySignalResolvers` removal, `finishSignalWait`, and promise resolution all happen once. Removed the now-redundant `finishSignalWait` calls in the three external paths that consume a resolver (PTY exit handler, `cleanupChildTask`, `signalDone`) so the active-wait count is not double-decremented. `unregisterCoordinator` now snapshots the resolver list before fan-out because `complete` splices itself out of the live array.
- **Finding 2 — store import cycles.** Extracted the focus-registry getters/setters into `src/store/focused-panel.ts` and moved `removeProjectWithTasks` into `src/store/project-cleanup.ts`. `projects.ts` no longer imports `closeTask`, and `navigation`/`tasks`/`terminals`/`ui` import focus helpers directly from `focused-panel` instead of round-tripping through `focus.ts`. `focus.ts` re-exports the moved symbols for existing component imports. The shared `electron/mcp/prompt-detect.ts` (pure regex helpers reused by the renderer task-status pipeline) is whitelisted alongside `channels.ts` in `.dependency-cruiser.cjs`.
- **Finding 3 — CI gates.** Replaced the typecheck/lint/format-only job with `npm run check` (which also runs `compile`), `npm run lint:arch`, `npm run lint:dead`, and `npm test`.
- **Finding 7 — Knip.** Dropped the unused `@types/dompurify` devDep (dompurify v3 ships its own types) and registered `semgrep`/`gitleaks` under `ignoreBinaries`. `npm run lint:dead` now exits 0.
- **Finding 38 — OpenSpec.** No code change required: upstream commit `1a65f3a` already retired the OpenSpec workflow, and the only remainder (`openspec/changes/add-focus-mode-shortcut/.claude/`) is gitignored.
- **Finding 41 — `.npmrc` warnings and semgrep preflight.** Removed the pnpm-only `onlyBuiltDependencies` block that triggered `Unknown project config` warnings on every npm invocation, and added a `semgrep --version` preflight to `scripts/test-semgrep-filesystem-safety.mjs` so a missing binary yields an install hint instead of a `spawnSync ENOENT` node stack trace.

## Test plan

- [x] `npm run check` (compile + typecheck + lint + format:check)
- [x] `npm run lint:arch` — `no dependency violations found (346 modules, 1096 dependencies cruised)`
- [x] `npm run lint:dead` — exits 0 (only knip "Configuration hints" remain, which are informational)
- [x] `npm test` — `1413 passed | 24 skipped (1437)`
- [x] Added retry-after-timeout coverage for `waitForSignalDone` in `electron/mcp/coordinator.test.ts`
- [x] `node scripts/test-semgrep-filesystem-safety.mjs` with semgrep absent now prints an install hint and exits 1 (instead of dumping internals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
