### PR TITLE
fix(theme): adapt light theme contrast

### DIFF
--- a/src/components/AskCodeCard.tsx
+++ b/src/components/AskCodeCard.tsx
@@ -103,7 +103,7 @@ export function AskCodeCard(props: AskCodeCardProps) {
           'justify-content': 'space-between',
           padding: '4px 10px',
           'border-bottom': `1px solid ${theme.borderSubtle}`,
-          background: 'rgba(255,255,255,0.03)',
+          background: 'color-mix(in srgb, var(--fg) 3%, transparent)',
         }}
       >
         <span

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -118,7 +118,8 @@ export function Dialog(props: DialogProps) {
               'flex-direction': 'column',
               gap: '16px',
               outline: 'none',
-              'box-shadow': '0 12px 48px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03) inset',
+              'box-shadow':
+                '0 12px 48px rgba(0,0,0,0.5), 0 0 0 1px color-mix(in srgb, var(--fg) 3%, transparent) inset',
               ...props.panelStyle,
             }}
             onClick={(e) => e.stopPropagation()}

--- a/src/components/DiffViewerDialog.tsx
+++ b/src/components/DiffViewerDialog.tsx
@@ -365,7 +365,7 @@ function DiffViewerContent(props: DiffViewerDialogProps) {
           value={searchQuery()}
           onInput={(e) => setSearchQuery(e.currentTarget.value)}
           style={{
-            background: 'rgba(255,255,255,0.06)',
+            background: 'color-mix(in srgb, var(--fg) 6%, transparent)',
             border: `1px solid ${theme.borderSubtle}`,
             'border-radius': '4px',
             color: theme.fg,

--- a/src/components/ReviewSidebar.tsx
+++ b/src/components/ReviewSidebar.tsx
@@ -48,7 +48,7 @@ function SidebarAnnotationItem(props: {
         'margin-bottom': '6px',
         'border-left': `3px solid ${theme.warning}`,
         'border-radius': '0 4px 4px 0',
-        background: 'rgba(255,255,255,0.03)',
+        background: 'color-mix(in srgb, var(--fg) 3%, transparent)',
         cursor: 'pointer',
         position: 'relative',
       }}

--- a/src/components/ScrollingDiffView.tsx
+++ b/src/components/ScrollingDiffView.tsx
@@ -36,8 +36,8 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 const LINE_BG: Record<DiffLine['type'], string> = {
-  add: 'rgba(47, 209, 152, 0.10)',
-  remove: 'rgba(255, 95, 115, 0.10)',
+  add: theme.diffAddBg,
+  remove: theme.diffRemoveBg,
   context: 'transparent',
 };
 
@@ -95,8 +95,8 @@ function isLineHighlighted(
 // Search highlight helpers
 // ---------------------------------------------------------------------------
 
-const SEARCH_HIGHLIGHT_BG = 'rgba(255, 200, 50, 0.35)';
-const CURRENT_MATCH_BG = 'rgba(100, 160, 255, 0.35)';
+const SEARCH_HIGHLIGHT_BG = `color-mix(in srgb, ${theme.searchMatch} 35%, transparent)`;
+const CURRENT_MATCH_BG = `color-mix(in srgb, ${theme.searchMatchActive} 35%, transparent)`;
 
 function highlightSearchMatches(text: string, query: string | undefined): JSX.Element {
   if (!query || query.length === 0) return <>{text}</>;
@@ -522,7 +522,7 @@ function FileSection(props: {
             color: getStatusColor(props.file.status),
             background:
               props.file.status === 'M'
-                ? 'rgba(255,255,255,0.06)'
+                ? 'color-mix(in srgb, var(--fg) 6%, transparent)'
                 : `color-mix(in srgb, ${getStatusColor(props.file.status)} 15%, transparent)`,
           }}
         >

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '../lib/fonts';
 import { presetsForTone } from '../lib/look';
 import type { AppearanceMode } from '../lib/look';
-import { theme, sectionLabelStyle, readCssVarsForPreset, terminalBackground } from '../lib/theme';
+import { theme, sectionLabelStyle, readCssVarsForPreset } from '../lib/theme';
 import { themeToCss, detectThemeTone } from '../lib/custom-theme';
 import {
   store,
@@ -259,7 +259,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
 
   function openCloneDialog(presetId: string, label: string) {
     const vars = readCssVarsForPreset(presetId);
-    const bg = terminalBackground[presetId as keyof typeof terminalBackground] ?? '#000000';
+    const bg = vars['--task-panel-bg'] ?? '#000000';
     setCloneCss(themeToCss(`${label} (copy)`, '', bg, vars));
     setEditingThemeId(null);
     setCustomThemeDialogOpen(true);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -10,7 +10,11 @@ import { invoke, fireAndForget, Channel } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { getTerminalFontFamily } from '../lib/fonts';
 import { TERMINAL_SCROLLBACK_LINES, base64ToUint8Array } from '../lib/terminalConstants';
-import { getTerminalTheme, getTerminalThemeForCustom } from '../lib/theme';
+import {
+  getTerminalSearchDecorations,
+  getTerminalTheme,
+  getTerminalThemeForCustom,
+} from '../lib/theme';
 import { matchesGlobalShortcut } from '../lib/shortcuts';
 import { isMac } from '../lib/platform';
 import { resolvedBindings } from '../store/keybindings';
@@ -166,17 +170,6 @@ const openTerminalHttpLinkWithModifier = createTerminalHttpLinkHandler({
 function getTerminalBindings() {
   return resolvedBindings().filter((b) => b.layer === 'terminal');
 }
-
-// Browser-style find: amber highlight for all matches, orange for the active
-// one. Like a browser, the highlight palette is fixed rather than theme-derived.
-// Overview-ruler colors must be solid; match backgrounds carry alpha so the
-// underlying glyphs stay legible on both light and dark terminals.
-const SEARCH_DECORATIONS = {
-  matchBackground: 'rgba(255, 213, 79, 0.4)',
-  matchOverviewRuler: '#ffd54f',
-  activeMatchBackground: 'rgba(255, 138, 0, 0.85)',
-  activeMatchColorOverviewRuler: '#ff8a00',
-} as const;
 
 export function TerminalView(props: TerminalViewProps) {
   let containerRef!: HTMLDivElement;
@@ -359,7 +352,7 @@ export function TerminalView(props: TerminalViewProps) {
       resetSearchResults();
       return;
     }
-    const opts = { incremental, decorations: SEARCH_DECORATIONS };
+    const opts = { incremental, decorations: getTerminalSearchDecorations() };
     if (direction === 'prev') searchAddon.findPrevious(q, opts);
     else searchAddon.findNext(q, opts);
   }
@@ -1190,14 +1183,14 @@ export function TerminalView(props: TerminalViewProps) {
             'align-items': 'center',
             'justify-content': 'center',
             gap: '12px',
-            background: 'rgba(0,0,0,0.85)',
+            background: 'color-mix(in srgb, var(--bg-elevated) 92%, transparent)',
             'font-family': 'var(--font-ui)',
             'z-index': '10',
           }}
         >
           <span
             style={{
-              color: '#ff6b6b',
+              color: 'var(--error)',
               'font-size': '13px',
               'text-align': 'center',
               padding: '0 16px',

--- a/src/lib/custom-theme-contrast.test.ts
+++ b/src/lib/custom-theme-contrast.test.ts
@@ -1,9 +1,8 @@
 /**
  * Contrast audit for all built-in themes.
  * Parses styles.css, extracts CSS variable values per theme, and runs
- * checkThemeContrast() against each. Prints a full report — failures are
- * logged but the test does NOT fail, so this acts as an audit rather than
- * a hard gate (some themes may have intentional low-contrast secondary text).
+ * checkThemeContrast() against each. Any warning fails the test so built-in
+ * presets cannot regress below the supported contrast thresholds.
  */
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -13,14 +12,27 @@ import type { CssVar } from './custom-theme';
 import { CSS_VARS } from './custom-theme';
 
 const CSS_VAR_SET = new Set<string>(CSS_VARS);
+const VAR_RE = /^\s*(--[\w-]+)\s*:\s*(.+?)\s*;?\s*$/;
+
+function parseVars(body: string): Partial<Record<CssVar, string>> {
+  const vars: Partial<Record<CssVar, string>> = {};
+  for (const line of body.split('\n')) {
+    const match = VAR_RE.exec(line);
+    if (match && CSS_VAR_SET.has(match[1])) {
+      vars[match[1] as CssVar] = match[2].trim();
+    }
+  }
+  return vars;
+}
 
 function parseThemesFromCss(css: string): Record<string, Partial<Record<CssVar, string>>> {
   const themes: Record<string, Partial<Record<CssVar, string>>> = {};
+  const rootMatch = /:root\s*\{([^}]*)\}/.exec(css);
+  const rootVars = rootMatch ? parseVars(rootMatch[1]) : {};
 
   // Match blocks like: html[data-look='name'] { ... } or html[data-look='a'], html[data-look='b'] { ... }
   const blockRe = /(html\[data-look='[^']+'\](?:\s*,\s*html\[data-look='[^']+'\])*)\s*\{([^}]*)\}/g;
   const nameRe = /data-look='([^']+)'/g;
-  const varRe = /^\s*(--[\w-]+)\s*:\s*(.+?)\s*;?\s*$/;
 
   let blockMatch: RegExpExecArray | null;
   while ((blockMatch = blockRe.exec(css)) !== null) {
@@ -36,17 +48,11 @@ function parseThemesFromCss(css: string): Record<string, Partial<Record<CssVar, 
     }
 
     // Parse CSS variable declarations from the block body
-    const vars: Partial<Record<CssVar, string>> = {};
-    for (const line of body.split('\n')) {
-      const m = varRe.exec(line);
-      if (m && CSS_VAR_SET.has(m[1])) {
-        vars[m[1] as CssVar] = m[2].trim();
-      }
-    }
+    const vars = parseVars(body);
 
     // Assign vars to each named theme (later blocks override earlier ones)
     for (const name of names) {
-      themes[name] = { ...(themes[name] ?? {}), ...vars };
+      themes[name] = { ...rootVars, ...(themes[name] ?? {}), ...vars };
     }
   }
 
@@ -62,6 +68,12 @@ describe('built-in theme contrast audit', () => {
     expect(Object.keys(themes).length).toBeGreaterThanOrEqual(10);
   });
 
+  it('applies root defaults to every parsed theme', () => {
+    for (const vars of Object.values(themes)) {
+      expect(CSS_VARS.every((name) => vars[name] !== undefined)).toBe(true);
+    }
+  });
+
   for (const [name, vars] of Object.entries(themes)) {
     it(`${name} — contrast check`, () => {
       const warnings = checkThemeContrast(vars);
@@ -73,8 +85,7 @@ describe('built-in theme contrast audit', () => {
           );
         }
       }
-      // Not a hard failure — this is an audit. Remove the expect() below to make it hard.
-      expect(warnings).toBeDefined();
+      expect(warnings).toEqual([]);
     });
   }
 });

--- a/src/lib/custom-theme.test.ts
+++ b/src/lib/custom-theme.test.ts
@@ -7,6 +7,7 @@ import {
   collectAllowedVars,
   formatVarLines,
   isHexTerminalBackground,
+  checkThemeContrast,
 } from './custom-theme';
 
 describe('parseThemeCss', () => {
@@ -166,6 +167,22 @@ describe('custom theme helper primitives', () => {
     ).toEqual({ '--bg': '#000' });
   });
 
+  it('supports semantic diff and search colors in custom themes', () => {
+    expect(
+      collectAllowedVars([
+        ['--diff-add-bg', 'rgba(47, 209, 152, 0.1)'],
+        ['--diff-remove-bg', 'rgba(255, 95, 115, 0.1)'],
+        ['--search-match', '#ffd54f'],
+        ['--search-match-active', '#ff8a00'],
+      ]),
+    ).toEqual({
+      '--diff-add-bg': 'rgba(47, 209, 152, 0.1)',
+      '--diff-remove-bg': 'rgba(255, 95, 115, 0.1)',
+      '--search-match': '#ffd54f',
+      '--search-match-active': '#ff8a00',
+    });
+  });
+
   it('can apply CSS value validation when collecting parser declarations', () => {
     expect(
       collectAllowedVars(
@@ -180,6 +197,28 @@ describe('custom theme helper primitives', () => {
 
   it('formats variable lines in supported CSS variable order by default', () => {
     expect(formatVarLines({ '--fg': '#fff', '--bg': '#000' })).toBe('  --bg: #000;\n  --fg: #fff;');
+  });
+});
+
+describe('checkThemeContrast', () => {
+  it('warns when subtle text falls below 3:1 on elevated backgrounds', () => {
+    const warnings = checkThemeContrast({
+      '--bg-elevated': '#ffffff',
+      '--bg-selected': '#ffffff',
+      '--fg': '#000000',
+      '--fg-muted': '#555555',
+      '--fg-subtle': '#aaaaaa',
+      '--accent': '#000000',
+      '--accent-text': '#ffffff',
+    });
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        fgVar: '--fg-subtle',
+        bgVar: '--bg-elevated',
+        required: 3,
+      }),
+    ]);
   });
 });
 

--- a/src/lib/custom-theme.ts
+++ b/src/lib/custom-theme.ts
@@ -28,6 +28,10 @@ export const CSS_VARS = [
   '--island-radius',
   '--task-container-bg',
   '--task-panel-bg',
+  '--diff-add-bg',
+  '--diff-remove-bg',
+  '--search-match',
+  '--search-match-active',
 ] as const;
 
 export type CssVar = (typeof CSS_VARS)[number];
@@ -110,6 +114,10 @@ const CSS_VAR_DESCRIPTIONS: Record<CssVar, string> = {
   '--task-container-bg': 'Background of the task list container within an island',
   '--task-panel-bg':
     'Content panel backgrounds inside tasks (conceptually matches terminalBackground)',
+  '--diff-add-bg': 'Background tint for added diff lines',
+  '--diff-remove-bg': 'Background tint for removed diff lines',
+  '--search-match': 'Background color for search matches',
+  '--search-match-active': 'Background color for the active search match',
 };
 
 export function validateCustomTheme(input: unknown): Omit<CustomTheme, 'id'> {
@@ -283,6 +291,7 @@ export interface ContrastWarning {
 const CONTRAST_PAIRS: [CssVar, CssVar, number][] = [
   ['--fg', '--bg-elevated', 4.5],
   ['--fg-muted', '--bg-elevated', 3.0],
+  ['--fg-subtle', '--bg-elevated', 3.0],
   ['--fg', '--bg-selected', 4.5],
   ['--accent-text', '--accent', 4.5],
 ];

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getTerminalSearchDecorations, getTerminalTheme, theme } from './theme';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('theme tokens', () => {
+  it('exposes semantic diff and search colors', () => {
+    expect(theme).toMatchObject({
+      diffAddBg: 'var(--diff-add-bg)',
+      diffRemoveBg: 'var(--diff-remove-bg)',
+      searchMatch: 'var(--search-match)',
+      searchMatchActive: 'var(--search-match-active)',
+    });
+  });
+});
+
+describe('getTerminalTheme', () => {
+  it('derives a built-in terminal background from the preset task panel token', () => {
+    const root = { dataset: { look: 'classic', customTheme: 'custom-id' } };
+    vi.stubGlobal('document', {
+      documentElement: root,
+      getElementById: () => null,
+    });
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: (name: string) =>
+        name === '--task-panel-bg' && root.dataset.look === 'islands-light' ? '#fefefe' : '',
+    }));
+
+    expect(getTerminalTheme('islands-light').background).toBe('#fefefe');
+    expect(root.dataset).toEqual({ look: 'classic', customTheme: 'custom-id' });
+  });
+});
+
+describe('getTerminalSearchDecorations', () => {
+  it('resolves the active preset search tokens for xterm', () => {
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: (name: string) =>
+        name === '--search-match' ? '#112233' : name === '--search-match-active' ? '#445566' : '',
+    }));
+
+    expect(getTerminalSearchDecorations()).toEqual({
+      matchBackground: 'rgba(17, 34, 51, 0.4)',
+      matchOverviewRuler: '#112233',
+      activeMatchBackground: 'rgba(68, 85, 102, 0.85)',
+      activeMatchColorOverviewRuler: '#445566',
+    });
+  });
+
+  it('falls back to readable search colors when custom token values are invalid', () => {
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: () => 'not-a-color',
+    }));
+
+    expect(getTerminalSearchDecorations()).toEqual({
+      matchBackground: 'rgba(255, 213, 79, 0.4)',
+      matchOverviewRuler: '#ffd54f',
+      activeMatchBackground: 'rgba(255, 138, 0, 0.85)',
+      activeMatchColorOverviewRuler: '#ff8a00',
+    });
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -40,23 +40,12 @@ export const theme = {
   islandRadius: 'var(--island-radius)',
   taskContainerBg: 'var(--task-container-bg)',
   taskPanelBg: 'var(--task-panel-bg)',
-} as const;
 
