### PR TITLE
fix: replace noisy console.warn with structured logger in steps.ts

### DIFF
--- a/electron/ipc/steps.ts
+++ b/electron/ipc/steps.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type { BrowserWindow } from 'electron';
 import { IPC } from './channels.js';
+import { info as logInfo, warn as logWarn, errMessage } from '../log.js';
 
 interface StepsWatcher {
   fsWatcher: fs.FSWatcher | null;
@@ -29,7 +30,7 @@ const processedCount = new Map<string, number>();
 function sendStepsContent(win: BrowserWindow, taskId: string, stepsFile: string): void {
   if (win.isDestroyed()) return;
   const steps = readStepsFile(stepsFile);
-  console.warn('[steps.send]', taskId, 'len=', steps?.length ?? 'null');
+  logInfo('steps', 'send', { taskId, len: steps?.length ?? null });
   if (steps) applyTimestamps(steps, stepsFile, taskId);
   win.webContents.send(IPC.StepsContent, { taskId, steps });
 }
@@ -64,7 +65,7 @@ function applyTimestamps(steps: unknown[], stepsFile: string, taskId: string): v
   try {
     fs.writeFileSync(stepsFile, JSON.stringify(steps, null, 2), 'utf-8');
   } catch (err) {
-    console.warn('[steps] Failed to write back timestamps:', err);
+    logWarn('steps', 'failed to write back timestamps', { err: errMessage(err) });
   }
 }
 
@@ -124,7 +125,7 @@ function ensureStepsIgnored(worktreePath: string): void {
     const prefix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
     fs.appendFileSync(excludePath, `${prefix}${entry}\n`, 'utf-8');
   } catch (err) {
-    console.warn('Failed to update git exclude for steps:', err);
+    logWarn('steps', 'failed to update git exclude', { err: errMessage(err) });
   }
 }
 
@@ -157,7 +158,7 @@ export function startStepsWatcher(win: BrowserWindow, taskId: string, worktreePa
 
   // filename may be null on some platforms; if present, filter to steps.json only
   const onChange = (event: string, filename: string | Buffer | null) => {
-    console.warn('[steps.watch]', taskId, event, String(filename));
+    logInfo('steps', 'watch event', { taskId, event, filename: String(filename) });
     if (filename !== null && filename !== 'steps.json') return;
     const current = watchers.get(taskId);
     if (!current) return;
@@ -187,11 +188,11 @@ export function startStepsWatcher(win: BrowserWindow, taskId: string, worktreePa
         }
       });
       parentWatcher.on('error', (err) => {
-        console.warn(`Steps parent watcher error for ${worktreePath}:`, err);
+        logWarn('steps', 'parent watcher error', { worktreePath, err: errMessage(err) });
       });
       entry.fsWatcher = parentWatcher;
     } catch (err) {
-      console.warn(`Failed to watch worktree root ${worktreePath}:`, err);
+      logWarn('steps', 'failed to watch worktree root', { worktreePath, err: errMessage(err) });
     }
   }
 
@@ -212,12 +213,15 @@ function attachStepsDirWatcher(
   try {
     const watcher = fs.watch(entry.stepsDir, onChange);
     watcher.on('error', (err) => {
-      console.warn(`Steps watcher error for ${entry.stepsDir}:`, err);
+      logWarn('steps', 'watcher error', { stepsDir: entry.stepsDir, err: errMessage(err) });
     });
     entry.fsWatcher = watcher;
     watchers.set(taskId, entry);
   } catch (err) {
-    console.warn(`Failed to watch steps directory ${entry.stepsDir}:`, err);
+    logWarn('steps', 'failed to watch steps dir', {
+      stepsDir: entry.stepsDir,
+      err: errMessage(err),
+    });
   }
 }
 

--- a/electron/ipc/steps.ts
+++ b/electron/ipc/steps.ts
@@ -2,7 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import type { BrowserWindow } from 'electron';
 import { IPC } from './channels.js';
-import { info as logInfo, warn as logWarn, errMessage } from '../log.js';
+import {
+  debug as logDebug,
+  info as logInfo,
+  warn as logWarn,
+  error as logError,
+  errMessage,
+} from '../log.js';
 
 interface StepsWatcher {
   fsWatcher: fs.FSWatcher | null;
@@ -78,7 +84,9 @@ function readStepsFile(stepsFile: string): unknown[] | null {
     return parsed as unknown[];
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.error('[steps] Failed to read steps file:', e);
+      // Non-ENOENT read failures (corrupt file, permissions, etc.)
+      // capture the full stack via the structured logger.
+      logError('steps', 'failed to read steps file', e);
     }
     return null;
   }
@@ -158,7 +166,7 @@ export function startStepsWatcher(win: BrowserWindow, taskId: string, worktreePa
 
   // filename may be null on some platforms; if present, filter to steps.json only
   const onChange = (event: string, filename: string | Buffer | null) => {
-    logInfo('steps', 'watch event', { taskId, event, filename: String(filename) });
+    logDebug('steps', 'watch event', { taskId, event, filename: String(filename) });
     if (filename !== null && filename !== 'steps.json') return;
     const current = watchers.get(taskId);
     if (!current) return;
@@ -188,11 +196,11 @@ export function startStepsWatcher(win: BrowserWindow, taskId: string, worktreePa
         }
       });
       parentWatcher.on('error', (err) => {
-        logWarn('steps', 'parent watcher error', { worktreePath, err: errMessage(err) });
+        logError('steps', 'parent watcher error', err, { worktreePath });
       });
       entry.fsWatcher = parentWatcher;
     } catch (err) {
-      logWarn('steps', 'failed to watch worktree root', { worktreePath, err: errMessage(err) });
+      logError('steps', 'failed to watch worktree root', err, { worktreePath });
     }
   }
 
@@ -213,15 +221,12 @@ function attachStepsDirWatcher(
   try {
     const watcher = fs.watch(entry.stepsDir, onChange);
     watcher.on('error', (err) => {
-      logWarn('steps', 'watcher error', { stepsDir: entry.stepsDir, err: errMessage(err) });
+      logError('steps', 'watcher error', err, { stepsDir: entry.stepsDir });
     });
     entry.fsWatcher = watcher;
     watchers.set(taskId, entry);
   } catch (err) {
-    logWarn('steps', 'failed to watch steps dir', {
-      stepsDir: entry.stepsDir,
-      err: errMessage(err),
-    });
+    logError('steps', 'failed to watch steps dir', err, { stepsDir: entry.stepsDir });
   }
 }
 


### PR DESCRIPTION
The step watcher was logging every send and every file change at `console.warn` level — that's debug info, not a warning. In a normal session with multiple agents running, this spams the console with hundreds of entries that make real warnings impossible to spot.

Switched all logging in `steps.ts` to the structured logger that the rest of the main process already uses:
- Routine events (step sends, watch events) → `info` level
- Actual failures (write errors, watcher errors) → `warn` level
- All entries use structured context objects instead of string concatenation

Found during quality audit (#157, finding 41).