### PR TITLE
Refactor duplicated inline icons into shared components

### DIFF
--- a/src/arena/ConfigScreen.tsx
+++ b/src/arena/ConfigScreen.tsx
@@ -19,6 +19,7 @@ import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { saveArenaPresets } from './persistence';
 import { ProjectSelect } from '../components/ProjectSelect';
+import { CloseIcon } from '../components/icons';
 import { MAX_COMPETITORS, MIN_COMPETITORS } from './store';
 import type { BattleCompetitor } from './types';
 
@@ -165,9 +166,7 @@ export function ConfigScreen() {
                   onClick={() => removeCompetitor(competitor.id)}
                   title="Remove competitor"
                 >
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                  </svg>
+                  <CloseIcon size={14} />
                 </button>
               </div>
               <input

--- a/src/components/CommitTreeOverlay.tsx
+++ b/src/components/CommitTreeOverlay.tsx
@@ -4,6 +4,7 @@ import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { accentControlColors } from '../lib/controlStyle';
 import { CommitTreeView } from './CommitTreeView';
+import { CloseIcon, GitGraphIcon } from './icons';
 import type { CommitSelection } from './CommitNavBar';
 import type { CommitInfo } from '../ipc/types';
 
@@ -93,9 +94,7 @@ export function CommitTreeOverlay(props: CommitTreeOverlayProps) {
         onClick={toggle}
         style={buttonStyle(open())}
       >
-        <svg width={12} height={12} viewBox="0 0 16 16" fill="currentColor">
-          <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
-        </svg>
+        <GitGraphIcon size={12} />
       </button>
 
       <Show when={open() ? panel() : null}>
@@ -146,7 +145,7 @@ export function CommitTreeOverlay(props: CommitTreeOverlayProps) {
               >
                 <span style={{ flex: '1' }}>Commit Tree</span>
                 <button title="Close" onClick={() => setOpen(false)} style={closeStyle()}>
-                  ✕
+                  <CloseIcon size={12} />
                 </button>
               </div>
               <div style={{ flex: '1', 'min-height': '0', display: 'flex' }}>

--- a/src/components/DiffViewerDialog.tsx
+++ b/src/components/DiffViewerDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { ReviewCommentsButton, ReviewSidebarPanel } from './ReviewSidebarPanel';
 import { ReviewProvider, useReview } from './ReviewProvider';
 import { ChangedFilesList } from './ChangedFilesList';
+import { CloseIcon } from './icons';
 import type { FileDiff } from '../lib/unified-diff-parser';
 import type { ReviewAnnotation } from './review-types';
 import type { CommitInfo } from '../ipc/types';
@@ -395,9 +396,7 @@ function DiffViewerContent(props: DiffViewerDialogProps) {
           }}
           title="Close"
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-          </svg>
+          <CloseIcon />
         </button>
       </div>
 

--- a/src/components/EditProjectDialog.tsx
+++ b/src/components/EditProjectDialog.tsx
@@ -12,6 +12,7 @@ import { theme, sectionLabelStyle } from '../lib/theme';
 import type { Project, TerminalBookmark, GitIsolationMode } from '../store/types';
 import { SegmentedButtons } from './SegmentedButtons';
 import { ImportWorktreesDialog } from './ImportWorktreesDialog';
+import { CloseIcon } from './icons';
 
 interface EditProjectDialogProps {
   project: Project | null;
@@ -469,9 +470,7 @@ export function EditProjectDialog(props: EditProjectDialogProps) {
                           }}
                           title="Remove bookmark"
                         >
-                          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                          </svg>
+                          <CloseIcon size={12} />
                         </button>
                       </div>
                     )}

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -9,6 +9,7 @@ import {
   untrack,
 } from 'solid-js';
 import { Dialog } from './Dialog';
+import { FolderIcon, GitBranchIcon } from './icons';
 import { errMessage } from '../lib/log';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
@@ -807,27 +808,11 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
                 }}
               >
                 <span style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
-                  <svg
-                    width="11"
-                    height="11"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    style={{ 'flex-shrink': '0' }}
-                  >
-                    <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
-                  </svg>
+                  <GitBranchIcon size={11} style={{ 'flex-shrink': '0' }} />
                   main branch (detected on create)
                 </span>
                 <span style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
-                  <svg
-                    width="11"
-                    height="11"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    style={{ 'flex-shrink': '0' }}
-                  >
-                    <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
-                  </svg>
+                  <FolderIcon size={11} style={{ 'flex-shrink': '0' }} />
                   {selectedProjectPath()}
                 </span>
               </div>
@@ -1090,7 +1075,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
                         gap: '4px',
                       }}
                     >
-                      <span aria-hidden="true">📁</span>
+                      <FolderIcon size={12} />
                       Using project Dockerfile:{' '}
                       <code style={{ 'font-family': "'JetBrains Mono', monospace" }}>
                         {PROJECT_DOCKERFILE_RELATIVE_PATH}

