### PR TITLE
Confirm before discarding new task drafts

### DIFF
--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -9,6 +9,7 @@ import {
   untrack,
 } from 'solid-js';
 import { Dialog } from './Dialog';
+import { ConfirmDialog } from './ConfirmDialog';
 import { errMessage } from '../lib/log';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
@@ -54,6 +55,7 @@ import {
   MAX_COORDINATOR_CONCURRENT_TASKS,
   MIN_COORDINATOR_CONCURRENT_TASKS,
 } from '../lib/coordinator-limits';
+import { hasNewTaskDraft } from './new-task-draft';
 
 interface NewTaskDialogProps {
   open: boolean;
@@ -67,6 +69,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const [selectedProjectId, setSelectedProjectId] = createSignal<string | null>(null);
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = createSignal(false);
   const [ignoredDirs, setIgnoredDirs] = createSignal<string[]>([]);
   const [selectedDirs, setSelectedDirs] = createSignal<Set<string>>(new Set());
   const [gitIsolation, setGitIsolation] = createSignal<GitIsolationMode>('worktree');
@@ -161,6 +164,19 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     focusables[nextIdx].focus();
   }
 
+  function requestClose(): void {
+    if (hasNewTaskDraft(prompt(), name())) {
+      setShowDiscardConfirm(true);
+      return;
+    }
+    props.onClose();
+  }
+
+  function discardDraftAndClose(): void {
+    setShowDiscardConfirm(false);
+    props.onClose();
+  }
+
   // Initialize state each time the dialog opens.  Wrapped in on() so the
   // effect only re-fires on the props.open *transition*, not whenever any
   // store default mutates while the dialog is already open (e.g. the user
@@ -190,6 +206,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     setName('');
     setError('');
     setLoading(false);
+    setShowDiscardConfirm(false);
     setGitIsolation('worktree');
     setDockerMode(false);
     setDockerImageReady(null);
@@ -677,7 +694,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   return (
     <Dialog
       open={props.open}
-      onClose={props.onClose}
+      onClose={requestClose}
       width={store.availableAgents.length > 8 ? 'min(840px, calc(100vw - 48px))' : '560px'}
       labelledBy={titleId}
       panelStyle={{ padding: '0', overflow: 'hidden', gap: '0' }}
@@ -1375,7 +1392,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
           <button
             type="button"
             class="btn-secondary"
-            onClick={() => props.onClose()}
+            onClick={requestClose}
             style={{
               padding: '9px 18px',
               background: theme.bgInput,
@@ -1414,6 +1431,16 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
           </button>
         </div>
       </form>
+      <ConfirmDialog
+        open={props.open && showDiscardConfirm()}
+        title="Discard task draft?"
+        message="The prompt or task name you typed will be lost."
+        confirmLabel="Discard draft"
+        cancelLabel="Keep editing"
+        danger
+        onConfirm={discardDraftAndClose}
+        onCancel={() => setShowDiscardConfirm(false)}
+      />
     </Dialog>
   );
 }

--- a/src/components/new-task-draft.test.ts
+++ b/src/components/new-task-draft.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { hasNewTaskDraft } from './new-task-draft';
+
+describe('hasNewTaskDraft', () => {
+  it('ignores empty dialog fields', () => {
+    expect(hasNewTaskDraft('', '')).toBe(false);
+    expect(hasNewTaskDraft('  \n ', '  ')).toBe(false);
+  });
+
+  it('detects a prompt draft', () => {
+    expect(hasNewTaskDraft('fix the failing tests', '')).toBe(true);
+  });
+
+  it('detects a task-name draft without a prompt', () => {
+    expect(hasNewTaskDraft('', 'release notes cleanup')).toBe(true);
+  });
+});

--- a/src/components/new-task-draft.ts
+++ b/src/components/new-task-draft.ts
@@ -1,0 +1,3 @@
+export function hasNewTaskDraft(prompt: string, name: string): boolean {
+  return prompt.trim().length > 0 || name.trim().length > 0;
+}


### PR DESCRIPTION
## Summary
- Add a NewTaskDialog close guard when the prompt or task name has draft text.
- Show a discard confirmation for overlay click, Escape, and Cancel instead of silently closing.
- Keep the draft in place when the user chooses to keep editing.

Fixes #201.

## Validation
- `npm run test -- src/components/new-task-draft.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run compile`
- `npm run test`

The local git hooks also reran `npm run check` and `npm run test` during commit/push.
