### PR TITLE
fix(commits): stop polling hidden task panels

### DIFF
--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -41,6 +41,7 @@ import { isMac } from '../lib/platform';
 import type { Task } from '../store/types';
 import type { CommitInfo } from '../ipc/types';
 import { isLandedTaskState } from '../store/landing';
+import { shouldPollTaskCommits } from './task-commit-polling';
 
 interface TaskPanelProps {
   task: Task;
@@ -193,16 +194,27 @@ export function TaskPanel(props: TaskPanelProps) {
     }
   });
 
-  // Poll for branch commits for worktree-isolated and direct-mode tasks (not just
-  // the active one), so CommitNavBar shows correct state regardless of which column
-  // is focused. For direct mode, request recent commits as fallback since there are
-  // no branch-specific commits when working on main.
+  // Poll for branch commits for visible worktree-isolated and direct-mode tasks.
+  // This includes inactive columns in the tiled layout, while hidden and offscreen
+  // panels restart with an immediate refresh when they become visible again. For
+  // direct mode, request recent commits since there are no branch-specific commits
+  // when working on main.
   createEffect(() => {
     const worktreePath = props.task.worktreePath;
     const baseBranch = props.task.baseBranch;
     const isolation = props.task.gitIsolation;
     if (isLandedTask()) return;
     if (isolation !== 'worktree' && isolation !== 'direct') return;
+    const focusMode = store.focusMode;
+    if (
+      !shouldPollTaskCommits(
+        focusMode,
+        focusMode ? props.isActive : false,
+        focusMode ? undefined : store.taskViewportVisibility[props.task.id],
+      )
+    ) {
+      return;
+    }
     let cancelled = false;
 
     async function fetchCommits() {

--- a/src/components/task-commit-polling.test.ts
+++ b/src/components/task-commit-polling.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPollTaskCommits } from './task-commit-polling';
+
+describe('shouldPollTaskCommits', () => {
+  it('polls visible and not-yet-measured panels in the tiled layout', () => {
+    expect(shouldPollTaskCommits(false, false, 'visible')).toBe(true);
+    expect(shouldPollTaskCommits(false, false, undefined)).toBe(true);
+  });
+
+  it('does not poll offscreen panels in the tiled layout', () => {
+    expect(shouldPollTaskCommits(false, true, 'offscreen-left')).toBe(false);
+    expect(shouldPollTaskCommits(false, true, 'offscreen-right')).toBe(false);
+  });
+
+  it('only polls the active panel in focus mode', () => {
+    expect(shouldPollTaskCommits(true, true, 'offscreen-left')).toBe(true);
+    expect(shouldPollTaskCommits(true, false, 'visible')).toBe(false);
+  });
+});

--- a/src/components/task-commit-polling.ts
+++ b/src/components/task-commit-polling.ts
@@ -1,0 +1,10 @@
+import type { TaskViewportVisibility } from '../store/types';
+
+export function shouldPollTaskCommits(
+  focusMode: boolean,
+  isActive: boolean,
+  viewportVisibility: TaskViewportVisibility | undefined,
+): boolean {
+  if (focusMode) return isActive;
+  return viewportVisibility !== 'offscreen-left' && viewportVisibility !== 'offscreen-right';
+}


### PR DESCRIPTION
## Summary

- stop the five-second branch-commit poll while a tiled task panel is offscreen
- only poll the active task panel in focus mode
- refresh immediately when a task panel becomes visible again
- cover tiled and focus-mode visibility decisions with unit tests

Closes #205

## Test plan

- `npm run check`
- `npm run check:static`
- `npm run test:security-rules`
- `npm test` (92 passed, 2 skipped; 1564 tests passed, 23 skipped)
