### PR TITLE
fix(copilot): use --additional-mcp-config so Copilot does not exit before prompt

### DIFF
--- a/electron/ipc/agents.ts
+++ b/electron/ipc/agents.ts
@@ -58,7 +58,7 @@ const DEFAULT_AGENTS: AgentDef[] = [
     name: 'Copilot CLI',
     command: 'copilot',
     args: [],
-    resume_args: [],
+    resume_args: ['--continue'],
     skip_permissions_args: ['--yolo'],
     description: "GitHub's Copilot CLI agent",
     // Copilot CLI shows up to two init dialogs (folder trust + instructions init)

--- a/electron/mcp/agent-args.test.ts
+++ b/electron/mcp/agent-args.test.ts
@@ -5,6 +5,7 @@ import {
   buildMcpLaunchArgs,
   isAntigravityCommand,
   isCodexCommand,
+  isCopilotCommand,
 } from './agent-args.js';
 
 const config = {
@@ -64,5 +65,22 @@ describe('MCP agent launch args', () => {
 
   it('emits no --mcp-config for Antigravity', () => {
     expect(buildMcpLaunchArgs('agy', '/tmp/config.json', config)).toEqual([]);
+  });
+
+  it('detects copilot commands by executable name', () => {
+    expect(isCopilotCommand('copilot')).toBe(true);
+    expect(isCopilotCommand('/opt/homebrew/bin/copilot')).toBe(true);
+    expect(isCopilotCommand('claude')).toBe(false);
+  });
+
+  it('uses --additional-mcp-config for Copilot instead of the unsupported --mcp-config', () => {
+    expect(buildMcpLaunchArgs('copilot', '/tmp/config.json', config)).toEqual([
+      '--additional-mcp-config',
+      '@/tmp/config.json',
+    ]);
+  });
+
+  it('emits no MCP args for Copilot when no config path is available', () => {
+    expect(buildMcpLaunchArgs('copilot', undefined, config)).toEqual([]);
   });
 });

--- a/electron/mcp/agent-args.ts
+++ b/electron/mcp/agent-args.ts
@@ -18,6 +18,10 @@ export function isAntigravityCommand(command: string): boolean {
   return command.split('/').pop() === 'agy';
 }
 
+export function isCopilotCommand(command: string): boolean {
+  return command.split('/').pop() === 'copilot';
+}
+
 function tomlString(value: string): string {
   return JSON.stringify(value);
 }
@@ -48,6 +52,13 @@ export function buildMcpLaunchArgs(
   // Antigravity (agy) has no `--mcp-config` flag; emit nothing so launch is not broken.
   if (isAntigravityCommand(command)) {
     return [];
+  }
+  // Copilot has no `--mcp-config` flag — passing it makes Copilot exit immediately
+  // with "unknown option" before the prompt is ever sent (#146). It accepts
+  // `--additional-mcp-config <@file|json>` (and also auto-discovers a workspace
+  // `.mcp.json`), both of which take this same config shape.
+  if (isCopilotCommand(command)) {
+    return configPath ? ['--additional-mcp-config', `@${configPath}`] : [];
   }
   return configPath ? ['--mcp-config', configPath] : [];
 }

--- a/src/lib/agent-args.test.ts
+++ b/src/lib/agent-args.test.ts
@@ -32,6 +32,16 @@ const antigravityAgent = {
   skip_permissions_args: ['--dangerously-skip-permissions'],
 };
 
+const copilotAgent = {
+  id: 'copilot',
+  name: 'Copilot CLI',
+  description: 'Copilot agent',
+  command: 'copilot',
+  args: [],
+  resume_args: ['--continue'],
+  skip_permissions_args: ['--yolo'],
+};
+
 describe('buildTaskAgentArgs', () => {
   it('uses explicit MCP launch args when provided (new task)', () => {
     expect(
@@ -134,6 +144,32 @@ describe('buildTaskAgentArgs', () => {
         true,
       ),
     ).toEqual(['-c']);
+  });
+
+  it('uses Copilot --additional-mcp-config fallback instead of the unsupported --mcp-config', () => {
+    expect(
+      buildTaskAgentArgs(
+        copilotAgent,
+        {
+          skipPermissions: false,
+          mcpConfigPath: '/tmp/mcp.json',
+        },
+        false,
+      ),
+    ).toEqual(['--additional-mcp-config', '@/tmp/mcp.json']);
+  });
+
+  it('passes the Copilot resume flag alongside the --additional-mcp-config fallback', () => {
+    expect(
+      buildTaskAgentArgs(
+        copilotAgent,
+        {
+          skipPermissions: false,
+          mcpConfigPath: '/tmp/mcp.json',
+        },
+        true,
+      ),
+    ).toEqual(['--continue', '--additional-mcp-config', '@/tmp/mcp.json']);
   });
 });
 

--- a/src/lib/agent-args.ts
+++ b/src/lib/agent-args.ts
@@ -9,6 +9,10 @@ function isAntigravityCommand(command: string): boolean {
   return command.split('/').pop() === 'agy';
 }
 
+function isCopilotCommand(command: string): boolean {
+  return command.split('/').pop() === 'copilot';
+}
+
 const RESUME_FAILURE_PATTERNS: Record<string, string[]> = {
   claude: ['No conversation found to continue'],
 };
@@ -24,6 +28,9 @@ export function isResumeArgsFailure(command: string, lastOutput: string[]): bool
 function legacyMcpConfigArgs(command: string, mcpConfigPath: string | undefined): string[] {
   // Codex and Antigravity have no `--mcp-config` flag; passing it would break launch.
   if (!mcpConfigPath || isCodexCommand(command) || isAntigravityCommand(command)) return [];
+  // Copilot has no `--mcp-config` flag either — it exits with "unknown option" (#146).
+  // Use its `--additional-mcp-config <@file>` flag, which takes the same config shape.
+  if (isCopilotCommand(command)) return ['--additional-mcp-config', `@${mcpConfigPath}`];
   return ['--mcp-config', mcpConfigPath];
 }
 


### PR DESCRIPTION
Fixes #146

## Problem

Parallel Code runs agents as interactive PTY REPLs and types the queued prompt once the TUI is ready. With Copilot, the process exits on launch before the prompt is sent, surfacing as "Agent exited before prompt was sent".

Root cause: when the MCP coordinator is wired in, Copilot was grouped with the Claude-compatible agents and launched with `--mcp-config <path>`. Copilot has no such flag and exits immediately:

    $ copilot --mcp-config /tmp/x.json
    error: unknown option '--mcp-config'

This happens whenever Copilot runs as a coordinator agent or a coordinated sub-agent (the core multi-agent workflow).

## Fix

Use Copilot's real flag. Copilot reads MCP config from `--additional-mcp-config <@file|json>` and auto-discovers the workspace `.mcp.json` that Parallel Code already writes; both take the same `{ "mcpServers": {...} }` shape. Map Copilot to `--additional-mcp-config @<configPath>` in both the backend launch-arg builder (`electron/mcp/agent-args.ts`) and the renderer fallback (`src/lib/agent-args.ts`), mirroring the existing Codex and Antigravity special cases. Also wire Copilot session resume via `--continue`.

## Testing (on this machine, copilot v1.0.65, real PTY)

- Before: `copilot --mcp-config @file` exits with "unknown option". After: `copilot --additional-mcp-config @file` launches and stays interactive.
- `copilot mcp list` confirms it auto-discovers the app's `.mcp.json` (`parallel-code (local)`).
- `copilot --continue` with no prior session starts fresh without error.
- `npm run typecheck`, `npm run lint` (eslint, max-warnings 0), `npm run format:check`, `npm run lint:arch` (dependency-cruiser), and the full `npm test` (vitest, 1433 tests) pass. Added unit tests for the Copilot command detection, the `--additional-mcp-config` mapping, and the resume arg ordering.
