### PR TITLE
fix: surface notification failure to renderer on macOS

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -133,6 +133,7 @@ export enum IPC {
   // Notifications
   ShowNotification = 'show_notification',
   NotificationClicked = 'notification_clicked',
+  NotificationFailed = 'notification_failed',
 
   // PR CI status
   StartPrChecksWatcher = 'start_pr_checks_watcher',

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -1040,11 +1040,12 @@ export function registerAllHandlers(win: BrowserWindow): void {
         release();
         logWarn('notification', 'show failed', { ...warnCtx, err: error });
         // Surface the failure to the renderer so the UI can inform the user.
-        // On macOS, unsigned development builds fail silently because
-        // UNNotification requires code-signing. This lets the user know.
+        // NOTE: The `failed` event only fires on macOS starting in Electron 42
+        // (UNNotification migration). On Electron 40 (current), this code path
+        // is macOS-inert — it still fires on Windows. Once the project upgrades
+        // past Electron 42, this will activate for unsigned macOS builds too.
         if (!win.isDestroyed()) {
           win.webContents.send(IPC.NotificationFailed, {
-            taskIds: args.taskIds,
             error: typeof error === 'string' ? error : String(error),
             platform: process.platform,
           });

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -1039,6 +1039,16 @@ export function registerAllHandlers(win: BrowserWindow): void {
       notification.on('failed', (_event, error) => {
         release();
         logWarn('notification', 'show failed', { ...warnCtx, err: error });
+        // Surface the failure to the renderer so the UI can inform the user.
+        // On macOS, unsigned development builds fail silently because
+        // UNNotification requires code-signing. This lets the user know.
+        if (!win.isDestroyed()) {
+          win.webContents.send(IPC.NotificationFailed, {
+            taskIds: args.taskIds,
+            error: typeof error === 'string' ? error : String(error),
+            platform: process.platform,
+          });
+        }
       });
       notification.on('click', () => {
         release();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -121,6 +121,7 @@ const ALLOWED_CHANNELS = new Set([
   // Notifications
   'show_notification',
   'notification_clicked',
+  'notification_failed',
   // PR CI status
   'start_pr_checks_watcher',
   'stop_pr_checks_watcher',

--- a/src/store/desktopNotifications.test.ts
+++ b/src/store/desktopNotifications.test.ts
@@ -191,9 +191,16 @@ describe('desktop notification dedupe', () => {
 
 describe('startDesktopNotificationWatcher', () => {
   it('replaces an existing watcher instead of stacking duplicate listeners', () => {
-    const offFirst = vi.fn();
-    const offSecond = vi.fn();
-    const on = vi.fn().mockReturnValueOnce(offFirst).mockReturnValueOnce(offSecond);
+    const offClickFirst = vi.fn();
+    const offClickSecond = vi.fn();
+    const offFailFirst = vi.fn();
+    const offFailSecond = vi.fn();
+    const on = vi
+      .fn()
+      .mockReturnValueOnce(offClickFirst) // first watcher: NotificationClicked
+      .mockReturnValueOnce(offFailFirst) // first watcher: NotificationFailed
+      .mockReturnValueOnce(offClickSecond) // second watcher: NotificationClicked
+      .mockReturnValueOnce(offFailSecond); // second watcher: NotificationFailed
     vi.stubGlobal('window', {
       electron: {
         ipcRenderer: {
@@ -204,17 +211,24 @@ describe('startDesktopNotificationWatcher', () => {
 
     createRoot((dispose) => {
       const stopFirst = startDesktopNotificationWatcher(() => false);
-      expect(offFirst).not.toHaveBeenCalled();
+      // First watcher's listeners should not be cleaned up yet
+      expect(offClickFirst).not.toHaveBeenCalled();
+      expect(offFailFirst).not.toHaveBeenCalled();
 
       const stopSecond = startDesktopNotificationWatcher(() => false);
-      expect(offFirst).toHaveBeenCalledTimes(1);
-      expect(offSecond).not.toHaveBeenCalled();
+      // Starting a second watcher should clean up the first watcher's listeners
+      expect(offClickFirst).toHaveBeenCalledTimes(1);
+      expect(offFailFirst).toHaveBeenCalledTimes(1);
+      expect(offClickSecond).not.toHaveBeenCalled();
+      expect(offFailSecond).not.toHaveBeenCalled();
 
       stopFirst();
-      expect(offFirst).toHaveBeenCalledTimes(1);
+      expect(offClickFirst).toHaveBeenCalledTimes(1);
+      expect(offFailFirst).toHaveBeenCalledTimes(1);
 
       stopSecond();
-      expect(offSecond).toHaveBeenCalledTimes(1);
+      expect(offClickSecond).toHaveBeenCalledTimes(1);
+      expect(offFailSecond).toHaveBeenCalledTimes(1);
 
       dispose();
     });

--- a/src/store/desktopNotifications.ts
+++ b/src/store/desktopNotifications.ts
@@ -230,19 +230,21 @@ export function startDesktopNotificationWatcher(windowFocused: Accessor<boolean>
     },
   );
 
-  // Surface notification failures so the UI can inform the user.
-  // On macOS, unsigned development builds silently drop notifications
-  // because UNNotification requires code-signing.  Without this listener,
-  // the user toggles the setting on and nothing ever appears.
+  // Surface notification failures to the UI.
+  // NOTE: The `failed` event only fires on macOS from Electron 42+ (UNNotification
+  // migration). On the current Electron 40, this path is macOS-inert — it fires
+  // on Windows only. After an Electron 42 upgrade, unsigned macOS builds will
+  // trigger this handler, letting the user know notifications need code-signing.
   const offNotificationFailed = window.electron.ipcRenderer.on(
     IPC.NotificationFailed,
     (data: unknown) => {
       const msg = data as Record<string, unknown>;
       if (msg?.platform === 'darwin') {
+        // Visible in the renderer console (DevTools). A future follow-up can
+        // add a toast/banner when the design for settings-level alerts lands.
         console.warn(
-          '[notifications] macOS notification delivery failed. If running an unsigned dev build, ' +
-            'notifications require ad-hoc code-signing (codesign --force --deep -s - <app>). ' +
-            'Error:',
+          '[notifications] macOS notification delivery failed. Unsigned dev builds need ' +
+            'ad-hoc code-signing (codesign --force --deep -s - <app>). Error:',
           msg?.error,
         );
       }

--- a/src/store/desktopNotifications.ts
+++ b/src/store/desktopNotifications.ts
@@ -230,12 +230,32 @@ export function startDesktopNotificationWatcher(windowFocused: Accessor<boolean>
     },
   );
 
+  // Surface notification failures so the UI can inform the user.
+  // On macOS, unsigned development builds silently drop notifications
+  // because UNNotification requires code-signing.  Without this listener,
+  // the user toggles the setting on and nothing ever appears.
+  const offNotificationFailed = window.electron.ipcRenderer.on(
+    IPC.NotificationFailed,
+    (data: unknown) => {
+      const msg = data as Record<string, unknown>;
+      if (msg?.platform === 'darwin') {
+        console.warn(
+          '[notifications] macOS notification delivery failed. If running an unsigned dev build, ' +
+            'notifications require ad-hoc code-signing (codesign --force --deep -s - <app>). ' +
+            'Error:',
+          msg?.error,
+        );
+      }
+    },
+  );
+
   let cleanedUp = false;
   const cleanup = (): void => {
     if (cleanedUp) return;
     cleanedUp = true;
     if (debounceTimer !== undefined) clearTimeout(debounceTimer);
     offNotificationClicked();
+    offNotificationFailed();
     if (activeDesktopNotificationWatcherCleanup === cleanup) {
       activeDesktopNotificationWatcherCleanup = undefined;
     }


### PR DESCRIPTION
## Summary

Surface notification `failed` events to the renderer so the UI can inform the user when a notification did not deliver.

On macOS, unsigned development builds silently drop notifications because `UNNotification` requires code-signing. The `failed` event currently fires only on Windows (Electron 40). Starting with Electron 42, it will fire on macOS too — this PR lays the groundwork by wiring the IPC channel now.

Refs #122

## Changes

- Add `IPC.NotificationFailed` channel + preload allowlist entry
- In `register.ts`, forward the `failed` event to the renderer via `NotificationFailed` (includes error string + platform)
- In `desktopNotifications.ts`, add a listener that logs a macOS-specific `console.warn` explaining unsigned-build requirements
- Update the watcher-replacement test to cover both `NotificationClicked` and `NotificationFailed` listener cleanup

## Reviewer notes

- `taskIds` removed from the `NotificationFailed` payload — the renderer listener does not use them
- Comments updated to note the Electron 42+ scope for macOS
- The `console.warn` in the renderer is a DevTools-visible diagnostic. A proper toast/banner can follow when the settings-level alerts design lands