### PR TITLE
refactor: simplify MCP coordinator surface

### DIFF
--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -1691,25 +1691,14 @@ export function registerAllHandlers(win: BrowserWindow): void {
       // Build mcpConfig and mergedMcpJson (pure computation — no filesystem or state side effects).
       // Doing this before any Docker copy or coordinator mutation ensures that if .mcp.json
       // merge logic ever grows fallible, Docker residue is never left behind.
-      const mcpConfig = {
-        mcpServers: {
-          'parallel-code': {
-            type: 'stdio' as const,
-            command: 'node',
-            args: [
-              mcpServerPath,
-              '--url',
-              serverUrl,
-              '--coordinator-id',
-              args.coordinatorTaskId,
-              ...(args.skipPermissions && args.propagateSkipPermissions
-                ? ['--skip-permissions']
-                : []),
-            ],
-            env: { PARALLEL_CODE_MCP_TOKEN: remoteServer.token },
-          },
-        },
-      };
+      const mcpConfig = buildCoordinatorMCPConfig({
+        mcpServerPath,
+        serverUrl,
+        token: remoteServer.token,
+        coordinatorTaskId: args.coordinatorTaskId,
+        skipPermissions: args.skipPermissions,
+        propagateSkipPermissions: args.propagateSkipPermissions,
+      });
 
       const configJson = JSON.stringify(mcpConfig, null, 2);
 

--- a/electron/mcp/config.test.ts
+++ b/electron/mcp/config.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  buildSubTaskMcpConfig,
   getMCPRemoteServerUrl,
   getSubTaskMcpConfigPath,
   detectStaleDockerMCPUrl,
+  isAllowedSubTaskMcpConfigPath,
+  writeSubTaskMcpConfig,
 } from './config.js';
 
 describe('getMCPRemoteServerUrl', () => {
@@ -51,6 +55,104 @@ describe('getSubTaskMcpConfigPath', () => {
     const serverPath = '/usr/lib/parallel-code/mcp-server.cjs';
     const result = getSubTaskMcpConfigPath(undefined, serverPath, 'task-123');
     expect(result).toBe(join(tmpdir(), 'parallel-code-subtask-task-123.json'));
+  });
+});
+
+describe('buildSubTaskMcpConfig', () => {
+  it('builds a task-scoped stdio server config with subtask and done tokens', () => {
+    const cfg = buildSubTaskMcpConfig({
+      serverPath: '/worktree/.parallel-code/mcp-server.cjs',
+      serverUrl: 'http://127.0.0.1:7777',
+      subtaskToken: 'subtask-token',
+      taskId: 'task-abc',
+      doneToken: 'done-token',
+    });
+
+    expect(cfg).toEqual({
+      mcpServers: {
+        'parallel-code': {
+          type: 'stdio',
+          command: 'node',
+          args: [
+            '/worktree/.parallel-code/mcp-server.cjs',
+            '--url',
+            'http://127.0.0.1:7777',
+            '--task-id',
+            'task-abc',
+          ],
+          env: {
+            PARALLEL_CODE_MCP_TOKEN: 'subtask-token',
+            PARALLEL_CODE_MCP_DONE_TOKEN: 'done-token',
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('writeSubTaskMcpConfig', () => {
+  it('writes the sub-task config as readable JSON', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parallel-code-config-test-'));
+    const configPath = join(dir, 'subtask-task-abc.json');
+    const cfg = buildSubTaskMcpConfig({
+      serverPath: '/srv/mcp-server.cjs',
+      serverUrl: 'http://127.0.0.1:7777',
+      subtaskToken: 'subtask-token',
+      taskId: 'task-abc',
+      doneToken: 'done-token',
+    });
+
+    try {
+      await writeSubTaskMcpConfig(configPath, cfg);
+
+      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual(cfg);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isAllowedSubTaskMcpConfigPath', () => {
+  it('allows the host temp path generated for the task', () => {
+    expect(
+      isAllowedSubTaskMcpConfigPath('/tmp/parallel-code-subtask-task-abc.json', {
+        taskId: 'task-abc',
+        serverPath: '/worktree/.parallel-code/mcp-server.cjs',
+        tempDir: '/tmp',
+      }),
+    ).toBe(true);
+  });
+
+  it('allows the Docker coordinator .parallel-code path generated for the task', () => {
+    expect(
+      isAllowedSubTaskMcpConfigPath('/worktree/.parallel-code/subtask-task-abc.json', {
+        taskId: 'task-abc',
+        serverPath: '/worktree/.parallel-code/mcp-server.cjs',
+        dockerContainerName: 'parallel-code-coord',
+        tempDir: '/tmp',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects the Docker coordinator path in host mode even when serverPath is present', () => {
+    expect(
+      isAllowedSubTaskMcpConfigPath('/worktree/.parallel-code/subtask-task-abc.json', {
+        taskId: 'task-abc',
+        serverPath: '/worktree/.parallel-code/mcp-server.cjs',
+        tempDir: '/tmp',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects basename matches outside the generated host or Docker locations', () => {
+    expect(
+      isAllowedSubTaskMcpConfigPath('/tmp/elsewhere/subtask-task-abc.json', {
+        taskId: 'task-abc',
+        serverPath: '/worktree/.parallel-code/mcp-server.cjs',
+        dockerContainerName: 'parallel-code-coord',
+        tempDir: '/tmp',
+      }),
+    ).toBe(false);
   });
 });
 

--- a/electron/mcp/config.ts
+++ b/electron/mcp/config.ts
@@ -1,5 +1,28 @@
 import os from 'os';
 import { join, dirname } from 'path';
+import { atomicWriteFile, atomicWriteFileSync } from './atomic.js';
+
+export interface SubTaskMcpConfigOpts {
+  serverPath: string;
+  serverUrl: string;
+  subtaskToken: string;
+  taskId: string;
+  doneToken: string;
+}
+
+export interface SubTaskMcpConfig {
+  mcpServers: {
+    'parallel-code': {
+      type: 'stdio';
+      command: 'node';
+      args: string[];
+      env: {
+        PARALLEL_CODE_MCP_TOKEN: string;
+        PARALLEL_CODE_MCP_DONE_TOKEN: string;
+      };
+    };
+  };
+}
 
 export function getMCPRemoteServerUrl(
   port: number,
@@ -32,6 +55,53 @@ export function getSubTaskMcpConfigPath(
   return dockerContainerName
     ? join(dirname(serverPath), `subtask-${taskId}.json`)
     : join(tempDir, `parallel-code-subtask-${taskId}.json`);
+}
+
+export function buildSubTaskMcpConfig(args: SubTaskMcpConfigOpts): SubTaskMcpConfig {
+  return {
+    mcpServers: {
+      'parallel-code': {
+        type: 'stdio',
+        command: 'node',
+        args: [args.serverPath, '--url', args.serverUrl, '--task-id', args.taskId],
+        env: {
+          PARALLEL_CODE_MCP_TOKEN: args.subtaskToken,
+          PARALLEL_CODE_MCP_DONE_TOKEN: args.doneToken,
+        },
+      },
+    },
+  };
+}
+
+export async function writeSubTaskMcpConfig(
+  configPath: string,
+  config: SubTaskMcpConfig,
+): Promise<void> {
+  await atomicWriteFile(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export function writeSubTaskMcpConfigSync(configPath: string, config: SubTaskMcpConfig): void {
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export function isAllowedSubTaskMcpConfigPath(
+  configPath: string | undefined,
+  args: {
+    taskId: string;
+    serverPath?: string;
+    dockerContainerName?: string | null;
+    tempDir?: string;
+  },
+): boolean {
+  if (!configPath) return false;
+  const tempDir = args.tempDir ?? os.tmpdir();
+  const allowed = new Set([getSubTaskMcpConfigPath(null, '', args.taskId, tempDir)]);
+  if (args.dockerContainerName && args.serverPath) {
+    allowed.add(
+      getSubTaskMcpConfigPath(args.dockerContainerName, args.serverPath, args.taskId, tempDir),
+    );
+  }
+  return allowed.has(configPath);
 }
 
 /**

--- a/electron/mcp/coordinator.test.ts
+++ b/electron/mcp/coordinator.test.ts
@@ -5066,11 +5066,35 @@ describe('Coordinator hydrateTask — mcpConfigPath directory scoping', () => {
     expect(configWrite).toBeDefined();
   });
 
+  it('host mode: dirname(serverPath)/subtask-{id}.json is rejected even when serverPath is present', () => {
+    const taskId = 'task-host-docker-path';
+    const serverPath = '/srv/app/.parallel-code/mcp-server.js';
+    const dockerPath = join(dirname(serverPath), `subtask-${taskId}.json`);
+
+    mockAtomicWriteFileSync.mockClear();
+    coordinator.hydrateTask({
+      id: taskId,
+      name: 'host-docker-path',
+      projectId: 'proj-1',
+      projectRoot: '/tmp/project',
+      branchName: 'task/host-docker-path',
+      worktreePath: '/tmp/host-docker-path',
+      agentId: 'agent-host-docker-path',
+      coordinatorTaskId: 'coord-1',
+      mcpConfigPath: dockerPath,
+    });
+
+    expect(coordinator.getTask(taskId)?.mcpConfigPath).toBeUndefined();
+    const configWrite = mockAtomicWriteFileSync.mock.calls.find((c) => c[0] === dockerPath);
+    expect(configWrite).toBeUndefined();
+  });
+
   it('Docker mode: dirname(serverPath)/subtask-{id}.json is accepted and config write occurs', () => {
     const taskId = 'task-valid-docker';
     const serverPath = '/srv/app/.parallel-code/mcp-server.js';
     const dockerPath = join(dirname(serverPath), `subtask-${taskId}.json`);
 
+    coordinator.setDockerContainerName('coord-1', 'parallel-code-coord');
     mockAtomicWriteFileSync.mockClear();
     coordinator.hydrateTask({
       id: taskId,
@@ -5093,6 +5117,7 @@ describe('Coordinator hydrateTask — mcpConfigPath directory scoping', () => {
     const taskId = 'task-evil-docker';
     const wrongPath = `/some/other/dir/subtask-${taskId}.json`;
 
+    coordinator.setDockerContainerName('coord-1', 'parallel-code-coord');
     coordinator.hydrateTask({
       id: taskId,
       name: 'evil-docker',
@@ -5776,66 +5801,6 @@ describe('preload.cjs MCP channel allowlist', () => {
     for (const channel of required) {
       expect(preload, `preload.cjs missing channel: ${channel}`).toContain(`'${channel}'`);
     }
-  });
-});
-
-// ─── validateUUID / hydrateTask path-traversal rejection ─────────────────────
-
-describe('validateUUID — rejects non-UUID ids in MCP IPC handler', () => {
-  it('rejects ids containing path separators', async () => {
-    const { validateUUID } = await import('./validation.js');
-    expect(() => validateUUID('../../etc/passwd', 'id')).toThrow('must be a valid UUID');
-  });
-
-  it('rejects ids containing slashes', async () => {
-    const { validateUUID } = await import('./validation.js');
-    expect(() => validateUUID('task/1', 'id')).toThrow('must be a valid UUID');
-  });
-
-  it('accepts a valid UUID', async () => {
-    const { validateUUID } = await import('./validation.js');
-    const id = '550e8400-e29b-41d4-a716-446655440000';
-    expect(validateUUID(id, 'id')).toBe(id);
-  });
-});
-
-// ─── validateBranchName — additional git check-ref-format rules ───────────────
-
-describe('validateBranchName — extended git rules', () => {
-  it('rejects names starting with "/"', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(() => validateBranchName('/feat/bad')).toThrow('must not start with "/"');
-  });
-
-  it('rejects names ending with "/"', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(() => validateBranchName('feat/bad/')).toThrow('must not end with "/"');
-  });
-
-  it('rejects names ending with ".lock"', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(() => validateBranchName('feat.lock')).toThrow('.lock');
-  });
-
-  it('rejects names containing "@{"', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    // { is caught by the shell metacharacter check
-    expect(() => validateBranchName('feat@{bad}')).toThrow('invalid characters');
-  });
-
-  it('rejects names containing "//"', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(() => validateBranchName('feat//bad')).toThrow('must not contain "//"');
-  });
-
-  it('rejects names starting with "."', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(() => validateBranchName('.hidden')).toThrow('must not start with "."');
-  });
-
-  it('still accepts normal branch names', async () => {
-    const { validateBranchName } = await import('./validation.js');
-    expect(validateBranchName('feat/my-feature')).toBe('feat/my-feature');
   });
 });
 

--- a/electron/mcp/coordinator.ts
+++ b/electron/mcp/coordinator.ts
@@ -6,26 +6,28 @@ import { randomUUID, randomBytes } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { unlinkSync, readFileSync, existsSync } from 'fs';
+import { unlink as fsUnlink } from 'fs/promises';
 import {
-  readFile as fsReadFile,
-  writeFile as fsWriteFile,
-  unlink as fsUnlink,
-  access as fsAccess,
-  mkdir as fsMkdir,
-} from 'fs/promises';
-import { join, dirname } from 'path';
-import os from 'os';
-import { getSubTaskMcpConfigPath } from './config.js';
+  buildSubTaskMcpConfig,
+  getSubTaskMcpConfigPath,
+  isAllowedSubTaskMcpConfigPath,
+  writeSubTaskMcpConfig,
+  writeSubTaskMcpConfigSync,
+} from './config.js';
 import { buildMcpLaunchArgs } from './agent-args.js';
 import { validateBranchName } from './validation.js';
-import { atomicWriteFileSync, atomicWriteFile } from './atomic.js';
+import { atomicWriteFileSync } from './atomic.js';
 import { ReplayCache } from './replay-cache.js';
 import {
   detectPreambleFiles,
   filterDiffSections,
   buildNormalizedPreambleFileDiff,
   stripPreambleFromBranch,
+  injectSubTaskPreamble,
+  restoreSubTaskPreambleInjection,
+  type InjectedSubTaskPreamble,
 } from './preamble.js';
+import { truncateDiffForTool } from './diff-format.js';
 
 const execAsync = promisify(execFile);
 import type { BrowserWindow } from 'electron';
@@ -135,34 +137,6 @@ function parsePorcelainPaths(statusOut: string): string[] {
 function execStdout(result: Awaited<ReturnType<typeof execAsync>>): string {
   const stdout = typeof result === 'string' ? result : result.stdout;
   return typeof stdout === 'string' ? stdout : stdout.toString('utf8');
-}
-
-/**
- * The per-sub-task MCP config: a stdio launch of the parallel-code MCP server
- * scoped to one task. Identical across createTask, coordinator re-registration,
- * and hydration rewrite — only the resolved doneToken differs, so callers own
- * token generation and pass the final value in.
- */
-function buildSubtaskMcpConfig(args: {
-  serverPath: string;
-  serverUrl: string;
-  subtaskToken: string;
-  taskId: string;
-  doneToken: string;
-}) {
-  return {
-    mcpServers: {
-      'parallel-code': {
-        type: 'stdio' as const,
-        command: 'node',
-        args: [args.serverPath, '--url', args.serverUrl, '--task-id', args.taskId],
-        env: {
-          PARALLEL_CODE_MCP_TOKEN: args.subtaskToken,
-          PARALLEL_CODE_MCP_DONE_TOKEN: args.doneToken,
-        },
-      },
-    },
-  };
 }
 
 export class Coordinator {
@@ -459,7 +433,7 @@ export class Coordinator {
     });
   }
 
-  private buildAgentOutputCb(task: CoordinatedTask): (encoded: string) => void {
+  private createAgentOutputMonitor(task: CoordinatedTask): (encoded: string) => void {
     return (encoded: string) => {
       const bytes = Buffer.from(encoded, 'base64');
       const text = (this.decoders.get(task.agentId) ?? new TextDecoder()).decode(bytes, {
@@ -482,37 +456,41 @@ export class Coordinator {
         }
       }
       if (hasAgentPrompt) {
-        this.scheduleInitialPromptDelivery(task, INITIAL_PROMPT_READY_DELAY_MS, true);
-        if (
-          !task.initialPrompt &&
-          task.assignedPromptDelivered &&
-          this.controlMap.get(task.id) !== 'human' &&
-          task.pendingPrompts?.length
-        ) {
-          if (stableAgentPrompt && !this.writingPromptTaskIds.has(task.id)) {
-            void this.flushNextQueuedPrompt(task);
-          } else {
-            this.scheduleQueuedPromptFlush(task);
-          }
-          return;
-        }
-        if (task.suppressIdleUntil !== undefined && this.suppressPromptEchoIdleIfNeeded(task)) {
-          return;
-        }
-        if (task.status === 'running') {
-          task.status = 'idle';
-          this.maybeQueueReviewNotification(task, 'idle', null);
-        }
-        const resolvers = this.idleResolvers.get(task.id);
-        if (resolvers?.length) {
-          for (const resolve of resolvers) resolve({ reason: 'idle' });
-          this.idleResolvers.delete(task.id);
-        }
+        this.handlePromptDetected(task, stableAgentPrompt);
       } else if (task.status === 'idle') {
         task.status = 'running';
         this.suppressPendingNotificationForTask(task);
       }
     };
+  }
+
+  private handlePromptDetected(task: CoordinatedTask, stableAgentPrompt: boolean): void {
+    this.scheduleInitialPromptDelivery(task, INITIAL_PROMPT_READY_DELAY_MS, true);
+    if (
+      !task.initialPrompt &&
+      task.assignedPromptDelivered &&
+      this.controlMap.get(task.id) !== 'human' &&
+      task.pendingPrompts?.length
+    ) {
+      if (stableAgentPrompt && !this.writingPromptTaskIds.has(task.id)) {
+        void this.flushNextQueuedPrompt(task);
+      } else {
+        this.scheduleQueuedPromptFlush(task);
+      }
+      return;
+    }
+    if (task.suppressIdleUntil !== undefined && this.suppressPromptEchoIdleIfNeeded(task)) {
+      return;
+    }
+    if (task.status === 'running') {
+      task.status = 'idle';
+      this.maybeQueueReviewNotification(task, 'idle', null);
+    }
+    const resolvers = this.idleResolvers.get(task.id);
+    if (resolvers?.length) {
+      for (const resolve of resolvers) resolve({ reason: 'idle' });
+      this.idleResolvers.delete(task.id);
+    }
   }
 
   private async tryDeliverInitialPrompt(taskId: string): Promise<void> {
@@ -610,16 +588,26 @@ export class Coordinator {
     for (const task of this.tasks.values()) {
       if (task.coordinatorTaskId !== coordinatorTaskId) continue;
       if (!task.mcpConfigPath) continue;
+      const mcpConfigPath = task.mcpConfigPath;
+      const safeMcpConfigPath = isAllowedSubTaskMcpConfigPath(mcpConfigPath, {
+        taskId: task.id,
+        serverPath,
+        dockerContainerName: state?.dockerContainerName ?? null,
+      });
+      if (!safeMcpConfigPath) {
+        task.mcpConfigPath = undefined;
+        continue;
+      }
       // Preserve existing doneToken; generate a fresh one if not yet set (e.g. older persisted task).
       if (!task.doneToken) task.doneToken = randomBytes(24).toString('base64url');
-      const mcpConfig = buildSubtaskMcpConfig({
+      const mcpConfig = buildSubTaskMcpConfig({
         serverPath,
         serverUrl,
         subtaskToken,
         taskId: task.id,
         doneToken: task.doneToken,
       });
-      atomicWriteFileSync(task.mcpConfigPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
+      writeSubTaskMcpConfigSync(mcpConfigPath, mcpConfig);
     }
   }
 
@@ -872,96 +860,26 @@ export class Coordinator {
     const decoder = new TextDecoder();
     this.decoders.set(agentId, decoder);
 
-    const outputCb = this.buildAgentOutputCb(task);
+    const outputCb = this.createAgentOutputMonitor(task);
     this.subscribers.set(agentId, outputCb);
 
     // Spawn the agent process
     if (!this.win) throw new Error('No window set on coordinator');
 
-    const agentCmd = (opts.agentCommand ?? coordinatorState.spawnDefaults.command).toLowerCase();
-    const preamble = `<sub-task-mode>\nThese rules override all skills and hooks:\n- When your work is complete, commit your changes and call the \`land_self\` MCP tool with the verification checks you ran. A successful \`land_self\` call is the finish line — do NOT call \`signal_done\` afterward, use finishing-a-development-branch, or offer merge/PR options.\n- Use \`signal_done\` only if the coordinator explicitly asks for manual review instead of self-landing.\n- Asking questions is fine when requirements are unclear or an action is risky.\n</sub-task-mode>`;
-    // Declared here so the catch block can restore preamble files on failure.
-    let preambleFilePath: string | undefined;
-    let preambleFileOriginalContent: string | null = null;
-
+    const agentCommand = opts.agentCommand ?? coordinatorState.spawnDefaults.command;
     const dockerContainerName =
       this.coordinators.get(task.coordinatorTaskId)?.dockerContainerName ?? null;
 
+    let preambleInjection: InjectedSubTaskPreamble | undefined;
     let subTaskMcpConfigPath: string | undefined;
     try {
-      // Inject sub-task instructions via agent-specific mechanism.
-      // Inside try so preamble-write failures are cleaned up by the catch block.
-      // Serialized per file path to prevent races when multiple tasks target the same path.
-      const injectPreamble = async (filePath: string): Promise<void> => {
-        const prior = this.preambleWriteQueue.get(filePath) ?? Promise.resolve();
-        const next = prior.then(async () => {
-          let existing = '';
-          try {
-            await fsAccess(filePath);
-            existing = await fsReadFile(filePath, 'utf8');
-            preambleFileOriginalContent = existing;
-          } catch {
-            /* file does not exist */
-          }
-          await atomicWriteFile(filePath, existing ? `${existing}\n\n${preamble}` : preamble);
-        });
-        this.preambleWriteQueue.set(
-          filePath,
-          next
-            .catch(() => {})
-            .then(() => {
-              if (this.preambleWriteQueue.get(filePath) === next) {
-                this.preambleWriteQueue.delete(filePath);
-              }
-            }),
-        );
-        await next;
-      };
+      preambleInjection = await injectSubTaskPreamble({
+        worktreePath: result.worktree_path,
+        agentCommand,
+        queue: this.preambleWriteQueue,
+      });
+      task.preambleFileExistedBefore = preambleInjection.existedBefore;
 
-      if (agentCmd.includes('codex') || agentCmd.includes('opencode')) {
-        const agentsPath = join(result.worktree_path, 'AGENTS.md');
-        preambleFilePath = agentsPath;
-        await injectPreamble(agentsPath);
-      } else if (agentCmd.includes('gemini')) {
-        const geminiPath = join(result.worktree_path, 'GEMINI.md');
-        preambleFilePath = geminiPath;
-        await injectPreamble(geminiPath);
-      } else if (agentCmd.includes('copilot')) {
-        const agentMdPath = join(result.worktree_path, '.agent.md');
-        preambleFilePath = agentMdPath;
-        await injectPreamble(agentMdPath);
-      } else {
-        // Claude and fallback: settings.local.json (gitignored, no restore needed)
-        const settingsDir = join(result.worktree_path, '.claude');
-        const settingsPath = join(settingsDir, 'settings.local.json');
-        await fsMkdir(settingsDir, { recursive: true });
-        const prior = this.preambleWriteQueue.get(settingsPath) ?? Promise.resolve();
-        const next = prior.then(async () => {
-          let existingSettings: Record<string, unknown> = {};
-          try {
-            await fsAccess(settingsPath);
-            existingSettings = JSON.parse(await fsReadFile(settingsPath, 'utf8'));
-          } catch {
-            /* ignore */
-          }
-          existingSettings.systemPrompt = existingSettings.systemPrompt
-            ? `${existingSettings.systemPrompt}\n\n${preamble}`
-            : preamble;
-          await atomicWriteFile(settingsPath, JSON.stringify(existingSettings, null, 2));
-        });
-        this.preambleWriteQueue.set(
-          settingsPath,
-          next
-            .catch(() => {})
-            .then(() => {
-              if (this.preambleWriteQueue.get(settingsPath) === next) {
-                this.preambleWriteQueue.delete(settingsPath);
-              }
-            }),
-        );
-        await next;
-      }
-      task.preambleFileExistedBefore = preambleFileOriginalContent !== null;
       // Write a per-sub-task MCP config so the agent can call signal_done.
       // In Docker mode, write to the coordinator's .parallel-code/ dir (which IS the explicitly
       // mounted volume) rather than the sub-task worktree (which may not be in the container).
@@ -972,7 +890,7 @@ export class Coordinator {
         const { serverUrl, subtaskToken, serverPath } = mcpServerInfoForTask;
         const doneToken = randomBytes(24).toString('base64url');
         task.doneToken = doneToken;
-        const mcpConfig = buildSubtaskMcpConfig({
+        const mcpConfig = buildSubTaskMcpConfig({
           serverPath,
           serverUrl,
           subtaskToken,
@@ -981,12 +899,11 @@ export class Coordinator {
         });
         subTaskMcpConfig = mcpConfig;
         const configPath = getSubTaskMcpConfigPath(dockerContainerName, serverPath, task.id);
-        await atomicWriteFile(configPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
+        await writeSubTaskMcpConfig(configPath, mcpConfig);
         subTaskMcpConfigPath = configPath;
         task.mcpConfigPath = configPath;
       }
 
-      const agentCommand = opts.agentCommand ?? coordinatorState.spawnDefaults.command;
       const agentArgs = opts.agentArgs ?? coordinatorState.spawnDefaults.args;
       const baseArgs = [
         ...agentArgs,
@@ -1060,17 +977,7 @@ export class Coordinator {
     } catch (err) {
       // Restore injected preamble file before cleaning up the worktree.
       // Must await — fire-and-forget could race with cleanupTask removing the worktree.
-      if (preambleFilePath !== undefined) {
-        try {
-          if (preambleFileOriginalContent !== null) {
-            await fsWriteFile(preambleFilePath, preambleFileOriginalContent);
-          } else {
-            await fsUnlink(preambleFilePath);
-          }
-        } catch {
-          /* ignore — worktree cleanup follows */
-        }
-      }
+      await restoreSubTaskPreambleInjection(preambleInjection);
       // Best-effort cleanup: kill agent, remove worktree/branch, clear in-memory state.
       // cleanupTask handles all of this; the task is still in this.tasks so it can find it.
       // Also delete the MCP config if it was written but not yet stored on task.mcpConfigPath.
@@ -1373,16 +1280,16 @@ export class Coordinator {
       );
     }
 
-    const MAX_DIFF_BYTES = 50_000;
-    if (filteredDiff.length > MAX_DIFF_BYTES) {
+    const truncatedDiff = truncateDiffForTool(filteredDiff);
+    if (truncatedDiff.truncated) {
       return {
         files: filteredFiles,
-        diff: filteredDiff.slice(0, MAX_DIFF_BYTES) + '\n... (diff truncated)',
+        diff: truncatedDiff.diff,
         truncated: true,
-        originalSizeBytes: filteredDiff.length,
+        originalSizeBytes: truncatedDiff.originalSizeBytes,
       };
     }
-    return { files: filteredFiles, diff: filteredDiff };
+    return { files: filteredFiles, diff: truncatedDiff.diff };
   }
 
   getTaskOutput(taskId: string): string {
@@ -1596,6 +1503,11 @@ export class Coordinator {
     this.decoders.delete(agentId);
   }
 
+  private clearAgentOutputState(task: CoordinatedTask): void {
+    this.unsubscribeAgentOutput(task.agentId);
+    this.clearAgentBuffers(task.agentId);
+  }
+
   /** Best-effort removal of a task's per-sub-task MCP config file. */
   private unlinkMcpConfigFile(path: string | undefined): void {
     if (!path) return;
@@ -1604,6 +1516,16 @@ export class Coordinator {
     } catch {
       /* already gone */
     }
+  }
+
+  private clearTaskMcpConfig(task: CoordinatedTask): void {
+    this.unlinkMcpConfigFile(task.mcpConfigPath);
+    task.mcpConfigPath = undefined;
+  }
+
+  private clearTaskControlState(taskId: string): void {
+    this.clearPromptDeliveryState(taskId);
+    this.controlMap.delete(taskId);
   }
 
   /** Resolve any pending waitForIdle callers for a task and clear the entry. */
@@ -1624,7 +1546,7 @@ export class Coordinator {
       this.suppressPendingNotificationForTask(task);
       this.queueLandedNotification(task);
 
-      this.unsubscribeAgentOutput(task.agentId);
+      this.clearAgentOutputState(task);
 
       try {
         killAgent(task.agentId);
@@ -1640,14 +1562,11 @@ export class Coordinator {
       });
 
       this.resolveIdleWaiters(task.id, 'exited');
-      this.clearAgentBuffers(task.agentId);
-      this.unlinkMcpConfigFile(task.mcpConfigPath);
-      task.mcpConfigPath = undefined;
+      this.clearTaskMcpConfig(task);
       task.status = 'exited';
       task.exitCode = 0;
       this.tasks.delete(task.id);
-      this.clearPromptDeliveryState(task.id);
-      this.controlMap.delete(task.id);
+      this.clearTaskControlState(task.id);
       this.notifyRenderer(IPC.MCP_TaskClosed, { taskId: task.id });
     } finally {
       this.closingTaskIds.delete(task.id);
@@ -1861,18 +1780,16 @@ export class Coordinator {
 
     this.suppressPendingNotificationForTask(task);
 
-    this.unsubscribeAgentOutput(task.agentId);
-    this.clearAgentBuffers(task.agentId);
+    this.clearAgentOutputState(task);
     this.resolveIdleWaiters(taskId, 'removed');
-    this.unlinkMcpConfigFile(task.mcpConfigPath);
+    this.clearTaskMcpConfig(task);
 
     // For Docker sub-tasks, the UI calls killAgent before removeCoordinatedTask,
     // which stops the sub-task's own container via stopDockerContainer in pty.ts.
     // No additional docker cleanup needed here.
 
     this.tasks.delete(taskId);
-    this.clearPromptDeliveryState(taskId);
-    this.controlMap.delete(taskId);
+    this.clearTaskControlState(taskId);
   }
 
   private async cleanupTask(taskId: string): Promise<void> {
@@ -1881,7 +1798,6 @@ export class Coordinator {
     this.closingTaskIds.add(taskId);
     this.suppressPendingNotificationForTask(task);
 
-    // Unsubscribe from PTY output
     this.unsubscribeAgentOutput(task.agentId);
 
     // Kill the agent. For Docker sub-tasks, killAgent also calls docker stop on the
@@ -1937,11 +1853,9 @@ export class Coordinator {
       });
     }
     this.clearAgentBuffers(task.agentId);
-    // Delete per-task MCP config tmp file
-    this.unlinkMcpConfigFile(task.mcpConfigPath);
+    this.clearTaskMcpConfig(task);
     this.tasks.delete(taskId);
-    this.clearPromptDeliveryState(taskId);
-    this.controlMap.delete(taskId);
+    this.clearTaskControlState(taskId);
     this.closingTaskIds.delete(taskId);
 
     // Notify renderer
@@ -1977,26 +1891,19 @@ export class Coordinator {
     pendingPrompts?: string[];
     assignedPromptDelivered?: boolean;
   }): { mcpLaunchArgs?: string[] } {
-    if (!this.coordinators.has(opts.coordinatorTaskId)) {
+    const coordinatorState = this.coordinators.get(opts.coordinatorTaskId);
+    if (!coordinatorState) {
       throw new Error(`coordinator ${opts.coordinatorTaskId} is not registered`);
     }
 
-    // Validate the persisted mcpConfigPath is exactly one of the two paths that
-    // getSubTaskMcpConfigPath generates — basename-only is too permissive and would
-    // allow a crafted state file to direct the token write to an arbitrary location.
-    // Host mode: os.tmpdir()/parallel-code-subtask-{id}.json
-    // Docker mode: dirname(serverPath)/subtask-{id}.json  (looked up from live coordinator state)
-    const serverInfo = this.coordinators.get(opts.coordinatorTaskId)?.mcpServerInfo;
-    const expectedHostPath = join(os.tmpdir(), `parallel-code-subtask-${opts.id}.json`);
-    const expectedDockerPath = serverInfo
-      ? join(dirname(serverInfo.serverPath), `subtask-${opts.id}.json`)
-      : null;
-    const safeMcpConfigPath =
-      opts.mcpConfigPath &&
-      (opts.mcpConfigPath === expectedHostPath ||
-        (expectedDockerPath !== null && opts.mcpConfigPath === expectedDockerPath))
-        ? opts.mcpConfigPath
-        : undefined;
+    const serverInfo = coordinatorState.mcpServerInfo;
+    const safeMcpConfigPath = isAllowedSubTaskMcpConfigPath(opts.mcpConfigPath, {
+      taskId: opts.id,
+      serverPath: serverInfo?.serverPath,
+      dockerContainerName: coordinatorState.dockerContainerName ?? null,
+    })
+      ? opts.mcpConfigPath
+      : undefined;
 
     const existingTask = this.tasks.get(opts.id);
     if (existingTask) {
@@ -2065,7 +1972,7 @@ export class Coordinator {
 
       this.tailBuffers.set(agentId, '');
       this.decoders.set(agentId, new TextDecoder());
-      const outputCb = this.buildAgentOutputCb(task);
+      const outputCb = this.createAgentOutputMonitor(task);
       this.subscribers.set(agentId, outputCb);
       // Subscribe immediately if the agent is already spawned (restart scenario where
       // PTY existed before hydration). The spawn handler covers the deferred case.
@@ -2095,7 +2002,7 @@ export class Coordinator {
     if (!serverInfo) return undefined;
     const { serverUrl, subtaskToken, serverPath } = serverInfo;
     if (!task.doneToken) task.doneToken = randomBytes(24).toString('base64url');
-    const mcpConfig = buildSubtaskMcpConfig({
+    const mcpConfig = buildSubTaskMcpConfig({
       serverPath,
       serverUrl,
       subtaskToken,
@@ -2103,7 +2010,7 @@ export class Coordinator {
       doneToken: task.doneToken,
     });
     if (mcpConfigPath) {
-      atomicWriteFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
+      writeSubTaskMcpConfigSync(mcpConfigPath, mcpConfig);
     }
     return buildMcpLaunchArgs(agentCommand ?? 'claude', mcpConfigPath, mcpConfig);
   }
@@ -2244,9 +2151,7 @@ export class Coordinator {
     for (const [taskId, task] of this.tasks) {
       if (task.coordinatorTaskId !== coordinatorTaskId) continue;
 
-      // Unsubscribe PTY output callback (stop receiving output, but keep task record)
-      this.unsubscribeAgentOutput(task.agentId);
-      this.clearAgentBuffers(task.agentId);
+      this.clearAgentOutputState(task);
       this.clearPromptDeliveryState(taskId);
 
       // Resolve pending idle waiters so callers aren't left hanging
@@ -2265,8 +2170,7 @@ export class Coordinator {
       // Transfer control to human so the user can decide what to do with orphaned tasks
       this.controlMap.set(taskId, 'human');
 
-      this.unlinkMcpConfigFile(task.mcpConfigPath);
-      task.mcpConfigPath = undefined;
+      this.clearTaskMcpConfig(task);
 
       // Notify the frontend so it can detach children consistently regardless
       // of whether backend deregistration or renderer close cleanup wins the IPC race.

--- a/electron/mcp/diff-format.test.ts
+++ b/electron/mcp/diff-format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { formatDiffForTool, MAX_DIFF_BYTES } from './diff-format.js';
+
+describe('formatDiffForTool', () => {
+  it('formats changed file summaries and uncommitted markers', () => {
+    const text = formatDiffForTool({
+      files: [
+        {
+          path: 'src/app.ts',
+          lines_added: 2,
+          lines_removed: 1,
+          status: 'M',
+          committed: false,
+        },
+      ],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n',
+    });
+
+    expect(text).toContain(
+      'M src/app.ts (+2 -1) [NOT COMMITTED — will be auto-committed on merge]',
+    );
+    expect(text).toContain('diff --git a/src/app.ts b/src/app.ts');
+  });
+
+  it('prepends merge info when supplied', () => {
+    const text = formatDiffForTool(
+      {
+        files: [],
+        diff: '',
+      },
+      'Merged into main: +1 -0 lines',
+    );
+
+    expect(text.startsWith('Merged into main: +1 -0 lines\n\nChanged files:')).toBe(true);
+  });
+
+  it('uses the shared truncation limit', () => {
+    const text = formatDiffForTool({
+      files: [],
+      diff: 'x'.repeat(MAX_DIFF_BYTES + 1),
+    });
+
+    expect(text).toContain(`${'x'.repeat(16)}`);
+    expect(text).toContain('... (diff truncated)');
+  });
+});

--- a/electron/mcp/diff-format.ts
+++ b/electron/mcp/diff-format.ts
@@ -1,0 +1,29 @@
+import type { ApiDiffResult } from './types.js';
+
+export const MAX_DIFF_BYTES = 50_000;
+
+export function truncateDiffForTool(diff: string): {
+  diff: string;
+  truncated?: true;
+  originalSizeBytes?: number;
+} {
+  if (diff.length <= MAX_DIFF_BYTES) return { diff };
+  return {
+    diff: diff.slice(0, MAX_DIFF_BYTES) + '\n... (diff truncated)',
+    truncated: true,
+    originalSizeBytes: diff.length,
+  };
+}
+
+export function formatDiffForTool(result: ApiDiffResult, mergeInfo?: string): string {
+  const summary = result.files
+    .map(
+      (f) =>
+        `${f.status} ${f.path} (+${f.lines_added} -${f.lines_removed})` +
+        (f.committed ? '' : ' [NOT COMMITTED — will be auto-committed on merge]'),
+    )
+    .join('\n');
+  const { diff } = truncateDiffForTool(result.diff);
+  const formatted = `Changed files:\n${summary}\n\n${diff}`;
+  return mergeInfo ? `${mergeInfo}\n\n${formatted}` : formatted;
+}

--- a/electron/mcp/mcp-tool-list.test.ts
+++ b/electron/mcp/mcp-tool-list.test.ts
@@ -36,6 +36,11 @@ describe('selectTools — role-based tool list', () => {
     }
   });
 
+  it('does not advertise deprecated review_and_merge_task', () => {
+    const names = selectTools('', 'coordinator-xyz').map((t: ToolDef) => t.name);
+    expect(names).not.toContain('review_and_merge_task');
+  });
+
   it('plain agent (neither taskId nor coordinatorId) gets coordinator tools', () => {
     const tools = selectTools('', '');
     expect(tools).toEqual(COORDINATOR_TOOLS);

--- a/electron/mcp/mcp-tool-list.ts
+++ b/electron/mcp/mcp-tool-list.ts
@@ -175,20 +175,6 @@ export const COORDINATOR_TOOLS: ToolDef[] = [
       required: [],
     },
   },
-  {
-    name: 'review_and_merge_task',
-    description:
-      'DEPRECATED: use get_task_diff → merge_task → close_task instead. This tool merges immediately without giving you a chance to review the diff first — the diff it returns is post-merge. Kept for backwards compatibility only.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        taskId: { type: 'string', description: 'Task ID' },
-        squash: { type: 'boolean', description: 'Squash merge (default: false)' },
-        message: { type: 'string', description: 'Custom merge commit message' },
-      },
-      required: ['taskId'],
-    },
-  },
 ];
 
 /**

--- a/electron/mcp/preamble.test.ts
+++ b/electron/mcp/preamble.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { injectSubTaskPreamble, restoreSubTaskPreambleInjection } from './preamble.js';
@@ -58,6 +58,39 @@ describe('sub-task preamble injection', () => {
       await restoreSubTaskPreambleInjection(injected);
 
       expect(existsSync(settingsPath)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports existing Claude settings content when appending the system prompt', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parallel-code-preamble-test-'));
+    const settingsDir = join(dir, '.claude');
+    const settingsPath = join(settingsDir, 'settings.local.json');
+    const originalContent = JSON.stringify({ permissions: { allow: ['Bash(npm test)'] } }, null, 2);
+    const queue = new Map<string, Promise<void>>();
+    mkdirSync(settingsDir);
+    writeFileSync(settingsPath, originalContent);
+
+    try {
+      const injected = await injectSubTaskPreamble({
+        worktreePath: dir,
+        agentCommand: 'claude',
+        queue,
+      });
+
+      expect(injected).toMatchObject({
+        filePath: settingsPath,
+        originalContent,
+        existedBefore: true,
+        restoreOnFailure: false,
+      });
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+        permissions?: { allow?: string[] };
+        systemPrompt?: string;
+      };
+      expect(settings.permissions?.allow).toEqual(['Bash(npm test)']);
+      expect(settings.systemPrompt).toContain('<sub-task-mode>');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/electron/mcp/preamble.test.ts
+++ b/electron/mcp/preamble.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { injectSubTaskPreamble, restoreSubTaskPreambleInjection } from './preamble.js';
+
+describe('sub-task preamble injection', () => {
+  it('appends to AGENTS.md for Codex-style agents and can restore the original content', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parallel-code-preamble-test-'));
+    const agentsPath = join(dir, 'AGENTS.md');
+    writeFileSync(agentsPath, 'existing instructions');
+    const queue = new Map<string, Promise<void>>();
+
+    try {
+      const injected = await injectSubTaskPreamble({
+        worktreePath: dir,
+        agentCommand: 'codex',
+        queue,
+      });
+
+      expect(injected).toMatchObject({
+        filePath: agentsPath,
+        existedBefore: true,
+        restoreOnFailure: true,
+      });
+      expect(readFileSync(agentsPath, 'utf8')).toContain('existing instructions');
+      expect(readFileSync(agentsPath, 'utf8')).toContain('<sub-task-mode>');
+
+      await restoreSubTaskPreambleInjection(injected);
+
+      expect(readFileSync(agentsPath, 'utf8')).toBe('existing instructions');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes Claude settings.local.json without making it a failure-restore target', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parallel-code-preamble-test-'));
+    const settingsPath = join(dir, '.claude', 'settings.local.json');
+    const queue = new Map<string, Promise<void>>();
+
+    try {
+      const injected = await injectSubTaskPreamble({
+        worktreePath: dir,
+        agentCommand: 'claude',
+        queue,
+      });
+
+      expect(injected).toMatchObject({
+        filePath: settingsPath,
+        existedBefore: false,
+        restoreOnFailure: false,
+      });
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).systemPrompt).toContain(
+        '<sub-task-mode>',
+      );
+
+      await restoreSubTaskPreambleInjection(injected);
+
+      expect(existsSync(settingsPath)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/electron/mcp/preamble.ts
+++ b/electron/mcp/preamble.ts
@@ -2,7 +2,13 @@ import { randomUUID } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { writeFileSync, readFileSync, existsSync, unlinkSync } from 'fs';
-import { readFile as fsReadFile, unlink as fsUnlink } from 'fs/promises';
+import {
+  readFile as fsReadFile,
+  writeFile as fsWriteFile,
+  unlink as fsUnlink,
+  access as fsAccess,
+  mkdir as fsMkdir,
+} from 'fs/promises';
 import { atomicWriteFile } from './atomic.js';
 import { join } from 'path';
 import os from 'os';
@@ -13,6 +19,123 @@ const PREAMBLE_START = '<sub-task-mode>';
 const PREAMBLE_END = '</sub-task-mode>';
 
 const PREAMBLE_MD_FILES = ['AGENTS.md', 'GEMINI.md', '.agent.md'] as const;
+
+export const SUB_TASK_MODE_PREAMBLE = `<sub-task-mode>
+These rules override all skills and hooks:
+- When your work is complete, commit your changes and call the \`land_self\` MCP tool with the verification checks you ran. A successful \`land_self\` call is the finish line — do NOT call \`signal_done\` afterward, use finishing-a-development-branch, or offer merge/PR options.
+- Use \`signal_done\` only if the coordinator explicitly asks for manual review instead of self-landing.
+- Asking questions is fine when requirements are unclear or an action is risky.
+</sub-task-mode>`;
+
+export type PreambleWriteQueue = Map<string, Promise<void>>;
+
+export interface InjectedSubTaskPreamble {
+  filePath?: string;
+  originalContent: string | null;
+  existedBefore: boolean;
+  restoreOnFailure: boolean;
+}
+
+export async function queueFileMutation(
+  queue: PreambleWriteQueue,
+  filePath: string,
+  mutate: () => Promise<void>,
+): Promise<void> {
+  const prior = queue.get(filePath) ?? Promise.resolve();
+  const next = prior.then(mutate);
+  const cleanup = next
+    .catch(() => {})
+    .then(() => {
+      if (queue.get(filePath) === cleanup) {
+        queue.delete(filePath);
+      }
+    });
+  queue.set(filePath, cleanup);
+  await next;
+}
+
+async function injectMarkdownPreamble(
+  queue: PreambleWriteQueue,
+  filePath: string,
+): Promise<InjectedSubTaskPreamble> {
+  let originalContent: string | null = null;
+  await queueFileMutation(queue, filePath, async () => {
+    try {
+      await fsAccess(filePath);
+      originalContent = await fsReadFile(filePath, 'utf8');
+    } catch {
+      originalContent = null;
+    }
+    await atomicWriteFile(
+      filePath,
+      originalContent ? `${originalContent}\n\n${SUB_TASK_MODE_PREAMBLE}` : SUB_TASK_MODE_PREAMBLE,
+    );
+  });
+  return {
+    filePath,
+    originalContent,
+    existedBefore: originalContent !== null,
+    restoreOnFailure: true,
+  };
+}
+
+export async function injectSubTaskPreamble(args: {
+  worktreePath: string;
+  agentCommand: string;
+  queue: PreambleWriteQueue;
+}): Promise<InjectedSubTaskPreamble> {
+  const agentCmd = args.agentCommand.toLowerCase();
+  if (agentCmd.includes('codex') || agentCmd.includes('opencode')) {
+    return injectMarkdownPreamble(args.queue, join(args.worktreePath, 'AGENTS.md'));
+  }
+  if (agentCmd.includes('gemini')) {
+    return injectMarkdownPreamble(args.queue, join(args.worktreePath, 'GEMINI.md'));
+  }
+  if (agentCmd.includes('copilot')) {
+    return injectMarkdownPreamble(args.queue, join(args.worktreePath, '.agent.md'));
+  }
+
+  const settingsDir = join(args.worktreePath, '.claude');
+  const settingsPath = join(settingsDir, 'settings.local.json');
+  await fsMkdir(settingsDir, { recursive: true });
+  await queueFileMutation(args.queue, settingsPath, async () => {
+    let existingSettings: Record<string, unknown> = {};
+    try {
+      await fsAccess(settingsPath);
+      existingSettings = JSON.parse(await fsReadFile(settingsPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      existingSettings = {};
+    }
+    existingSettings.systemPrompt = existingSettings.systemPrompt
+      ? `${existingSettings.systemPrompt}\n\n${SUB_TASK_MODE_PREAMBLE}`
+      : SUB_TASK_MODE_PREAMBLE;
+    await atomicWriteFile(settingsPath, JSON.stringify(existingSettings, null, 2));
+  });
+  return {
+    filePath: settingsPath,
+    originalContent: null,
+    existedBefore: false,
+    restoreOnFailure: false,
+  };
+}
+
+export async function restoreSubTaskPreambleInjection(
+  injection: InjectedSubTaskPreamble | undefined,
+): Promise<void> {
+  if (!injection?.filePath || !injection.restoreOnFailure) return;
+  try {
+    if (injection.originalContent !== null) {
+      await fsWriteFile(injection.filePath, injection.originalContent);
+    } else {
+      await fsUnlink(injection.filePath);
+    }
+  } catch {
+    /* ignore — worktree cleanup follows */
+  }
+}
 
 /** Remove the injected `<sub-task-mode>…</sub-task-mode>` block and its surrounding
  *  blank-line separators. Content before and after the block is preserved. */

--- a/electron/mcp/preamble.ts
+++ b/electron/mcp/preamble.ts
@@ -98,14 +98,12 @@ export async function injectSubTaskPreamble(args: {
   const settingsDir = join(args.worktreePath, '.claude');
   const settingsPath = join(settingsDir, 'settings.local.json');
   await fsMkdir(settingsDir, { recursive: true });
+  let originalContent: string | null = null;
   await queueFileMutation(args.queue, settingsPath, async () => {
     let existingSettings: Record<string, unknown> = {};
     try {
-      await fsAccess(settingsPath);
-      existingSettings = JSON.parse(await fsReadFile(settingsPath, 'utf8')) as Record<
-        string,
-        unknown
-      >;
+      originalContent = await fsReadFile(settingsPath, 'utf8');
+      existingSettings = JSON.parse(originalContent) as Record<string, unknown>;
     } catch {
       existingSettings = {};
     }
@@ -116,8 +114,8 @@ export async function injectSubTaskPreamble(args: {
   });
   return {
     filePath: settingsPath,
-    originalContent: null,
-    existedBefore: false,
+    originalContent,
+    existedBefore: originalContent !== null,
     restoreOnFailure: false,
   };
 }

--- a/electron/mcp/server.ts
+++ b/electron/mcp/server.ts
@@ -8,6 +8,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { MCPClient } from './client.js';
 import { selectTools } from './mcp-tool-list.js';
 import { validateBranchName } from './validation.js';
+import { formatDiffForTool } from './diff-format.js';
 import type { LandSelfInput } from './types.js';
 
 export interface MCPToolHandlerContext {
@@ -107,24 +108,8 @@ export async function handleMCPToolCall(
         const result = await client.getTaskDiff(
           (params as Record<string, unknown>).taskId as string,
         );
-        // Return files summary + truncated diff
-        const summary = result.files
-          .map(
-            (f) =>
-              `${f.status} ${f.path} (+${f.lines_added} -${f.lines_removed})` +
-              (f.committed ? '' : ' [NOT COMMITTED — will be auto-committed on merge]'),
-          )
-          .join('\n');
-        let diffText: string;
-        if (result.diff.length > 50_000) {
-          result.truncated = true;
-          result.originalSizeBytes = result.diff.length;
-          diffText = result.diff.slice(0, 50_000) + '\n... (diff truncated)';
-        } else {
-          diffText = result.diff;
-        }
         return {
-          content: [{ type: 'text', text: `Changed files:\n${summary}\n\n${diffText}` }],
+          content: [{ type: 'text', text: formatDiffForTool(result) }],
         };
       }
 
@@ -175,23 +160,12 @@ export async function handleMCPToolCall(
           squash: p.squash as boolean | undefined,
           message: p.message as string | undefined,
         });
-        const summary = result.diff.files
-          .map(
-            (f) =>
-              `${f.status} ${f.path} (+${f.lines_added} -${f.lines_removed})` +
-              (f.committed ? '' : ' [NOT COMMITTED — will be auto-committed on merge]'),
-          )
-          .join('\n');
-        let diffText = result.diff.diff;
-        if (diffText.length > 50_000) {
-          diffText = diffText.slice(0, 50_000) + '\n... (diff truncated)';
-        }
         const mergeInfo = `Merged into ${result.merge.mainBranch}: +${result.merge.linesAdded} -${result.merge.linesRemoved} lines`;
         return {
           content: [
             {
               type: 'text',
-              text: `${mergeInfo}\n\nChanged files:\n${summary}\n\n${diffText}`,
+              text: formatDiffForTool(result.diff, mergeInfo),
             },
           ],
         };

--- a/electron/mcp/validation.test.ts
+++ b/electron/mcp/validation.test.ts
@@ -68,7 +68,7 @@ describe('validateBranchName', () => {
   });
 
   it('rejects @{ sequence', () => {
-    expect(() => validateBranchName('foo@{bar}')).toThrow();
+    expect(() => validateBranchName('foo@{bar}')).toThrow('must not contain "@{"');
   });
 
   it('rejects path component starting with dot', () => {

--- a/electron/mcp/validation.ts
+++ b/electron/mcp/validation.ts
@@ -16,12 +16,12 @@ export function validateBranchName(value: unknown, field = 'branch'): string {
     throw new Error(`${field} must not contain a ".lock" path component`);
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f\x7f ]/.test(value)) throw new Error(`${field} contains invalid characters`);
+  if (value.includes('@{')) throw new Error(`${field} must not contain "@{"`);
   // Reject git check-ref-format illegal characters.
   if (/[`$(){}[\]<>\\'*?!#;|&":^~]/.test(value))
     throw new Error(`${field} contains invalid characters`);
   // Reject sequences illegal per git check-ref-format.
   if (value.includes('..')) throw new Error(`${field} must not contain ".."`);
-  if (value.includes('@{')) throw new Error(`${field} must not contain "@{"`);
   if (value.includes('//')) throw new Error(`${field} must not contain "//"`);
   // Reject path components starting with "." (e.g. feature/.hidden).
   if (/(?:^|\/)\./.test(value))


### PR DESCRIPTION
## Summary

Addresses quality-audit work from https://github.com/johannesjo/parallel-code/issues/159.

## Review

Adversarial review completed.

Adversarial review findings handled before final validation:
- major: Host-mode hydration still accepts the Docker-style config path

## Verification

- [x] check: 11991ms
- [x] lint:arch: 2066ms
- [x] lint:dead: 1058ms
- [x] test: 2429ms
- [x] dev: npm run dev reached Vite/Electron readiness and was stopped

Refs #159
