### PR TITLE
fix: clean up landedOrderCounters on coordinator close

### DIFF
--- a/electron/mcp/coordinator.ts
+++ b/electron/mcp/coordinator.ts
@@ -2216,6 +2216,7 @@ export class Coordinator {
     }
 
     this.coordinators.delete(coordinatorTaskId);
+    this.landedOrderCounters.delete(coordinatorTaskId);
 
     // Resolve any pending wait_for_signal_done calls so they don't hang until
     // the 5-minute timeout fires after the coordinator closes.


### PR DESCRIPTION
The `landedOrderCounters` Map accumulates entries keyed by `coordinatorTaskId` but never deletes them when a coordinator closes. Over a long session with many coordinator cycles, these stale entries grow without bound — a slow memory leak.

Every other Map in the same cleanup path (`coordinators`, `activeSignalWaitCounts`, etc.) is already cleaned up on coordinator close. `landedOrderCounters` was just missed.

One line: add `this.landedOrderCounters.delete(coordinatorTaskId)` next to the existing `this.coordinators.delete(coordinatorTaskId)` call.