### PR TITLE
fix(accessibility): honor reduced motion

### DIFF
--- a/src/components/AskCodeCard.tsx
+++ b/src/components/AskCodeCard.tsx
@@ -149,6 +149,7 @@ export function AskCodeCard(props: AskCodeCardProps) {
       >
         <Show when={loading() && !response()}>
           <span
+            class="askcode-loading-pulse"
             style={{
               color: theme.fgSubtle,
               animation: 'askcode-pulse 1.5s ease-in-out infinite',
@@ -160,6 +161,7 @@ export function AskCodeCard(props: AskCodeCardProps) {
         <Show when={response()}>{response()}</Show>
         <Show when={loading() && response()}>
           <span
+            class="askcode-loading-pulse"
             style={{
               color: theme.accent,
               'font-size': sf(11),

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -364,6 +364,7 @@ export function HelpDialog(props: HelpDialogProps) {
                           </button>
                         </Show>
                         <kbd
+                          class="keybinding-recording-pulse"
                           role="button"
                           tabIndex={0}
                           aria-label={

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -364,7 +364,7 @@ export function HelpDialog(props: HelpDialogProps) {
                           </button>
                         </Show>
                         <kbd
-                          class="keybinding-recording-pulse"
+                          class="keybinding-key"
                           role="button"
                           tabIndex={0}
                           aria-label={

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -48,6 +48,7 @@ import { abbreviateHomePath } from '../lib/path';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import type { ImportableWorktree } from '../ipc/types';
+import { shouldAnimateTaskAppearance } from '../lib/reducedMotion';
 
 const DRAG_THRESHOLD = 5;
 const SIDEBAR_DEFAULT_WIDTH = 240;
@@ -171,9 +172,17 @@ export function TaskRowShell(props: {
   style?: JSX.CSSProperties;
   children: JSX.Element;
 }) {
+  const className = () =>
+    shouldAnimateTaskAppearance()
+      ? props.class
+      : props.class
+          .split(/\s+/)
+          .filter((className) => className !== 'task-item-appearing')
+          .join(' ');
+
   return (
     <div
-      class={props.class}
+      class={className()}
       role={props.role}
       tabIndex={props.tabIndex}
       data-task-index={props.taskIndex}

--- a/src/components/StatusDot.tsx
+++ b/src/components/StatusDot.tsx
@@ -49,7 +49,7 @@ export function StatusDot(props: {
   const isPulsing = () => props.attention === 'active' || props.status === 'busy';
   return (
     <span
-      class={isPulsing() ? 'status-dot-pulse' : undefined}
+      class={isPulsing() ? 'status-dot-pulse status-dot-ring' : undefined}
       title={getDotTooltip(props.status, props.attention)}
       style={{
         display: 'inline-block',

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -29,13 +29,9 @@ import { markDirty } from '../lib/terminalFitManager';
 import { theme } from '../lib/theme';
 import { mod } from '../lib/platform';
 import { createCtrlShiftWheelResizeHandler } from '../lib/wheelZoom';
+import { shouldAnimateTaskAppearance } from '../lib/reducedMotion';
 
 const VIEWPORT_EPSILON_PX = 4;
-
-function shouldAnimateTaskAppearance(): boolean {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true;
-  return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
 
 /** Tiling-layout top-level child. Distinct from `PanelChild` because this
  *  layout owns its own horizontal drag model — fixed placeholders, per-panel

--- a/src/components/TilingLayout.tsx
+++ b/src/components/TilingLayout.tsx
@@ -32,6 +32,11 @@ import { createCtrlShiftWheelResizeHandler } from '../lib/wheelZoom';
 
 const VIEWPORT_EPSILON_PX = 4;
 
+function shouldAnimateTaskAppearance(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true;
+  return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 /** Tiling-layout top-level child. Distinct from `PanelChild` because this
  *  layout owns its own horizontal drag model — fixed placeholders, per-panel
  *  min/max widths, pixel-precise persisted sizes — that doesn't map onto the
@@ -244,6 +249,7 @@ export function TilingLayout() {
           content: () => {
             const task = store.tasks[panelId];
             const terminal = store.terminals[panelId];
+            const appearanceClass = shouldAnimateTaskAppearance() ? 'task-appearing' : undefined;
             // eslint-disable-next-line solid/components-return-once
             if (!task && !terminal) return <div />;
             return (
@@ -252,7 +258,7 @@ export function TilingLayout() {
                 class={
                   task?.closingStatus === 'removing' || terminal?.closingStatus === 'removing'
                     ? 'task-removing'
-                    : 'task-appearing'
+                    : appearanceClass
                 }
                 style={{
                   height: '100%',
@@ -264,6 +270,10 @@ export function TilingLayout() {
                   'box-sizing': 'border-box',
                 }}
                 onAnimationEnd={(e) => {
+                  if (e.animationName === 'taskAppear')
+                    e.currentTarget.classList.remove('task-appearing');
+                }}
+                onAnimationCancel={(e) => {
                   if (e.animationName === 'taskAppear')
                     e.currentTarget.classList.remove('task-appearing');
                 }}

--- a/src/lib/reduced-motion-styles.test.ts
+++ b/src/lib/reduced-motion-styles.test.ts
@@ -3,8 +3,6 @@ import { resolve } from 'path';
 import { describe, expect, it } from 'vitest';
 
 const css = readFileSync(resolve(__dirname, '../styles.css'), 'utf8');
-const helpDialog = readFileSync(resolve(__dirname, '../components/HelpDialog.tsx'), 'utf8');
-const tilingLayout = readFileSync(resolve(__dirname, '../components/TilingLayout.tsx'), 'utf8');
 
 function reducedMotionBlock(): { block: string; end: number } {
   const marker = '@media (prefers-reduced-motion: reduce)';
@@ -34,7 +32,7 @@ function expectRule(block: string, selectors: string[], declaration: RegExp): vo
   expect(block).toMatch(rule);
 }
 
-describe('reduced-motion styles', () => {
+describe('main stylesheet reduced-motion styles', () => {
   it('pairs each main-app selector group with its reduced-motion override', () => {
     const { block, end } = reducedMotionBlock();
 
@@ -50,7 +48,8 @@ describe('reduced-motion styles', () => {
       ],
       /animation:\s*none\s*;/,
     );
-    expectRule(block, ['.status-dot-pulse'], /outline:\s*1px solid var\(--fg-muted\)\s*;/);
+    expectRule(block, ['.status-dot-ring'], /outline:\s*1px solid var\(--fg-muted\)\s*;/);
+    expectRule(block, ['.status-dot-ring'], /outline-offset:\s*2px\s*;/);
     expectRule(
       block,
       ['.askcode-loading-pulse', '.keybinding-key'],
@@ -58,14 +57,9 @@ describe('reduced-motion styles', () => {
     );
     expect(block).not.toContain('.inline-spinner');
     expect(block).not.toContain('keybinding-recording-pulse');
-    expect(css.slice(end + 1).trim()).toBe('');
-  });
-
-  it('avoids stale entry and keybinding animation classes', () => {
-    expect(tilingLayout).toContain("window.matchMedia('(prefers-reduced-motion: reduce)').matches");
-    expect(tilingLayout).toContain('const appearanceClass = shouldAnimateTaskAppearance()');
-    expect(tilingLayout).toContain('onAnimationCancel');
-    expect(helpDialog).toContain('class="keybinding-key"');
-    expect(helpDialog).not.toContain('keybinding-recording-pulse');
+    expect(
+      css.slice(end + 1).trim(),
+      'Keep the reduced-motion block at the end of styles.css so its class rules win by source order',
+    ).toBe('');
   });
 });

--- a/src/lib/reduced-motion-styles.test.ts
+++ b/src/lib/reduced-motion-styles.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(resolve(__dirname, '../styles.css'), 'utf8');
+
+function reducedMotionBlock(): string {
+  const marker = '@media (prefers-reduced-motion: reduce)';
+  const start = css.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const openingBrace = css.indexOf('{', start);
+  let depth = 0;
+  for (let index = openingBrace; index < css.length; index += 1) {
+    if (css[index] === '{') depth += 1;
+    if (css[index] === '}') depth -= 1;
+    if (depth === 0) return css.slice(start, index + 1);
+  }
+
+  throw new Error('Unclosed reduced-motion media query');
+}
+
+describe('reduced-motion styles', () => {
+  it('disables nonessential task and pulse animations', () => {
+    const block = reducedMotionBlock();
+    const animatedSelectors = [
+      '.task-appearing',
+      '.task-item-appearing',
+      '.task-removing',
+      '.task-item-removing',
+      '.status-dot-pulse',
+      '.askcode-loading-pulse',
+      '.keybinding-recording-pulse',
+    ];
+
+    for (const selector of animatedSelectors) {
+      expect(block).toContain(selector);
+    }
+    expect(block).toMatch(/animation:\s*none\s*!important/);
+  });
+});

--- a/src/lib/reduced-motion-styles.test.ts
+++ b/src/lib/reduced-motion-styles.test.ts
@@ -3,39 +3,69 @@ import { resolve } from 'path';
 import { describe, expect, it } from 'vitest';
 
 const css = readFileSync(resolve(__dirname, '../styles.css'), 'utf8');
+const helpDialog = readFileSync(resolve(__dirname, '../components/HelpDialog.tsx'), 'utf8');
+const tilingLayout = readFileSync(resolve(__dirname, '../components/TilingLayout.tsx'), 'utf8');
 
-function reducedMotionBlock(): string {
+function reducedMotionBlock(): { block: string; end: number } {
   const marker = '@media (prefers-reduced-motion: reduce)';
   const start = css.indexOf(marker);
   expect(start).toBeGreaterThanOrEqual(0);
+  expect(css.lastIndexOf(marker)).toBe(start);
 
   const openingBrace = css.indexOf('{', start);
   let depth = 0;
   for (let index = openingBrace; index < css.length; index += 1) {
     if (css[index] === '{') depth += 1;
     if (css[index] === '}') depth -= 1;
-    if (depth === 0) return css.slice(start, index + 1);
+    if (depth === 0) return { block: css.slice(start, index + 1), end: index };
   }
 
   throw new Error('Unclosed reduced-motion media query');
 }
 
-describe('reduced-motion styles', () => {
-  it('disables nonessential task and pulse animations', () => {
-    const block = reducedMotionBlock();
-    const animatedSelectors = [
-      '.task-appearing',
-      '.task-item-appearing',
-      '.task-removing',
-      '.task-item-removing',
-      '.status-dot-pulse',
-      '.askcode-loading-pulse',
-      '.keybinding-recording-pulse',
-    ];
+function expectRule(block: string, selectors: string[], declaration: RegExp): void {
+  const selectorPattern = selectors
+    .map((selector) => selector.replaceAll('.', '\\.'))
+    .join('\\s*,\\s*');
+  const rule = new RegExp(
+    `${selectorPattern}\\s*\\{[^}]*${declaration.source}[^}]*\\}`,
+    declaration.flags,
+  );
+  expect(block).toMatch(rule);
+}
 
-    for (const selector of animatedSelectors) {
-      expect(block).toContain(selector);
-    }
-    expect(block).toMatch(/animation:\s*none\s*!important/);
+describe('reduced-motion styles', () => {
+  it('pairs each main-app selector group with its reduced-motion override', () => {
+    const { block, end } = reducedMotionBlock();
+
+    expectRule(block, ['.projects-collapser'], /transition:\s*none\s*;/);
+    expectRule(
+      block,
+      [
+        '.task-appearing',
+        '.task-item-appearing',
+        '.task-removing',
+        '.task-item-removing',
+        '.status-dot-pulse',
+      ],
+      /animation:\s*none\s*;/,
+    );
+    expectRule(block, ['.status-dot-pulse'], /outline:\s*1px solid var\(--fg-muted\)\s*;/);
+    expectRule(
+      block,
+      ['.askcode-loading-pulse', '.keybinding-key'],
+      /animation:\s*none\s*!important\s*;/,
+    );
+    expect(block).not.toContain('.inline-spinner');
+    expect(block).not.toContain('keybinding-recording-pulse');
+    expect(css.slice(end + 1).trim()).toBe('');
+  });
+
+  it('avoids stale entry and keybinding animation classes', () => {
+    expect(tilingLayout).toContain("window.matchMedia('(prefers-reduced-motion: reduce)').matches");
+    expect(tilingLayout).toContain('const appearanceClass = shouldAnimateTaskAppearance()');
+    expect(tilingLayout).toContain('onAnimationCancel');
+    expect(helpDialog).toContain('class="keybinding-key"');
+    expect(helpDialog).not.toContain('keybinding-recording-pulse');
   });
 });

--- a/src/lib/reducedMotion.test.ts
+++ b/src/lib/reducedMotion.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shouldAnimateTaskAppearance } from './reducedMotion';
+
+describe('shouldAnimateTaskAppearance', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('allows animation when reduced motion is not requested', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: false });
+    vi.stubGlobal('window', { matchMedia });
+
+    expect(shouldAnimateTaskAppearance()).toBe(true);
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+  });
+
+  it('disables animation when reduced motion is requested', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal('window', { matchMedia });
+
+    expect(shouldAnimateTaskAppearance()).toBe(false);
+  });
+
+  it('allows animation when matchMedia is unavailable', () => {
+    vi.stubGlobal('window', {});
+
+    expect(shouldAnimateTaskAppearance()).toBe(true);
+  });
+});

--- a/src/lib/reducedMotion.ts
+++ b/src/lib/reducedMotion.ts
@@ -1,0 +1,4 @@
+export function shouldAnimateTaskAppearance(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true;
+  return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -982,22 +982,6 @@ textarea::placeholder {
   overflow: hidden;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .projects-collapser {
-    transition: none;
-  }
-
-  .task-appearing,
-  .task-item-appearing,
-  .task-removing,
-  .task-item-removing,
-  .status-dot-pulse,
-  .askcode-loading-pulse,
-  .keybinding-recording-pulse {
-    animation: none !important;
-  }
-}
-
 .tiling-layout-shell {
   position: relative;
   flex: 1;
@@ -2207,5 +2191,32 @@ body.dragging-task * {
   }
   50% {
     opacity: 0.3;
+  }
+}
+
+/* Keep reduced-motion overrides last so class-based rules win by source order. */
+@media (prefers-reduced-motion: reduce) {
+  .projects-collapser {
+    transition: none;
+  }
+
+  .task-appearing,
+  .task-item-appearing,
+  .task-removing,
+  .task-item-removing,
+  .status-dot-pulse {
+    animation: none;
+  }
+
+  /* Preserve a static busy-state distinction after removing the pulse. */
+  .status-dot-pulse {
+    outline: 1px solid var(--fg-muted);
+    outline-offset: 1px;
+  }
+
+  /* These animations are declared inline and require an important override. */
+  .askcode-loading-pulse,
+  .keybinding-key {
+    animation: none !important;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1441,6 +1441,7 @@ textarea::placeholder {
 }
 
 .inline-spinner {
+  /* Rotation is the loading cue, so functional spinners remain animated under reduced motion. */
   display: inline-block;
   box-sizing: border-box;
   width: 12px;
@@ -2209,9 +2210,9 @@ body.dragging-task * {
   }
 
   /* Preserve a static busy-state distinction after removing the pulse. */
-  .status-dot-pulse {
+  .status-dot-ring {
     outline: 1px solid var(--fg-muted);
-    outline-offset: 1px;
+    outline-offset: 2px;
   }
 
   /* These animations are declared inline and require an important override. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -986,6 +986,16 @@ textarea::placeholder {
   .projects-collapser {
     transition: none;
   }
+
+  .task-appearing,
+  .task-item-appearing,
+  .task-removing,
+  .task-item-removing,
+  .status-dot-pulse,
+  .askcode-loading-pulse,
+  .keybinding-recording-pulse {
+    animation: none !important;
+  }
 }
 
 .tiling-layout-shell {


### PR DESCRIPTION
## Summary
- disable task enter/exit animations when the OS requests reduced motion
- suppress status, Ask Code, and keybinding pulse animations in reduced-motion mode
- preserve the status dot's busy sub-state with a static outer ring after its pulse is removed
- move the main reduced-motion block to the end of the stylesheet and reserve `!important` for inline animations
- avoid stale task-entry classes when reduced motion is already enabled
- strengthen regression coverage so selector groups are paired with their declarations

Functional loading spinners remain animated because rotation is the loading signal in icon-only states; status dots now have a non-motion fallback.

## Validation
- `npx vitest run src/lib/reduced-motion-styles.test.ts`
- `npm test` (1,573 passed, 23 skipped)
- `npm run check`
- `npm run check:static`

Addresses the reduced-motion item in #211.