### PR TITLE
Gate close task confirmation while status loads

### DIFF
--- a/src/components/CloseTaskDialog.test.ts
+++ b/src/components/CloseTaskDialog.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDisableCloseTaskConfirm } from './CloseTaskDialog';
+
+describe('shouldDisableCloseTaskConfirm', () => {
+  it('disables confirmation for internal worktree tasks while status is loading', () => {
+    expect(
+      shouldDisableCloseTaskConfirm({ gitIsolation: 'worktree', externalWorktree: false }, true),
+    ).toBe(true);
+  });
+
+  it('enables confirmation after internal worktree status loads', () => {
+    expect(
+      shouldDisableCloseTaskConfirm({ gitIsolation: 'worktree', externalWorktree: false }, false),
+    ).toBe(false);
+  });
+
+  it('does not block imported external worktrees', () => {
+    expect(
+      shouldDisableCloseTaskConfirm({ gitIsolation: 'worktree', externalWorktree: true }, true),
+    ).toBe(false);
+  });
+
+  it('does not block non-worktree tasks', () => {
+    expect(shouldDisableCloseTaskConfirm({ gitIsolation: 'direct' }, true)).toBe(false);
+    expect(shouldDisableCloseTaskConfirm({ gitIsolation: 'none' }, true)).toBe(false);
+  });
+});

--- a/src/components/CloseTaskDialog.tsx
+++ b/src/components/CloseTaskDialog.tsx
@@ -13,6 +13,13 @@ interface CloseTaskDialogProps {
   onDone: () => void;
 }
 
+export function shouldDisableCloseTaskConfirm(
+  task: Pick<Task, 'gitIsolation' | 'externalWorktree'>,
+  worktreeStatusLoading: boolean,
+): boolean {
+  return worktreeStatusLoading && task.gitIsolation === 'worktree' && !task.externalWorktree;
+}
+
 export function CloseTaskDialog(props: CloseTaskDialogProps) {
   const [worktreeStatus] = createResource(
     () =>
@@ -21,6 +28,8 @@ export function CloseTaskDialog(props: CloseTaskDialogProps) {
         : null,
     (path) => invoke<WorktreeStatus>(IPC.GetWorktreeStatus, { worktreePath: path }),
   );
+  const confirmWaitingForStatus = () =>
+    shouldDisableCloseTaskConfirm(props.task, worktreeStatus.loading);
 
   return (
     <ConfirmDialog
@@ -140,6 +149,8 @@ export function CloseTaskDialog(props: CloseTaskDialogProps) {
       confirmLabel={
         props.task.gitIsolation !== 'worktree' || props.task.externalWorktree ? 'Close' : 'Delete'
       }
+      confirmDisabled={confirmWaitingForStatus()}
+      confirmLoading={confirmWaitingForStatus()}
       danger={props.task.gitIsolation === 'worktree' && !props.task.externalWorktree}
       onConfirm={() => {
         props.onDone();


### PR DESCRIPTION
## Summary
- disable the CloseTaskDialog confirm action while internal worktree status is still loading
- show the existing confirm loading spinner during that pending state
- add focused coverage for the confirm gating logic

Fixes #199.

## Why
CloseTaskDialog checks dirty/unmerged worktree state asynchronously, but the destructive Delete action was clickable before that status resolved. This created a small race where uncommitted work could be deleted before the warning rendered.

## Tests
- npm run test -- src/components/CloseTaskDialog.test.ts
- npm run typecheck
- npm run check
- npm run test