### PR TITLE
fix(diff): show deleted file hunks

### DIFF
--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -1,6 +1,6 @@
 import { For, Show, createSignal, createEffect, onMount, onCleanup } from 'solid-js';
 import type { JSX } from 'solid-js';
-import { theme, bannerStyle } from '../lib/theme';
+import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { getStatusColor } from '../lib/status-colors';
 import { openFileInEditor } from '../lib/shell';
@@ -684,21 +684,7 @@ function FileSection(props: {
           </div>
         </Show>
 
-        <Show when={!props.file.binary && props.file.status === 'D'}>
-          <div
-            style={{
-              ...bannerStyle(theme.error),
-              margin: '12px',
-              'font-size': sf(13),
-              'text-align': 'center',
-              'font-weight': '600',
-            }}
-          >
-            This file was deleted
-          </div>
-        </Show>
-
-        <Show when={!props.file.binary && props.file.status !== 'D'}>
+        <Show when={!props.file.binary}>
           <div
             style={{
               'padding-bottom': '8px',


### PR DESCRIPTION
## Summary

- Show deleted file hunks in the diff viewer instead of replacing them with a single deleted-file banner.
- Align deleted file rendering with added and modified file diff blocks, so the changed code remains visible.
- Remove the now-unused deleted-file banner styling import.

## Why

Deleted files previously only showed a single "This file was deleted" message in the diff block. That made deleted-file diffs inconsistent with added and modified files, and it prevented users from seeing what an agent actually removed.

## Test Plan

- [x] npm run typecheck
- [x] git diff --check
