### PR TITLE
Fix quality audit repository gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,16 @@ jobs:
       - name: Check (compile + typecheck + lint + format)
         run: npm run check
 
-      - name: Lint (architecture)
-        run: npm run lint:arch
+      - name: Check static (typecheck + lint + dead code + architecture)
+        run: npm run check:static
 
-      - name: Lint (dead code)
-        run: npm run lint:dead
+      - name: Install Semgrep
+        run: |
+          pipx install semgrep
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Test security rules
+        run: npm run test:security-rules
 
       - name: Test
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ update-test/
 .claude
 .DS_Store
 docs/
-openspec/
 
 # Sandbox bind-mount artifacts from user home (not project files).
 # Root-anchored so legitimate nested files with these names are still tracked.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,38 +1,14 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  entry: [
-    'electron/main.ts',
-    'electron/preload.cjs',
-    'electron/mcp/server.ts', // added in coordinator-2-mcp-backend; listed here so knip tracks it from the start
-    'src/main.tsx',
-    'src/remote/main.tsx',
-  ],
+  entry: ['electron/main.ts', 'electron/preload.cjs', 'electron/mcp/server.ts'],
   project: ['electron/**/*.ts', 'src/**/*.{ts,tsx}'],
-  ignore: [
-    'dist/**',
-    'dist-electron/**',
-    'dist-remote/**',
-    'release/**',
-    'scripts/**',
-    // Vite/Electron configs are entry points picked up by their respective tools
-    'electron/vite.config.electron.ts',
-    'electron/vite.config.electron.test.ts',
-    'electron/shims/**',
-  ],
-  ignoreDependencies: [
-    // Peer dependencies and indirect runtime deps
-    'electron',
-    'electron-builder',
-    'concurrently',
-    'wait-on',
-  ],
   ignoreBinaries: [
-    // Optional security tooling invoked from npm scripts; installed on demand
+    // Optional security tooling invoked from npm scripts; installed on demand.
     'semgrep',
     'gitleaks',
   ],
-  // Test files are allowed to have unused exports (test helpers, fixtures)
+  // Test files are allowed to have unused exports (test helpers, fixtures).
   ignoreExportsUsedInFile: true,
 };
 


### PR DESCRIPTION
## Summary
- Clean up Knip configuration so the dead-code gate runs without stale config hints.
- Remove the last stale OpenSpec repo reference now that OpenSpec has been removed.
- Expand CI to run `check:static` and the Semgrep filesystem-safety regression test.

## Notes
- Addresses #157.
- Semgrep remains an external CLI and is installed in CI with `pipx install semgrep` rather than adding the placeholder npm package.
- Existing coordinator replay-cache and store import-cycle fixes were left untouched and verified through the existing tests/gates.

## Verification
- `npm run lint:arch`
- `npm run lint:dead`
- `export PATH="$HOME/.local/bin:$PATH"; npm run test:security-rules`
- `rg -n --hidden --glob '!node_modules/**' --glob '!.git/**' --glob '!docs/**' 'openspec|OpenSpec' .` exits 1 with no matches
- `npm run check`
- `npm test`
- `gh workflow view CI --repo johannesjo/parallel-code`

## Review
- Independent code review found no Critical or Important findings.
- Minor follow-up only: consider pinning Semgrep if CI drift becomes a concern.