### PR TITLE
fix(agent): fallback to fresh start when resume args fail

### DIFF
--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -30,7 +30,7 @@ import { createHighlightedMarkdown } from '../lib/marked-shiki';
 import type { Task } from '../store/types';
 import type { AgentDef } from '../ipc/types';
 import type { PromptInputHandle } from './PromptInput';
-import { buildTaskAgentArgs } from '../lib/agent-args';
+import { buildTaskAgentArgs, isResumeArgsFailure } from '../lib/agent-args';
 
 function aiTerminalPanelId(agentId: string): string {
   return `ai-terminal:${agentId}`;
@@ -614,7 +614,19 @@ function AgentTerminalPane(props: {
                 }
                 attachExisting={a().attachExisting}
                 preserveSessionOnCleanup
-                onExit={(code) => markAgentExited(a().id, code)}
+                onExit={(code) => {
+                  if (
+                    a().resumed &&
+                    code.exit_code !== 0 &&
+                    isResumeArgsFailure(a().def.command, code.last_output)
+                  ) {
+                    // Resume args failed (e.g. Claude's "No conversation to continue");
+                    // fall back to a fresh start with normal args.
+                    restartAgent(a().id, false);
+                    return;
+                  }
+                  markAgentExited(a().id, code);
+                }}
                 onData={(data) => markAgentOutput(a().id, data, props.task.id)}
                 onFileLink={props.onFileLink}
                 onPromptDetected={(text) => setLastPrompt(props.task.id, text)}

--- a/src/lib/agent-args.test.ts
+++ b/src/lib/agent-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildTaskAgentArgs } from './agent-args';
+import { buildTaskAgentArgs, isResumeArgsFailure } from './agent-args';
 
 const codexAgent = {
   id: 'codex',
@@ -134,5 +134,53 @@ describe('buildTaskAgentArgs', () => {
         true,
       ),
     ).toEqual(['-c']);
+  });
+});
+
+describe('isResumeArgsFailure', () => {
+  describe('Claude resume failure patterns', () => {
+    it('returns true when Claude reports no conversation to continue', () => {
+      expect(isResumeArgsFailure('claude', ['No conversation found to continue'])).toBe(true);
+    });
+
+    it('returns true for a Claude command with a full path', () => {
+      expect(
+        isResumeArgsFailure('/usr/local/bin/claude', ['No conversation found to continue']),
+      ).toBe(true);
+    });
+
+    it('returns false when Claude output does not match a resume failure', () => {
+      expect(isResumeArgsFailure('claude', ['Resuming conversation...'])).toBe(false);
+    });
+
+    it('matches Claude resume failures across multiple output lines', () => {
+      expect(
+        isResumeArgsFailure('claude', [
+          '\x1b[1mClaude Code\x1b[22m',
+          '────────────────────────────────',
+          'No conversation found to continue',
+          'Run claude without --continue to start a new conversation',
+          '❯ ',
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe('unsupported commands', () => {
+    it('returns false for commands without configured resume failure patterns', () => {
+      expect(isResumeArgsFailure('unknown-agent', ['No conversation found to continue'])).toBe(
+        false,
+      );
+    });
+
+    it('returns false for full-path commands without configured resume failure patterns', () => {
+      expect(
+        isResumeArgsFailure('/usr/local/bin/unknown-agent', ['No conversation found to continue']),
+      ).toBe(false);
+    });
+  });
+
+  it('returns false for empty last output', () => {
+    expect(isResumeArgsFailure('claude', [])).toBe(false);
   });
 });

--- a/src/lib/agent-args.ts
+++ b/src/lib/agent-args.ts
@@ -9,6 +9,18 @@ function isAntigravityCommand(command: string): boolean {
   return command.split('/').pop() === 'agy';
 }
 
+const RESUME_FAILURE_PATTERNS: Record<string, string[]> = {
+  claude: ['No conversation found to continue'],
+};
+
+export function isResumeArgsFailure(command: string, lastOutput: string[]): boolean {
+  const base = command.split('/').pop() ?? command;
+  const patterns = RESUME_FAILURE_PATTERNS[base];
+  if (!patterns || lastOutput.length === 0) return false;
+  const text = lastOutput.join('\n');
+  return patterns.some((pattern) => text.includes(pattern));
+}
+
 function legacyMcpConfigArgs(command: string, mcpConfigPath: string | undefined): string[] {
   // Codex and Antigravity have no `--mcp-config` flag; passing it would break launch.
   if (!mcpConfigPath || isCodexCommand(command) || isAntigravityCommand(command)) return [];


### PR DESCRIPTION
## Summary

When using Claude Code (which supports session resumption via `--continue` ) to create a task, if the user closes and restarts the app before any conversation has taken place, the system relaunches the agent using the `resume_args` defined in `AgentDef`. Because no session exists to continue, the process exits immediately with `No conversation found to continue`, forcing the user to manually click the restart button to recover the task. 

## 1. Root Cause

- After the app restarts, agents in the `resumed` state are launched with `AgentDef.resume_args` (for Claude Code this is typically `--continue` ).
- If no conversation took place before the restart, Claude Code cannot find a session to resume and exits with an error.
- The previous implementation had no automatic fallback when an agent exited due to failed resume arguments, leaving the user to manually restart.

## 2. Solution

This PR adds resume-failure detection in the `onExit` callback of `TaskAITerminal`:

- If the agent is in `resumed` state, exits with a non-zero code, and its final output matches a known resume-failure signature (e.g. Claude's `No conversation found to continue`), it automatically calls `restartAgent(id, false)`.
- Passing `false` skips `resume_args` and falls back to `AgentDef.args`, starting a fresh session without requiring manual intervention.

It also introduces `isResumeArgsFailure` in `src/lib/agent-args.ts` to centralize the resume-failure signatures for each CLI, making future extensions easier.