--- a/src/components/PlanViewerDialog.tsx
+++ b/src/components/PlanViewerDialog.tsx
@@ -6,6 +6,7 @@ import { ReviewCommentsButton, ReviewSidebarPanel } from './ReviewSidebarPanel';
 import { ReviewCommentCard } from './ReviewCommentCard';
 import { InlineInput } from './InlineInput';
 import { AskCodeCard } from './AskCodeCard';
+import { CloseIcon } from './icons';
 import { createHighlightedMarkdown } from '../lib/marked-shiki';
 import { getPlanSelection } from '../lib/plan-selection';
 import { openFileInEditor } from '../lib/shell';
@@ -253,9 +254,7 @@ function PlanViewerContent(props: PlanViewerContentProps) {
           }}
           title="Close"
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-          </svg>
+          <CloseIcon />
         </button>
       </div>
 

--- a/src/components/SubTaskStrip.tsx
+++ b/src/components/SubTaskStrip.tsx
@@ -7,6 +7,7 @@ import { StatusDot } from './StatusDot';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { Dialog } from './Dialog';
+import { CheckIcon, CloseIcon } from './icons';
 
 interface SubTaskStripProps {
   coordinatorTaskId: string;
@@ -58,7 +59,7 @@ function MCPLogModal(props: { onClose: () => void }) {
           }}
           onClick={() => props.onClose()}
         >
-          ✕
+          <CloseIcon size={14} />
         </button>
       </div>
       <div
@@ -216,7 +217,11 @@ export function SubTaskStrip(props: SubTaskStripProps) {
                   when={taskTone(task)}
                   fallback={<StatusDot status={getTaskDotStatus(task.id)} size="sm" />}
                 >
-                  {(tone) => <span style={{ color: tone().color, 'font-size': sf(10) }}>✓</span>}
+                  {(tone) => (
+                    <span style={{ color: tone().color, display: 'inline-flex' }}>
+                      <CheckIcon size={10} />
+                    </span>
+                  )}
                 </Show>
                 <span style={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }}>{task.name}</span>
               </button>

--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -21,6 +21,7 @@ import { warn as logWarn } from '../lib/log';
 import { InfoBar } from './InfoBar';
 import { TerminalView } from './TerminalView';
 import { Dialog } from './Dialog';
+import { CloseIcon } from './icons';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { invoke } from '../lib/ipc';
@@ -309,9 +310,7 @@ export function TaskAITerminal(props: TaskAITerminalProps) {
                             padding: '0',
                           }}
                         >
-                          <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor">
-                            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                          </svg>
+                          <CloseIcon size={11} />
                         </button>
                       </Show>
                     </span>
@@ -723,9 +722,7 @@ function MarkdownViewerDialog(props: {
           }}
           title="Close"
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-          </svg>
+          <CloseIcon />
         </button>
       </div>
       <div

--- a/src/components/TaskShellSection.tsx
+++ b/src/components/TaskShellSection.tsx
@@ -17,6 +17,7 @@ import {
   isPanelFocusedPrefix,
 } from '../store/store';
 import { TerminalView } from './TerminalView';
+import { CloseIcon } from './icons';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { mod } from '../lib/platform';
@@ -249,9 +250,7 @@ export function TaskShellSection(props: TaskShellSectionProps) {
                       'font-size': '15px',
                     }}
                   >
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                    </svg>
+                    <CloseIcon size={12} />
                   </button>
                   <Show when={shellExits[shellId]}>
                     <div

--- a/src/components/TaskStepsSection.tsx
+++ b/src/components/TaskStepsSection.tsx
@@ -3,6 +3,7 @@ import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
 import { useFocusRegistration } from '../lib/focus-registration';
 import { setTaskFocusedPanel, isPanelFocused } from '../store/store';
+import { CheckIcon, CopyIcon } from './icons';
 import type { Task } from '../store/types';
 import type { StepEntry } from '../ipc/types';
 import { warn as logWarn } from '../lib/log';
@@ -228,7 +229,7 @@ function CopyButton(props: { text: string; visible: boolean; label: string }) {
         'line-height': '1',
       }}
     >
-      {copied() ? '✓' : '⧉'}
+      {copied() ? <CheckIcon size={11} /> : <CopyIcon size={11} />}
     </button>
   );
 }

--- a/src/components/TaskTitleBar.tsx
+++ b/src/components/TaskTitleBar.tsx
@@ -14,6 +14,7 @@ import {
 import { EditableText, type EditableTextHandle } from './EditableText';
 import { IconButton } from './IconButton';
 import { StatusDot } from './StatusDot';
+import { CheckIcon, CloseIcon } from './icons';
 import { theme } from '../lib/theme';
 import { badgeStyle } from '../lib/badgeStyle';
 import { handleDragReorder } from '../lib/dragReorder';
@@ -311,14 +312,10 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
                     <span class="inline-spinner" style={{ width: '12px', height: '12px' }} />
                   </Show>
                   <Show when={c().overall === 'success'}>
-                    <svg width="9" height="9" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
-                    </svg>
+                    <CheckIcon size={9} />
                   </Show>
                   <Show when={c().overall === 'failure'}>
-                    <svg width="9" height="9" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                    </svg>
+                    <CloseIcon size={9} />
                   </Show>
                 </div>
               )}