-/** Opaque terminal background per preset — matches --task-panel-bg */
-export const terminalBackground: Record<LookPreset, string> = {
-  classic: '#2d2e32',
-  graphite: '#1c2630',
-  midnight: '#000000',
-  indigo: '#1c2038',
-  ember: '#211918',
-  glacier: '#232e3a',
-  minimal: '#252520',
-  zenburnesque: '#2e2d2a',
-  'catppuccin-mocha': '#1e1e2e',
-  'islands-dark': '#181a1d',
-  'islands-light': '#ffffff',
-  workbench: '#1f1f1f',
-};
+  diffAddBg: 'var(--diff-add-bg)',
+  diffRemoveBg: 'var(--diff-remove-bg)',
+  searchMatch: 'var(--search-match)',
+  searchMatchActive: 'var(--search-match-active)',
+} as const;
 
 // GitHub-light-ish xterm palette (text, cursor, selection + 16 ANSI colors)
 // for light terminal backgrounds, so colored output (claude prompts,
@@ -91,12 +80,11 @@ export const LIGHT_TERMINAL_THEME = {
  * white-ish bright ANSI palette) so plain output stays readable.
  */
 export function getTerminalTheme(preset: LookPreset) {
+  const background = readCssVarsForPreset(preset)['--task-panel-bg'] ?? '#000000';
   if (preset === 'islands-light') {
-    return { background: '#ffffff', ...LIGHT_TERMINAL_THEME };
+    return { background, ...LIGHT_TERMINAL_THEME };
   }
-  return {
-    background: terminalBackground[preset],
-  };
+  return { background };
 }
 
 /**
@@ -151,6 +139,21 @@ export function getTerminalThemeForCustom(bg: string) {
     return { background: bg, ...LIGHT_TERMINAL_THEME };
   }
   return { background: bg };
+}
+
+export function getTerminalSearchDecorations() {
+  const style = getComputedStyle(document.documentElement);
+  const rawMatch = style.getPropertyValue('--search-match').trim();
+  const rawActive = style.getPropertyValue('--search-match-active').trim();
+  const match = colord(rawMatch).isValid() ? rawMatch : '#ffd54f';
+  const active = colord(rawActive).isValid() ? rawActive : '#ff8a00';
+
+  return {
+    matchBackground: colord(match).alpha(0.4).toRgbString(),
+    matchOverviewRuler: match,
+    activeMatchBackground: colord(active).alpha(0.85).toRgbString(),
+    activeMatchColorOverviewRuler: active,
+  } as const;
 }
 
 /** Generates a styled banner (warning/error/info) using color-mix for background+border. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,6 +31,10 @@
   --success: #2fd198;
   --error: #ff5f73;
   --warning: #ffc569;
+  --diff-add-bg: rgba(47, 209, 152, 0.1);
+  --diff-remove-bg: rgba(255, 95, 115, 0.1);
+  --search-match: #ffd54f;
+  --search-match-active: #ff8a00;
 
   --island-bg: #192028;
   --island-border: #2e3e50;
@@ -168,7 +172,7 @@ html[data-look='classic'] {
   --border-focus: #4267ff;
   --fg: #cccdd2;
   --fg-muted: #8b8d93;
-  --fg-subtle: #6d7076;
+  --fg-subtle: #767980;
   --accent: #4267ff;
   --accent-hover: #3a5bff;
   --accent-text: #ffffff;
@@ -460,6 +464,10 @@ html[data-look='islands-light'] {
   --success: #369650;
   --error: #d62b40;
   --warning: #a98708;
+  --diff-add-bg: rgba(54, 150, 80, 0.14);
+  --diff-remove-bg: rgba(214, 43, 64, 0.12);
+  --search-match: #d39e00;
+  --search-match-active: #f57c00;
   --island-bg: #ffffff;
   --island-border: #d3d5db;
   --island-radius: 12px;


### PR DESCRIPTION
## Summary

- Replace dark-only overlay and inset colors with theme-adaptive surfaces.
- Add semantic diff and search tokens, including light-preset values and xterm resolution.
- Enforce `--fg-subtle` contrast and make the built-in preset audit a hard gate with inherited root tokens.
- Derive built-in terminal and cloned-theme backgrounds from `--task-panel-bg` instead of a duplicate table.

## Root cause

Several renderer styles and terminal decorations bypassed the theme token system, while the contrast audit omitted tertiary text and could never fail. Built-in terminal backgrounds also duplicated CSS values in TypeScript, allowing the two sources to drift.

## Validation

- `npm run check`
- `npm test -- --reporter=dot` — 1,571 passed, 24 skipped
- Electron development smoke (`npm run dev`)
- Islands Light click-through: Settings/Themes rendering, themed terminal search highlight, New Task draft retention after Escape/Cancel, and task-count-aware project removal confirmation

Fixes #207.
