### PR TITLE
fix(import): prevent dismissal while importing worktrees

### DIFF
--- a/src/components/ImportWorktreesDialog.tsx
+++ b/src/components/ImportWorktreesDialog.tsx
@@ -5,6 +5,7 @@ import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { createImportedTask, getProjectPath, loadAgents, store } from '../store/store';
 import { theme } from '../lib/theme';
+import { createImportWorktreesCloseHandler } from './import-worktrees-dismiss';
 import type { Project } from '../store/types';
 import type { AgentDef, ImportableWorktree } from '../ipc/types';
 
@@ -22,6 +23,7 @@ export function ImportWorktreesDialog(props: ImportWorktreesDialogProps) {
   const [loading, setLoading] = createSignal(false);
   const [importing, setImporting] = createSignal(false);
   const [error, setError] = createSignal('');
+  const requestClose = createImportWorktreesCloseHandler(importing, () => props.onClose());
 
   const trackedWorktreePaths = createMemo(() => {
     const projectId = props.project?.id;
@@ -127,7 +129,7 @@ export function ImportWorktreesDialog(props: ImportWorktreesDialogProps) {
   }
 
   return (
-    <Dialog open={props.open} onClose={props.onClose} width="560px" panelStyle={{ gap: '18px' }}>
+    <Dialog open={props.open} onClose={requestClose} width="560px" panelStyle={{ gap: '18px' }}>
       <div style={{ display: 'flex', 'flex-direction': 'column', gap: '18px' }}>
         <div>
           <h2
@@ -302,15 +304,17 @@ export function ImportWorktreesDialog(props: ImportWorktreesDialogProps) {
         <div style={{ display: 'flex', 'justify-content': 'flex-end', gap: '8px' }}>
           <button
             type="button"
-            onClick={() => props.onClose()}
+            disabled={importing()}
+            onClick={requestClose}
             style={{
               padding: '9px 18px',
               background: theme.bgInput,
               border: `1px solid ${theme.border}`,
               'border-radius': '8px',
               color: theme.fgMuted,
-              cursor: 'pointer',
+              cursor: importing() ? 'not-allowed' : 'pointer',
               'font-size': '13px',
+              opacity: importing() ? '0.4' : '1',
             }}
           >
             Cancel

--- a/src/components/import-worktrees-dismiss.test.ts
+++ b/src/components/import-worktrees-dismiss.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createImportWorktreesCloseHandler } from './import-worktrees-dismiss';
+
+describe('createImportWorktreesCloseHandler', () => {
+  it('closes when no import is running', () => {
+    const onClose = vi.fn();
+    const requestClose = createImportWorktreesCloseHandler(() => false, onClose);
+
+    requestClose();
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('blocks dismissal until the running import finishes', () => {
+    let importing = true;
+    const onClose = vi.fn();
+    const requestClose = createImportWorktreesCloseHandler(() => importing, onClose);
+
+    requestClose();
+    expect(onClose).not.toHaveBeenCalled();
+
+    importing = false;
+    requestClose();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/import-worktrees-dismiss.ts
+++ b/src/components/import-worktrees-dismiss.ts
@@ -1,0 +1,8 @@
+export function createImportWorktreesCloseHandler(
+  isImporting: () => boolean,
+  onClose: () => void,
+): () => void {
+  return () => {
+    if (!isImporting()) onClose();
+  };
+}


### PR DESCRIPTION
## Summary

- Route Escape, overlay clicks, and the Cancel button through a shared close guard.
- Disable and visually mute Cancel while sequential worktree imports are running.
- Preserve the existing successful-completion close path.

Addresses one remaining item from #214.

## Validation

- `npm test -- src/components/import-worktrees-dismiss.test.ts` (2 passed)
- `npm run check`
- `npm run lint:dead`
- `npm run lint:arch`
- `npm test` (1573 passed, 23 skipped)