### PR TITLE
Confirm missing-folder project removal

### DIFF
--- a/src/components/EditProjectDialog.tsx
+++ b/src/components/EditProjectDialog.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createEffect, For, Show } from 'solid-js';
 import { Dialog } from './Dialog';
 import {
+  store,
   updateProject,
   PASTEL_HUES,
   isProjectMissing,
@@ -12,6 +13,12 @@ import { theme, sectionLabelStyle } from '../lib/theme';
 import type { Project, TerminalBookmark, GitIsolationMode } from '../store/types';
 import { SegmentedButtons } from './SegmentedButtons';
 import { ImportWorktreesDialog } from './ImportWorktreesDialog';
+import { ConfirmDialog } from './ConfirmDialog';
+import {
+  getProjectTaskCount,
+  projectRemoveConfirmLabel,
+  projectRemoveConfirmMessage,
+} from './project-remove-confirmation';
 
 interface EditProjectDialogProps {
   project: Project | null;
@@ -34,12 +41,17 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
   const [bookmarks, setBookmarks] = createSignal<TerminalBookmark[]>([]);
   const [newCommand, setNewCommand] = createSignal('');
   const [showImportDialog, setShowImportDialog] = createSignal(false);
+  const [confirmRemoveProjectId, setConfirmRemoveProjectId] = createSignal<string | null>(null);
   let nameRef!: HTMLInputElement;
 
   // Sync signals when project prop changes
   createEffect(() => {
     const p = props.project;
-    if (!p) return;
+    if (!p) {
+      setConfirmRemoveProjectId(null);
+      return;
+    }
+    setConfirmRemoveProjectId(null);
     setName(p.name);
     setSelectedHue(hueFromColor(p.color));
     setBranchPrefix(sanitizeBranchPrefix(p.branchPrefix ?? 'task'));
@@ -69,6 +81,10 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
   }
 
   const canSave = () => name().trim().length > 0;
+  const confirmRemoveTaskCount = () => {
+    const projectId = confirmRemoveProjectId();
+    return projectId ? getProjectTaskCount(store, projectId) : 0;
+  };
 
   function handleSave() {
     if (!canSave() || !props.project) return;
@@ -199,10 +215,7 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
                 </button>
                 <button
                   type="button"
-                  onClick={async () => {
-                    await removeProjectWithTasks(project().id);
-                    props.onClose();
-                  }}
+                  onClick={() => setConfirmRemoveProjectId(project().id)}
                   style={{
                     padding: '5px 12px',
                     background: 'transparent',
@@ -572,6 +585,21 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
               open={showImportDialog()}
               project={project()}
               onClose={() => setShowImportDialog(false)}
+            />
+            <ConfirmDialog
+              open={confirmRemoveProjectId() !== null}
+              title="Remove project?"
+              message={projectRemoveConfirmMessage(confirmRemoveTaskCount())}
+              confirmLabel={projectRemoveConfirmLabel(confirmRemoveTaskCount())}
+              danger
+              onConfirm={() => {
+                const projectId = confirmRemoveProjectId();
+                if (!projectId) return;
+                const onClose = props.onClose;
+                setConfirmRemoveProjectId(null);
+                void removeProjectWithTasks(projectId).then(onClose);
+              }}
+              onCancel={() => setConfirmRemoveProjectId(null)}
             />
           </>
         )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,6 +41,11 @@ import { SidebarFooter } from './SidebarFooter';
 import { IconButton } from './IconButton';
 import { UpdateButton } from './UpdateButton';
 import { StatusDot, getDotTooltip } from './StatusDot';
+import {
+  getProjectTaskCount,
+  projectRemoveConfirmLabel,
+  projectRemoveConfirmMessage,
+} from './project-remove-confirmation';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { mod } from '../lib/platform';
@@ -864,21 +869,13 @@ export function Sidebar() {
         {/* Confirm remove project dialog */}
         {(() => {
           const id = confirmRemove();
-          const taskCount = id
-            ? [...store.taskOrder, ...store.collapsedTaskOrder].filter(
-                (tid) => store.tasks[tid]?.projectId === id,
-              ).length
-            : 0;
+          const taskCount = id ? getProjectTaskCount(store, id) : 0;
           return (
             <ConfirmDialog
               open={id !== null}
               title="Remove project?"
-              message={
-                taskCount > 0
-                  ? `This project has ${taskCount} open task(s). Removing it will also close all tasks, delete their worktrees and branches.`
-                  : 'Are you sure you want to remove this project?'
-              }
-              confirmLabel={taskCount > 0 ? 'Remove all' : 'Remove'}
+              message={projectRemoveConfirmMessage(taskCount)}
+              confirmLabel={projectRemoveConfirmLabel(taskCount)}
               danger
               onConfirm={() => {
                 if (id) {

--- a/src/components/project-remove-confirmation.test.ts
+++ b/src/components/project-remove-confirmation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProjectTaskCount,
+  projectRemoveConfirmLabel,
+  projectRemoveConfirmMessage,
+} from './project-remove-confirmation';
+
+describe('project remove confirmation helpers', () => {
+  it('counts open and collapsed tasks for the project', () => {
+    expect(
+      getProjectTaskCount(
+        {
+          taskOrder: ['task-1', 'task-2', 'missing-task'],
+          collapsedTaskOrder: ['collapsed-1', 'collapsed-other'],
+          tasks: {
+            'task-1': { projectId: 'project-a' },
+            'task-2': { projectId: 'project-b' },
+            'collapsed-1': { projectId: 'project-a' },
+            'collapsed-other': { projectId: 'project-c' },
+          },
+        },
+        'project-a',
+      ),
+    ).toBe(2);
+  });
+
+  it('uses the task-closing confirmation copy when tasks exist', () => {
+    expect(projectRemoveConfirmMessage(3)).toContain('3 open task(s)');
+    expect(projectRemoveConfirmLabel(3)).toBe('Remove all');
+  });
+
+  it('uses the simple confirmation copy when no tasks exist', () => {
+    expect(projectRemoveConfirmMessage(0)).toBe('Are you sure you want to remove this project?');
+    expect(projectRemoveConfirmLabel(0)).toBe('Remove');
+  });
+});

--- a/src/components/project-remove-confirmation.ts
+++ b/src/components/project-remove-confirmation.ts
@@ -1,0 +1,23 @@
+import type { Task } from '../store/types';
+
+interface ProjectTaskCountSource {
+  taskOrder: readonly string[];
+  collapsedTaskOrder: readonly string[];
+  tasks: Record<string, Pick<Task, 'projectId'> | undefined>;
+}
+
+export function getProjectTaskCount(source: ProjectTaskCountSource, projectId: string): number {
+  return [...source.taskOrder, ...source.collapsedTaskOrder].filter(
+    (taskId) => source.tasks[taskId]?.projectId === projectId,
+  ).length;
+}
+
+export function projectRemoveConfirmMessage(taskCount: number): string {
+  return taskCount > 0
+    ? `This project has ${taskCount} open task(s). Removing it will also close all tasks, delete their worktrees and branches.`
+    : 'Are you sure you want to remove this project?';
+}
+
+export function projectRemoveConfirmLabel(taskCount: number): string {
+  return taskCount > 0 ? 'Remove all' : 'Remove';
+}


### PR DESCRIPTION
## Summary
- route the missing-folder Remove action in EditProjectDialog through ConfirmDialog
- show the same task-count-aware project removal copy used by the Sidebar path
- share project removal confirmation helpers between both call sites
- add focused coverage for task counting and confirmation copy

Fixes #200.

## Why
The missing-folder banner removed a project and closed its tasks immediately after one click. That is the same destructive operation as Sidebar project removal, so it should use the same confirmation flow before closing tasks and deleting their worktrees/branches.

## Tests
- npm run test -- src/components/project-remove-confirmation.test.ts
- npm run typecheck
- npm run check
- npm run test