@@ -353,15 +350,7 @@ export function TaskTitleBar(props: TaskTitleBarProps) {
             title="Collapse task"
           />
         </Show>
-        <IconButton
-          icon={
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-            </svg>
-          }
-          onClick={() => props.onClose()}
-          title="Close task"
-        />
+        <IconButton icon={<CloseIcon />} onClick={() => props.onClose()} title="Close task" />
       </div>
     </div>
   );

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { EditableText, type EditableTextHandle } from './EditableText';
 import { IconButton } from './IconButton';
 import { TerminalView } from './TerminalView';
+import { CloseIcon } from './icons';
 import { theme } from '../lib/theme';
 import { handleDragReorder } from '../lib/dragReorder';
 import type { Terminal } from '../store/types';
@@ -117,11 +118,7 @@ export function TerminalPanel(props: TerminalPanelProps) {
         </div>
         <div style={{ display: 'flex', gap: '4px', 'margin-left': '8px', 'flex-shrink': '0' }}>
           <IconButton
-            icon={
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-              </svg>
-            }
+            icon={<CloseIcon />}
             onClick={() => closeTerminal(props.terminal.id)}
             title="Close terminal"
           />

--- a/src/components/TerminalSearchOverlay.tsx
+++ b/src/components/TerminalSearchOverlay.tsx
@@ -1,4 +1,5 @@
 import { onMount, type JSX } from 'solid-js';
+import { CloseIcon } from './icons';
 
 export interface TerminalSearchOverlayProps {
   query: string;
@@ -147,7 +148,7 @@ export function TerminalSearchOverlay(props: TerminalSearchOverlayProps): JSX.El
         onClick={() => props.onClose()}
         style={ICON_BUTTON_STYLE}
       >
-        ✕
+        <CloseIcon size={13} />
       </button>
     </div>
   );

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,80 @@
+import type { JSX } from 'solid-js';
+
+interface IconProps {
+  size?: number | string;
+  title?: string;
+  class?: string;
+  style?: JSX.CSSProperties;
+}
+
+interface SvgIconProps extends IconProps {
+  children: JSX.Element;
+}
+
+function SvgIcon(props: SvgIconProps): JSX.Element {
+  const size = () => props.size ?? 16;
+
+  return (
+    <svg
+      width={size()}
+      height={size()}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      class={props.class}
+      style={props.style}
+      aria-hidden={props.title ? undefined : 'true'}
+      role={props.title ? 'img' : undefined}
+    >
+      {props.title ? <title>{props.title}</title> : null}
+      {props.children}
+    </svg>
+  );
+}
+
+export function CheckIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+    </SvgIcon>
+  );
+}
+
+export function CloseIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+    </SvgIcon>
+  );
+}
+
+export function CopyIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M2.75 2A1.75 1.75 0 0 0 1 3.75v6.5C1 11.216 1.784 12 2.75 12H4v-1.5H2.75a.25.25 0 0 1-.25-.25v-6.5a.25.25 0 0 1 .25-.25h6.5a.25.25 0 0 1 .25.25V5H11V3.75A1.75 1.75 0 0 0 9.25 2h-6.5ZM6.75 6A1.75 1.75 0 0 0 5 7.75v4.5C5 13.216 5.784 14 6.75 14h6.5A1.75 1.75 0 0 0 15 12.25v-4.5A1.75 1.75 0 0 0 13.25 6h-6.5Zm-.25 1.75a.25.25 0 0 1 .25-.25h6.5a.25.25 0 0 1 .25.25v4.5a.25.25 0 0 1-.25.25h-6.5a.25.25 0 0 1-.25-.25v-4.5Z" />
+    </SvgIcon>
+  );
+}
+
+export function FolderIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
+    </SvgIcon>
+  );
+}
+
+export function GitBranchIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6.25 7.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 7.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 0h5.5a2.5 2.5 0 0 0 2.5-2.5v-.5a.75.75 0 0 0-1.5 0v.5a1 1 0 0 1-1 1H5a3.25 3.25 0 1 0 0 6.5h6.25a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 1 1 0-3.5Z" />
+    </SvgIcon>
+  );
+}
+
+export function GitGraphIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared `src/components/icons.tsx` module with reusable `currentColor` icon components
- replace the duplicated Octicon close path call sites with `CloseIcon`
- replace the named glyph/emoji examples from #208 (`✕`, `✓`, `📁`) with shared SVG icons
- reuse shared folder, branch, and commit-graph icons in the touched dialog/overlay surfaces

Refs #208

## Validation
- `npm run typecheck`
- `npm run check`
- pre-push hook: `npm run check` + `npm run test`
