### PR TITLE
fix(progress): gate merged-lines counter on cleanup

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -152,7 +152,7 @@ import {
   updateTaskBranch,
 } from './tasks';
 import { getCoordinatorChildren } from './sidebar-order';
-import { recordTaskMerged } from './completion';
+import { recordMergedLines, recordTaskMerged } from './completion';
 import { markAgentSpawned, rescheduleTaskStatusPolling } from './taskStatus';
 import { saveState } from './persistence';
 import { getProjectBranchPrefix, getProjectPath, isProjectMissing } from './projects';
@@ -1116,9 +1116,11 @@ describe('recordTaskMerged counts merges with cleanup, not closures', () => {
     await mergeTask('task-1', { cleanup: true });
 
     expect(recordTaskMerged).toHaveBeenCalledTimes(1);
+    expect(recordMergedLines).toHaveBeenCalledTimes(1);
+    expect(recordMergedLines).toHaveBeenCalledWith(10, 2);
   });
 
-  it('merging without cleanup does NOT increment the counter', async () => {
+  it('merging without cleanup does NOT increment the counter or lines totals', async () => {
     mockTasks['task-1'] = {
       agentIds: [],
       shellAgentIds: [],
@@ -1138,6 +1140,7 @@ describe('recordTaskMerged counts merges with cleanup, not closures', () => {
     await mergeTask('task-1', { cleanup: false });
 
     expect(recordTaskMerged).not.toHaveBeenCalled();
+    expect(recordMergedLines).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -589,9 +589,9 @@ export async function mergeTask(
     message: options?.message,
     cleanup,
   });
-  recordMergedLines(mergeResult.lines_added, mergeResult.lines_removed);
 
   if (cleanup) {
+    recordMergedLines(mergeResult.lines_added, mergeResult.lines_removed);
     recordTaskMerged();
     await Promise.allSettled(
       [...agentIds, ...shellAgentIds].map((id) => invoke(IPC.KillAgent, { agentId: id })),


### PR DESCRIPTION
## Summary

- `mergeTask` was calling `recordMergedLines()` unconditionally before the `if (cleanup)` gate, while `recordTaskMerged()` (the "Merged today" counter) was correctly gated inside the block — leftover asymmetry from the issue #151 fix.
- This let the two side-by-side sidebar stats ("Merged today" / "Merged (total)") drift apart on the non-cleanup merge path.
- Move `recordMergedLines(...)` inside `if (cleanup) { ... }` so both stats share one gate and the same source-of-truth event.

## Reproduce on `main`

1. Merge a task with the "merge & keep" option (`cleanup: false`).
2. `mergedLinesAdded` / `mergedLinesRemoved` bump; `completedTaskCount` does not.
3. Close the same task later via `closeTask` — "Merged today" is never incremented, but the lines totals already moved.
4. Sidebar footer shows lines added/removed for a task that "Merged today" never counted.

After this change both counters react to the same event (`cleanup === true`), matching the invariant locked in by the issue #151 fix ("only count tasks that complete the full merge+cleanup lifecycle").

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` — 1412 pass / 0 fail
- [x] Existing `recordTaskMerged counts merges with cleanup, not closures` describe extended with `recordMergedLines` parity assertions (called once with the merge result on `cleanup: true`; never called on `cleanup: false`).
