### PR TITLE
fix(changed-files): focus open editor button clicks

### DIFF
--- a/src/components/ChangedFilesList.tsx
+++ b/src/components/ChangedFilesList.tsx
@@ -20,6 +20,7 @@ interface ChangedFilesListProps {
   onFileClick?: (file: ChangedFile) => void;
   /** Optional path to visually mark as the active/open diff target. */
   activeFilePath?: string | null;
+  onOpenInEditorClick?: () => void;
   ref?: (el: HTMLDivElement) => void;
   /** Optional coverage artifact path relative to the repo root. */
   coverageReportPath?: string;
@@ -148,12 +149,17 @@ function FileCoverageBadge(props: {
   );
 }
 
-function OpenInEditorButton(props: { worktreePath: string; filePath: string }) {
+function OpenInEditorButton(props: {
+  worktreePath: string;
+  filePath: string;
+  onOpenInEditorClick?: () => void;
+}) {
   return (
     <button
       class="changed-files-open-editor-btn"
       onClick={(e) => {
         e.stopPropagation();
+        props.onOpenInEditorClick?.();
         void openFileInEditor(props.worktreePath, props.filePath);
       }}
       onKeyDown={(e) => e.stopPropagation()}
@@ -625,6 +631,7 @@ export function ChangedFilesList(props: ChangedFilesListProps) {
                     <OpenInEditorButton
                       worktreePath={props.worktreePath}
                       filePath={row().node.file?.path ?? row().node.path}
+                      onOpenInEditorClick={props.onOpenInEditorClick}
                     />
                   </Show>
                 </>

--- a/src/components/TaskChangedFilesSection.tsx
+++ b/src/components/TaskChangedFilesSection.tsx
@@ -1,5 +1,5 @@
 import { Show, onMount } from 'solid-js';
-import { getProject, setTaskFocusedPanel, isPanelFocused } from '../store/store';
+import { getProject, setActiveTask, setTaskFocusedPanel, isPanelFocused } from '../store/store';
 import { ChangedFilesList } from './ChangedFilesList';
 import { CommitTreeOverlay } from './CommitTreeOverlay';
 import {
@@ -36,6 +36,10 @@ export function TaskChangedFilesSection(props: TaskChangedFilesSectionProps) {
       : undefined;
   const showUncommittedBanner = () =>
     isUncommittedSelection(props.selectedCommit) && hasCommitNav();
+  const focusChangedFilesPanel = () => {
+    setActiveTask(props.task.id);
+    setTaskFocusedPanel(props.task.id, 'changed-files');
+  };
 
   let changedFilesRef: HTMLDivElement | undefined;
 
@@ -65,7 +69,7 @@ export function TaskChangedFilesSection(props: TaskChangedFilesSectionProps) {
         display: 'flex',
         'flex-direction': 'column',
       }}
-      onClick={() => setTaskFocusedPanel(props.task.id, 'changed-files')}
+      onClick={focusChangedFilesPanel}
     >
       <div
         style={{
@@ -153,6 +157,7 @@ export function TaskChangedFilesSection(props: TaskChangedFilesSectionProps) {
           coverageReportPath={coverageReportPath()}
           selectedCommit={props.selectedCommit}
           onFileClick={(file) => props.onDiffFileClick(file.path)}
+          onOpenInEditorClick={focusChangedFilesPanel}
           ref={(el) => (changedFilesRef = el)}
         />
       </div>


### PR DESCRIPTION
  ## Summary

  Fixes focus behavior when clicking the external open button in the Changed Files panel.

  This addresses two cases:

  1. When the Notes area is focused, clicking a file's external open button in Changed Files should move the highlight to Changed Files only.
  2. When the TaskPanel is not focused, clicking a file's external open button in its Changed Files panel should select that TaskPanel and highlight Changed Files.

  ## Changes

  - Adds an `onOpenInEditorClick` callback to `ChangedFilesList`.
  - Calls the Changed Files focus path before opening a file in the editor.
  - Updates `TaskChangedFilesSection` so Changed Files focus also activates the task via `setActiveTask`.
  - Keeps `stopPropagation()` on the external open button so clicking it does not also trigger the file row diff click.