### PR TITLE
Polish small UX issues from audit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,7 @@ import { isMac, mod } from './lib/platform';
 import { createCtrlWheelZoomHandler } from './lib/wheelZoom';
 import { redrawAllTerminals } from './lib/terminalFitManager';
 import { ArenaOverlay } from './arena/ArenaOverlay';
+import { resetForNewMatch } from './arena/store';
 import { startDesktopNotificationWatcher } from './store/desktopNotifications';
 import { startPrChecksSubscription } from './store/pr-checks';
 import { startUpdateSubscription } from './store/updates';
@@ -144,6 +145,11 @@ function App() {
   const [windowMaximized, setWindowMaximized] = createSignal(false);
   const [showDropOverlay, setShowDropOverlay] = createSignal(false);
   let dragCounter = 0;
+
+  function closeArena() {
+    void resetForNewMatch();
+    toggleArena(false);
+  }
 
   function extractGitHubUrl(dt: DataTransfer): string | null {
     const uriList = dt.getData('text/uri-list');
@@ -682,7 +688,10 @@ function App() {
       toggleHelp: () => toggleHelpDialog(),
       toggleSettings: () => toggleSettingsDialog(),
       closeDialogs: () => {
-        if (store.showArena) return;
+        if (store.showArena) {
+          closeArena();
+          return;
+        }
         if (store.showHelpDialog) {
           toggleHelpDialog(false);
           return;
@@ -933,7 +942,7 @@ function App() {
           onClose={() => toggleSettingsDialog(false)}
         />
         <Show when={store.showArena}>
-          <ArenaOverlay onClose={() => toggleArena(false)} />
+          <ArenaOverlay onClose={closeArena} />
         </Show>
         <Show when={showDropOverlay()}>
           <DropOverlay />

--- a/src/arena/ArenaOverlay.tsx
+++ b/src/arena/ArenaOverlay.tsx
@@ -5,7 +5,7 @@ import './arena-battle.css';
 import './arena-results.css';
 import './arena-history.css';
 import { Show, onMount } from 'solid-js';
-import { arenaStore, resetForNewMatch } from './store';
+import { arenaStore } from './store';
 import { loadArenaPresets, loadArenaHistory } from './persistence';
 import { ConfigScreen } from './ConfigScreen';
 import { CountdownScreen } from './CountdownScreen';
@@ -24,7 +24,6 @@ export function ArenaOverlay(props: ArenaOverlayProps) {
   });
 
   function handleClose() {
-    void resetForNewMatch();
     props.onClose();
   }
 

--- a/src/components/EditProjectDialog.tsx
+++ b/src/components/EditProjectDialog.tsx
@@ -328,7 +328,7 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
 
             {/* Git-specific settings — hidden for non-git projects */}
             <Show when={props.project?.isGitRepo !== false}>
-              {/* Merge cleanup preference */}
+              {/* Close cleanup preference */}
               <label
                 style={{
                   display: 'flex',
@@ -345,7 +345,7 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
                   onChange={(e) => setDeleteBranchOnClose(e.currentTarget.checked)}
                   style={{ cursor: 'pointer' }}
                 />
-                Always delete branch and worklog on merge
+                Always delete branch and worktree on close
               </label>
 
               {/* Default isolation mode */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,6 +44,7 @@ import { StatusDot, getDotTooltip } from './StatusDot';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { mod } from '../lib/platform';
+import { abbreviateHomePath } from '../lib/path';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import type { ImportableWorktree } from '../ipc/types';
@@ -326,19 +327,6 @@ export function Sidebar() {
     window.addEventListener('mouseup', onUp);
   }
 
-  function abbreviatePath(path: string): string {
-    const prefixes = ['/home/', '/Users/'];
-    for (const prefix of prefixes) {
-      if (path.startsWith(prefix)) {
-        const rest = path.slice(prefix.length);
-        const slashIdx = rest.indexOf('/');
-        if (slashIdx !== -1) return '~' + rest.slice(slashIdx);
-        return '~';
-      }
-    }
-    return path;
-  }
-
   function globalIndex(taskId: string): number {
     return taskIndexById().get(taskId) ?? -1;
   }
@@ -577,7 +565,7 @@ export function Sidebar() {
                         >
                           {isProjectMissing(project.id)
                             ? 'Folder not found'
-                            : abbreviatePath(project.path)}
+                            : abbreviateHomePath(project.path)}
                         </div>
                       </div>
                       <button

--- a/src/components/TaskBranchInfoBar.tsx
+++ b/src/components/TaskBranchInfoBar.tsx
@@ -6,6 +6,7 @@ import { InfoBar } from './InfoBar';
 import { theme } from '../lib/theme';
 import { isMac } from '../lib/platform';
 import { parseGitHubUrl } from '../lib/github-url';
+import { abbreviateHomePath } from '../lib/path';
 import type { Task } from '../store/types';
 
 const infoBarBtnStyle: JSX.CSSProperties = {
@@ -46,6 +47,7 @@ export function TaskBranchInfoBar(props: TaskBranchInfoBarProps) {
     store.editorCommand
       ? `Click to open in ${store.editorCommand} · ${mod}+Click to reveal in file manager · ${mod}+Shift+Click to open the project root in ${store.editorCommand}`
       : `Click to reveal in file manager · ${mod}+Shift+Click to reveal the project root`;
+  const worktreeTitle = () => `${props.task.worktreePath}\n${editorTitle()}`;
 
   const handleOpenInEditor = (e: MouseEvent) => {
     const modKey = e.ctrlKey || e.metaKey;
@@ -231,9 +233,9 @@ export function TaskBranchInfoBar(props: TaskBranchInfoBarProps) {
       </Show>
       <button
         type="button"
-        title={editorTitle()}
+        title={worktreeTitle()}
         onClick={handleOpenInEditor}
-        style={{ ...infoBarBtnStyle, opacity: 0.6 }}
+        style={{ ...infoBarBtnStyle, opacity: 0.6, 'min-width': '0', overflow: 'hidden' }}
       >
         <svg
           width="12"
@@ -244,7 +246,16 @@ export function TaskBranchInfoBar(props: TaskBranchInfoBarProps) {
         >
           <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
         </svg>
-        {props.task.worktreePath}
+        <span
+          style={{
+            overflow: 'hidden',
+            'text-overflow': 'ellipsis',
+            'white-space': 'nowrap',
+            'min-width': '0',
+          }}
+        >
+          {abbreviateHomePath(props.task.worktreePath)}
+        </span>
       </button>
       <Show when={props.task.externalWorktree}>
         <span

--- a/src/lib/path.test.ts
+++ b/src/lib/path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { abbreviateHomePath } from './path';
+
+describe('abbreviateHomePath', () => {
+  it('shortens macOS home paths', () => {
+    expect(abbreviateHomePath('/Users/liang/projects/app')).toBe('~/projects/app');
+  });
+
+  it('shortens Linux home paths', () => {
+    expect(abbreviateHomePath('/home/liang/projects/app')).toBe('~/projects/app');
+  });
+
+  it('shortens the home directory itself', () => {
+    expect(abbreviateHomePath('/Users/liang')).toBe('~');
+  });
+
+  it('leaves non-home paths unchanged', () => {
+    expect(abbreviateHomePath('/var/tmp/app')).toBe('/var/tmp/app');
+  });
+});

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -1,0 +1,12 @@
+export function abbreviateHomePath(path: string): string {
+  const prefixes = ['/home/', '/Users/'];
+  for (const prefix of prefixes) {
+    if (path.startsWith(prefix)) {
+      const rest = path.slice(prefix.length);
+      const slashIdx = rest.indexOf('/');
+      if (slashIdx !== -1) return '~' + rest.slice(slashIdx);
+      return '~';
+    }
+  }
+  return path;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1360,7 +1360,6 @@ textarea::placeholder {
 
 .dialog-overlay {
   animation: fadeIn 0.16s ease;
-  background: color-mix(in srgb, #000 44%, transparent);
   backdrop-filter: saturate(1.15);
 }
 


### PR DESCRIPTION
## Summary
- Fix the close-cleanup setting copy so it says the branch/worktree cleanup happens on close, not on merge.
- Move the existing home-path abbreviation into a shared helper, reuse it for the task worktree path, and keep the full path in the tooltip with ellipsis support.
- Remove the stale `.dialog-overlay` background rule that was overridden by the inline dialog overlay background.
- Let the Escape close-dialog action close Arena through the same reset-and-close path as the Arena close button.

Addresses part of #214.

## Validation
- `npm run test -- src/lib/path.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run compile`
- `npm run test`

The local git hooks also reran `npm run check` and `npm run test` during commit/push.
