### PR TITLE
feat(git): widen worktree symlink candidates

### DIFF
--- a/electron/ipc/git-exclude.ts
+++ b/electron/ipc/git-exclude.ts
@@ -41,7 +41,9 @@ export function appendGitInfoExcludeBlockAtPath(
         if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
       }
     }
-    if (existing.split('\n').some((line) => line.trim() === marker)) return 'present';
+    // Gitignore strips trailing whitespace only — a hand-written line with
+    // leading spaces is a different pattern, not the marker.
+    if (existing.split('\n').some((line) => line.replace(/\s+$/, '') === marker)) return 'present';
     const normalizedBlock = block.replace(/^\n+/, '').endsWith('\n')
       ? block.replace(/^\n+/, '')
       : `${block.replace(/^\n+/, '')}\n`;

--- a/electron/ipc/git-exclude.ts
+++ b/electron/ipc/git-exclude.ts
@@ -5,6 +5,22 @@ import path from 'path';
 export type AppendGitInfoExcludeResult = 'appended' | 'present' | 'missing' | 'failed';
 type ExecFileSync = typeof childProcess.execFileSync;
 
+/**
+ * Normalize an exclude line for dedup comparison the way Git parses it: a CR
+ * from CRLF endings and unescaped trailing ASCII spaces are insignificant,
+ * while tabs, Unicode whitespace, and escaped trailing spaces (`\ `) stay
+ * significant. Use this everywhere an existing line is compared against a
+ * pattern — plain exact match and `\s+$` stripping both diverge from Git.
+ */
+export function normalizeExcludeLine(line: string): string {
+  const noCr = line.endsWith('\r') ? line.slice(0, -1) : line;
+  // ponytail: `endsWith('\\ ')` only inspects the final space — `/foo\  `
+  // (escaped space followed by an unescaped one) is normalized imprecisely,
+  // but such lines don't occur in real exclude files.
+  if (/ +$/.test(noCr) && !noCr.endsWith('\\ ')) return noCr.replace(/ +$/, '');
+  return noCr;
+}
+
 export function resolveGitInfoExcludePath(
   worktreePath: string,
   execFileSyncImpl: ExecFileSync = childProcess.execFileSync,
@@ -29,6 +45,10 @@ export function appendGitInfoExcludeBlockAtPath(
   block: string,
   onError?: (err: unknown) => void,
   knownExisting?: string,
+  // Set when the caller has already computed the missing lines from
+  // `knownExisting` itself — the single-marker recheck below must not gate a
+  // multi-line block whose remaining entries may genuinely be missing.
+  skipMarkerCheck?: boolean,
 ): AppendGitInfoExcludeResult {
   try {
     fs.mkdirSync(path.dirname(excludePath), { recursive: true });
@@ -41,9 +61,14 @@ export function appendGitInfoExcludeBlockAtPath(
         if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
       }
     }
-    // Gitignore strips trailing whitespace only — a hand-written line with
-    // leading spaces is a different pattern, not the marker.
-    if (existing.split('\n').some((line) => line.replace(/\s+$/, '') === marker)) return 'present';
+    // Comparison matches Git's parsing (see normalizeExcludeLine): a
+    // hand-written line with leading spaces or a trailing tab is a different
+    // pattern, not the marker.
+    if (
+      !skipMarkerCheck &&
+      existing.split('\n').some((line) => normalizeExcludeLine(line) === marker)
+    )
+      return 'present';
     const normalizedBlock = block.replace(/^\n+/, '').endsWith('\n')
       ? block.replace(/^\n+/, '')
       : `${block.replace(/^\n+/, '')}\n`;

--- a/electron/ipc/git-helpers.test.ts
+++ b/electron/ipc/git-helpers.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { changedFilesFromMaps, countReadableTextLines } from './git.js';
+import { changedFilesFromMaps, countReadableTextLines, ensureSymlinkExcludes } from './git.js';
 import { appendGitInfoExcludeBlock, resolveGitInfoExcludePath } from './git-exclude.js';
 
 const tempDirs: string[] = [];
@@ -148,5 +148,32 @@ describe('git exclude helpers', () => {
       appendGitInfoExcludeBlock(root, '# marker', '# marker\nignored\n');
 
       expect(fs.readFileSync(excludePath, 'utf8')).toBe('existing\n# marker\nignored\n');
+    }));
+
+  it('symlink excludes cover missing entries beside a hand-written trailing-space line', () =>
+    withoutInheritedGitContext(() => {
+      const root = initRepository();
+      const excludePath = path.join(root, '.git', 'info', 'exclude');
+      // Git strips the unescaped trailing space, so `/foo ` already covers
+      // `foo` — but a marker match on it must not swallow the missing `/bar`.
+      fs.writeFileSync(excludePath, '/foo \n', 'utf8');
+
+      ensureSymlinkExcludes(root, ['foo', 'bar']);
+
+      expect(() => git(root, ['check-ignore', '-q', 'foo'])).not.toThrow();
+      expect(() => git(root, ['check-ignore', '-q', 'bar'])).not.toThrow();
+    }));
+
+  it('symlink excludes treat a tab-suffixed line as a distinct pattern', () =>
+    withoutInheritedGitContext(() => {
+      const root = initRepository();
+      const excludePath = path.join(root, '.git', 'info', 'exclude');
+      // Git does not strip trailing tabs — `/foo\t` ignores `foo\t`, so `foo`
+      // still needs its own entry.
+      fs.writeFileSync(excludePath, '/foo\t\n', 'utf8');
+
+      ensureSymlinkExcludes(root, ['foo']);
+
+      expect(() => git(root, ['check-ignore', '-q', 'foo'])).not.toThrow();
     }));
 });

--- a/electron/ipc/git-symlink-excludes.test.ts
+++ b/electron/ipc/git-symlink-excludes.test.ts
@@ -208,6 +208,20 @@ describe('ensureSymlinkExcludes', () => {
     expect(appended).toContain('/foo\n');
   });
 
+  it('appends entries when an existing line only matches after trimming leading whitespace', () => {
+    // Gitignore semantics strip trailing whitespace only — a hand-written
+    // line with a leading space is a different pattern, not a duplicate.
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce(' /foo\n');
+
+    ensureSymlinkExcludes('/worktree', ['foo', 'bar']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/foo');
+    expect(appended).toContain('/bar');
+  });
+
   it('escapes gitignore metacharacters so names match literally', () => {
     mockExecFileSync.mockReturnValueOnce('.git\n');
     mockReadFileSync.mockReturnValueOnce('');
@@ -220,6 +234,18 @@ describe('ensureSymlinkExcludes', () => {
     expect(appended).toContain('/br\\[ack\\]et\n');
     expect(appended).toContain('/\\!bang\n');
     expect(appended).toContain('/\\#hash\n');
+  });
+
+  it('escapes trailing spaces so the pattern matches the exact name', () => {
+    // Gitignore strips unescaped trailing spaces — `foo ` must be written as
+    // `foo\ ` or the pattern would match `foo` instead.
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['foo ']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/foo\\ \n');
   });
 
   it('treats an already-present escaped entry as a duplicate', () => {

--- a/electron/ipc/git-symlink-excludes.test.ts
+++ b/electron/ipc/git-symlink-excludes.test.ts
@@ -282,4 +282,53 @@ describe('ensureSymlinkExcludes', () => {
     expect(mockAppendFileSync).not.toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it('treats a hand-written trailing-space line as covering the same pattern', () => {
+    // Git strips unescaped trailing ASCII spaces, so `/foo ` already ignores
+    // `foo` — only the genuinely missing `/bar` may be appended. A marker
+    // match on `/foo` must not suppress the rest of the block.
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/foo \n');
+
+    ensureSymlinkExcludes('/worktree', ['foo', 'bar']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).not.toContain('/foo');
+    expect(appended).toContain('/bar\n');
+  });
+
+  it('treats a tab-suffixed line as a distinct pattern and still appends', () => {
+    // Git strips trailing spaces only — `/foo\t` ignores a file named `foo\t`,
+    // not `foo`, so the real entry must still be written.
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/foo\t\n');
+
+    ensureSymlinkExcludes('/worktree', ['foo']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/foo\n');
+  });
+
+  it('treats a CRLF line as covering the same pattern', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/foo\r\n');
+
+    ensureSymlinkExcludes('/worktree', ['foo']);
+
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('treats an escaped trailing-space line as a distinct pattern and still appends', () => {
+    // `/foo\ ` ignores the file named `foo `, not `foo`.
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/foo\\ \n');
+
+    ensureSymlinkExcludes('/worktree', ['foo']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/foo\n');
+  });
 });

--- a/electron/ipc/git-symlink-excludes.test.ts
+++ b/electron/ipc/git-symlink-excludes.test.ts
@@ -196,4 +196,64 @@ describe('ensureSymlinkExcludes', () => {
     expect(appended).toContain('/.env');
     expect(appended).toContain('/.cursor');
   });
+
+  it('writes /foo even when /foobar is already present', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/foobar\n');
+
+    ensureSymlinkExcludes('/worktree', ['foo']);
+
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/foo\n');
+  });
+
+  it('escapes gitignore metacharacters so names match literally', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['star*file', 'que?stion', 'br[ack]et', '!bang', '#hash']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/star\\*file\n');
+    expect(appended).toContain('/que\\?stion\n');
+    expect(appended).toContain('/br\\[ack\\]et\n');
+    expect(appended).toContain('/\\!bang\n');
+    expect(appended).toContain('/\\#hash\n');
+  });
+
+  it('treats an already-present escaped entry as a duplicate', () => {
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('/star\\*file\n');
+
+    ensureSymlinkExcludes('/worktree', ['star*file']);
+
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects names containing newlines and warns instead of writing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockExecFileSync.mockReturnValueOnce('.git\n');
+    mockReadFileSync.mockReturnValueOnce('');
+
+    ensureSymlinkExcludes('/worktree', ['good', 'bad\nname']);
+
+    const [, appended] = mockAppendFileSync.mock.calls[0] as [string, string];
+    expect(appended).toContain('/good');
+    expect(appended).not.toContain('bad');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Refusing to exclude invalid symlink name'),
+    );
+    warn.mockRestore();
+  });
+
+  it('does nothing at all when every name is invalid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    ensureSymlinkExcludes('/worktree', ['bad\r\nname']);
+
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
 });

--- a/electron/ipc/git-worktree.test.ts
+++ b/electron/ipc/git-worktree.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createWorktree, getSymlinkCandidates } from './git.js';
 
@@ -211,6 +211,16 @@ describe('getSymlinkCandidates', () => {
     expect(fs.realpathSync(target)).toBe(fs.realpathSync(path.join(root, 'dàta')));
     const exclude = fs.readFileSync(path.join(root, '.git', 'info', 'exclude'), 'utf8');
     expect(exclude).toContain('/dàta');
+  });
+
+  it('returns an empty list and warns when the git probe fails', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'parallel-code-not-a-repo-'));
+    tempDirs.push(root);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   it('handles non-ASCII file names', async () => {

--- a/electron/ipc/git-worktree.test.ts
+++ b/electron/ipc/git-worktree.test.ts
@@ -1,0 +1,197 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createWorktree, getGitIgnoredDirs } from './git.js';
+
+const tempDirs: string[] = [];
+const localGitEnvVars = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n')
+  .filter(Boolean);
+const inheritedGitEnv = new Map<string, string | undefined>();
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function initRepository(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'parallel-code-git-worktree-'));
+  tempDirs.push(root);
+  git(root, ['init', '--quiet', '--initial-branch=main']);
+  fs.writeFileSync(path.join(root, 'tracked.txt'), 'initial\n', 'utf8');
+  git(root, ['add', 'tracked.txt']);
+  git(root, [
+    '-c',
+    'user.name=Parallel Code Tests',
+    '-c',
+    'user.email=tests@parallel-code.local',
+    'commit',
+    '-m',
+    'initial',
+  ]);
+  return root;
+}
+
+beforeEach(() => {
+  for (const name of localGitEnvVars) {
+    inheritedGitEnv.set(name, process.env[name]);
+    Reflect.deleteProperty(process.env, name);
+  }
+});
+
+afterEach(() => {
+  for (const [name, value] of inheritedGitEnv) {
+    if (value === undefined) Reflect.deleteProperty(process.env, name);
+    else process.env[name] = value;
+  }
+  inheritedGitEnv.clear();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('getGitIgnoredDirs', () => {
+  it('includes a fully ignored default directory marked as default', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'node_modules'));
+    fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([
+      { name: 'node_modules', isDefault: true },
+    ]);
+  });
+
+  it('includes a fully ignored non-default directory marked as discovered', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'dist/\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'dist'));
+    fs.writeFileSync(path.join(root, 'dist', 'app.js'), 'built\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
+  });
+
+  it('includes an ignored top-level file', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '.env\n', 'utf8');
+    fs.writeFileSync(path.join(root, '.env'), 'TOKEN=test\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: '.env', isDefault: true }]);
+  });
+
+  it('does not expose a tracked directory that only contains ignored files', async () => {
+    const root = initRepository();
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(path.join(root, 'src', 'tracked.ts'), 'export {};\n', 'utf8');
+    git(root, ['add', 'src/tracked.ts']);
+    git(root, [
+      '-c',
+      'user.name=Parallel Code Tests',
+      '-c',
+      'user.email=tests@parallel-code.local',
+      'commit',
+      '-m',
+      'track source directory',
+    ]);
+    fs.writeFileSync(path.join(root, '.gitignore'), '*.log\n', 'utf8');
+    fs.writeFileSync(path.join(root, 'src', 'foo.log'), 'ignored\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([]);
+  });
+
+  it('does not include a default candidate that is not ignored', async () => {
+    const root = initRepository();
+    fs.mkdirSync(path.join(root, 'node_modules'));
+    fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([]);
+  });
+
+  it('filters entries managed internally by Parallel Code', async () => {
+    const root = initRepository();
+    const sandboxArtifacts = [
+      '.bash_profile',
+      '.bashrc',
+      '.gitconfig',
+      '.gitmodules',
+      '.mcp.json',
+      '.profile',
+      '.ripgreprc',
+      '.zprofile',
+      '.zshrc',
+    ];
+    fs.writeFileSync(path.join(root, '.gitignore'), '.claude/\ndist/\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.claude'));
+    fs.writeFileSync(path.join(root, '.claude', 'settings.json'), '{}\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'dist'));
+    fs.writeFileSync(path.join(root, 'dist', 'app.js'), 'built\n', 'utf8');
+    fs.appendFileSync(
+      path.join(root, '.git', 'info', 'exclude'),
+      sandboxArtifacts.map((name) => `/${name}`).join('\n') + '\n',
+    );
+    for (const name of sandboxArtifacts) {
+      fs.writeFileSync(path.join(root, name), 'sandbox artifact\n', 'utf8');
+    }
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
+  });
+
+  it('filters the Parallel Code worktree container without hiding a singular name', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '.worktree/\n.worktrees/\ndist/\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.worktree'));
+    fs.writeFileSync(path.join(root, '.worktree', 'user.txt'), 'user directory\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.worktrees'));
+    fs.writeFileSync(path.join(root, '.worktrees', 'task.txt'), 'managed worktree\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'dist'));
+    fs.writeFileSync(path.join(root, 'dist', 'app.js'), 'built\n', 'utf8');
+
+    await expect(getGitIgnoredDirs(root)).resolves.toEqual([
+      { name: '.worktree', isDefault: false },
+      { name: 'dist', isDefault: false },
+    ]);
+  });
+});
+
+describe('createWorktree', () => {
+  it('symlinks a selected ignored directory from the main checkout', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n', 'utf8');
+    const source = path.join(root, 'node_modules');
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, 'package.json'), '{}\n', 'utf8');
+
+    const result = await createWorktree(root, 'task-symlink', ['node_modules']);
+    const target = path.join(result.path, 'node_modules');
+
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(target)).toBe(fs.realpathSync(source));
+  });
+
+  it('silently rejects selected names nested below the repository root', async () => {
+    const root = initRepository();
+    fs.mkdirSync(path.join(root, 'foo', 'bar'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'foo', 'tracked.txt'), 'tracked\n', 'utf8');
+    git(root, ['add', 'foo/tracked.txt']);
+    git(root, [
+      '-c',
+      'user.name=Parallel Code Tests',
+      '-c',
+      'user.email=tests@parallel-code.local',
+      'commit',
+      '-m',
+      'track parent directory',
+    ]);
+
+    const result = await createWorktree(root, 'task-nested', ['foo/bar']);
+
+    expect(fs.existsSync(path.join(result.path, 'foo', 'tracked.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(result.path, 'foo', 'bar'))).toBe(false);
+  });
+});

--- a/electron/ipc/git-worktree.test.ts
+++ b/electron/ipc/git-worktree.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { createWorktree, getGitIgnoredDirs } from './git.js';
+import { createWorktree, getSymlinkCandidates } from './git.js';
 
 const tempDirs: string[] = [];
 const localGitEnvVars = execFileSync('git', ['rev-parse', '--local-env-vars'], {
@@ -56,14 +56,14 @@ afterEach(() => {
   }
 });
 
-describe('getGitIgnoredDirs', () => {
+describe('getSymlinkCandidates', () => {
   it('includes a fully ignored default directory marked as default', async () => {
     const root = initRepository();
     fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n', 'utf8');
     fs.mkdirSync(path.join(root, 'node_modules'));
     fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
       { name: 'node_modules', isDefault: true },
     ]);
   });
@@ -74,7 +74,7 @@ describe('getGitIgnoredDirs', () => {
     fs.mkdirSync(path.join(root, 'dist'));
     fs.writeFileSync(path.join(root, 'dist', 'app.js'), 'built\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
   });
 
   it('includes an ignored top-level file', async () => {
@@ -82,7 +82,7 @@ describe('getGitIgnoredDirs', () => {
     fs.writeFileSync(path.join(root, '.gitignore'), '.env\n', 'utf8');
     fs.writeFileSync(path.join(root, '.env'), 'TOKEN=test\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: '.env', isDefault: true }]);
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([{ name: '.env', isDefault: true }]);
   });
 
   it('does not expose a tracked directory that only contains ignored files', async () => {
@@ -102,7 +102,7 @@ describe('getGitIgnoredDirs', () => {
     fs.writeFileSync(path.join(root, '.gitignore'), '*.log\n', 'utf8');
     fs.writeFileSync(path.join(root, 'src', 'foo.log'), 'ignored\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([]);
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
   });
 
   it('does not include a default candidate that is not ignored', async () => {
@@ -110,7 +110,7 @@ describe('getGitIgnoredDirs', () => {
     fs.mkdirSync(path.join(root, 'node_modules'));
     fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([]);
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
   });
 
   it('filters entries managed internally by Parallel Code', async () => {
@@ -139,7 +139,7 @@ describe('getGitIgnoredDirs', () => {
       fs.writeFileSync(path.join(root, name), 'sandbox artifact\n', 'utf8');
     }
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([{ name: 'dist', isDefault: false }]);
   });
 
   it('filters the Parallel Code worktree container without hiding a singular name', async () => {
@@ -152,10 +152,76 @@ describe('getGitIgnoredDirs', () => {
     fs.mkdirSync(path.join(root, 'dist'));
     fs.writeFileSync(path.join(root, 'dist', 'app.js'), 'built\n', 'utf8');
 
-    await expect(getGitIgnoredDirs(root)).resolves.toEqual([
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
       { name: '.worktree', isDefault: false },
       { name: 'dist', isDefault: false },
     ]);
+  });
+
+  it('does not show a directory whose contents are ignored by *.log', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '*.log\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'logs'));
+    fs.writeFileSync(path.join(root, 'logs', 'app.log'), 'ignored\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
+
+    await createWorktree(root, 'task-logs', []);
+    const exclude = fs.readFileSync(path.join(root, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).not.toContain('/logs');
+  });
+
+  it('does not show a directory whose contents are ignored by coverage/*', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'coverage/*\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'coverage'));
+    fs.writeFileSync(path.join(root, 'coverage', 'lcov.info'), 'ignored\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
+
+    await createWorktree(root, 'task-coverage', []);
+    const exclude = fs.readFileSync(path.join(root, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).not.toContain('/coverage');
+  });
+
+  it('does not show a directory whose contents are ignored by *.tmp', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '*.tmp\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'tmp'));
+    fs.writeFileSync(path.join(root, 'tmp', 'foo.tmp'), 'ignored\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
+
+    await createWorktree(root, 'task-tmp', []);
+    const exclude = fs.readFileSync(path.join(root, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).not.toContain('/tmp');
+  });
+
+  it('handles non-ASCII directory names', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'dàta/\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'dàta'));
+    fs.writeFileSync(path.join(root, 'dàta', 'file.txt'), 'data\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([{ name: 'dàta', isDefault: false }]);
+
+    const result = await createWorktree(root, 'task-data', ['dàta']);
+    const target = path.join(result.path, 'dàta');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(target)).toBe(fs.realpathSync(path.join(root, 'dàta')));
+    const exclude = fs.readFileSync(path.join(root, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).toContain('/dàta');
+  });
+
+  it('handles non-ASCII file names', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), 'nöte.txt\n', 'utf8');
+    fs.writeFileSync(path.join(root, 'nöte.txt'), 'notes\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
+      { name: 'nöte.txt', isDefault: false },
+    ]);
+    expect(fs.existsSync(path.join(root, 'nöte.txt'))).toBe(true);
   });
 });
 

--- a/electron/ipc/git-worktree.test.ts
+++ b/electron/ipc/git-worktree.test.ts
@@ -213,6 +213,28 @@ describe('getSymlinkCandidates', () => {
     expect(exclude).toContain('/dàta');
   });
 
+  it('writes an exclude entry that matches a trailing-space name exactly', async () => {
+    const root = initRepository();
+    // Directory-only ignore rule for a directory whose name ends in a space.
+    fs.writeFileSync(path.join(root, '.gitignore'), 'foo\\ /\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'foo '));
+    fs.writeFileSync(path.join(root, 'foo ', 'f.txt'), 'x\n', 'utf8');
+    // Same name without the trailing space: not ignored, never a candidate.
+    fs.mkdirSync(path.join(root, 'foo'));
+    fs.writeFileSync(path.join(root, 'foo', 'f.txt'), 'x\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([{ name: 'foo ', isDefault: false }]);
+
+    await createWorktree(root, 'task-trailing-space', ['foo ']);
+
+    // Raw execFileSync — the shared git() helper trims stdout and would eat
+    // the trailing space this test is about.
+    expect(execFileSync('git', ['check-ignore', 'foo '], { cwd: root, encoding: 'utf8' })).toBe(
+      'foo \n',
+    );
+    expect(() => git(root, ['check-ignore', 'foo'])).toThrow();
+  });
+
   it('returns an empty list and warns when the git probe fails', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'parallel-code-not-a-repo-'));
     tempDirs.push(root);
@@ -249,10 +271,13 @@ describe('getSymlinkCandidates', () => {
       'track source directory',
     ]);
     fs.writeFileSync(path.join(root, '.gitignore'), '*.log\nnode_modules/\n', 'utf8');
-    // 15000 nested ignored files: unbounded enumeration of these used to blow
-    // the exec buffer and lose every candidate, node_modules included.
-    for (let i = 0; i < 15000; i++) {
-      fs.writeFileSync(path.join(root, 'src', `f${i}.log`), 'ignored\n', 'utf8');
+    // 5000 nested ignored files with 240-char names (just under the 255 fs
+    // limit): ≈1.2 MB of output, ~17% above the old 1 MiB execFile default —
+    // unbounded enumeration of these used to blow the exec buffer and lose
+    // every candidate, node_modules included.
+    for (let i = 0; i < 5000; i++) {
+      const name = `f${i}-`.padEnd(236, 'x') + '.log';
+      fs.writeFileSync(path.join(root, 'src', name), 'ignored\n', 'utf8');
     }
     fs.mkdirSync(path.join(root, 'node_modules'));
     fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
@@ -284,28 +309,32 @@ describe('getSymlinkCandidates', () => {
     await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
   });
 
-  it('filters case variants of reserved names when core.ignorecase is true', async () => {
-    const root = initRepository();
-    git(root, ['config', 'core.ignorecase', 'true']);
-    fs.writeFileSync(
-      path.join(root, '.gitignore'),
-      '.worktrees/\nnode_modules/\n.claude/\n',
-      'utf8',
-    );
-    fs.mkdirSync(path.join(root, '.WORKTREES'));
-    fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
-    fs.mkdirSync(path.join(root, '.CLAUDE'));
-    fs.writeFileSync(path.join(root, '.CLAUDE', 'settings.json'), '{}\n', 'utf8');
-    fs.mkdirSync(path.join(root, 'Node_Modules'));
-    fs.writeFileSync(path.join(root, 'Node_Modules', 'package.json'), '{}\n', 'utf8');
+  // Git accepts yes/on/1 and case variants as boolean true — every synonym
+  // must enable case folding, not just the literal string "true".
+  for (const ignoreCaseValue of ['true', 'yes', 'on', '1', 'TRUE']) {
+    it(`filters case variants of reserved names when core.ignorecase=${ignoreCaseValue}`, async () => {
+      const root = initRepository();
+      git(root, ['config', 'core.ignorecase', ignoreCaseValue]);
+      fs.writeFileSync(
+        path.join(root, '.gitignore'),
+        '.worktrees/\nnode_modules/\n.claude/\n',
+        'utf8',
+      );
+      fs.mkdirSync(path.join(root, '.WORKTREES'));
+      fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
+      fs.mkdirSync(path.join(root, '.CLAUDE'));
+      fs.writeFileSync(path.join(root, '.CLAUDE', 'settings.json'), '{}\n', 'utf8');
+      fs.mkdirSync(path.join(root, 'Node_Modules'));
+      fs.writeFileSync(path.join(root, 'Node_Modules', 'package.json'), '{}\n', 'utf8');
 
-    // .WORKTREES / .CLAUDE must never be offered (self-referential symlink
-    // loop / bwrap breakage); Node_Modules is a legitimate candidate and is
-    // recognized as a default despite the case difference.
-    await expect(getSymlinkCandidates(root)).resolves.toEqual([
-      { name: 'Node_Modules', isDefault: true },
-    ]);
-  });
+      // .WORKTREES / .CLAUDE must never be offered (self-referential symlink
+      // loop / bwrap breakage); Node_Modules is a legitimate candidate and is
+      // recognized as a default despite the case difference.
+      await expect(getSymlinkCandidates(root)).resolves.toEqual([
+        { name: 'Node_Modules', isDefault: true },
+      ]);
+    });
+  }
 });
 
 describe('createWorktree', () => {
@@ -356,18 +385,20 @@ describe('createWorktree', () => {
     expect(fs.realpathSync(target)).toBe(fs.realpathSync(path.join(root, 'foo..bar')));
   });
 
-  it('refuses a case variant of the worktree container when core.ignorecase is true', async () => {
-    const root = initRepository();
-    git(root, ['config', 'core.ignorecase', 'true']);
-    fs.mkdirSync(path.join(root, '.WORKTREES'));
-    fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
+  for (const ignoreCaseValue of ['true', 'yes', 'on', '1', 'TRUE']) {
+    it(`refuses a case variant of the worktree container when core.ignorecase=${ignoreCaseValue}`, async () => {
+      const root = initRepository();
+      git(root, ['config', 'core.ignorecase', ignoreCaseValue]);
+      fs.mkdirSync(path.join(root, '.WORKTREES'));
+      fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
 
-    // Even if the UI (or a bug above it) passes a reserved name through, the
-    // backend must not link the worktree container into its own child.
-    const result = await createWorktree(root, 'task-reserved', ['.WORKTREES']);
+      // Even if the UI (or a bug above it) passes a reserved name through, the
+      // backend must not link the worktree container into its own child.
+      const result = await createWorktree(root, 'task-reserved', ['.WORKTREES']);
 
-    expect(fs.existsSync(path.join(result.path, '.WORKTREES'))).toBe(false);
-  });
+      expect(fs.existsSync(path.join(result.path, '.WORKTREES'))).toBe(false);
+    });
+  }
 });
 
 describe('ensureSymlinkExcludes', () => {

--- a/electron/ipc/git-worktree.test.ts
+++ b/electron/ipc/git-worktree.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createWorktree, getSymlinkCandidates } from './git.js';
+import { createWorktree, ensureSymlinkExcludes, getSymlinkCandidates } from './git.js';
 
 const tempDirs: string[] = [];
 const localGitEnvVars = execFileSync('git', ['rev-parse', '--local-env-vars'], {
@@ -233,6 +233,79 @@ describe('getSymlinkCandidates', () => {
     ]);
     expect(fs.existsSync(path.join(root, 'nöte.txt'))).toBe(true);
   });
+
+  it('finds root candidates even above a tracked directory full of ignored files', async () => {
+    const root = initRepository();
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(path.join(root, 'src', 'tracked.ts'), 'export {};\n', 'utf8');
+    git(root, ['add', 'src/tracked.ts']);
+    git(root, [
+      '-c',
+      'user.name=Parallel Code Tests',
+      '-c',
+      'user.email=tests@parallel-code.local',
+      'commit',
+      '-m',
+      'track source directory',
+    ]);
+    fs.writeFileSync(path.join(root, '.gitignore'), '*.log\nnode_modules/\n', 'utf8');
+    // 15000 nested ignored files: unbounded enumeration of these used to blow
+    // the exec buffer and lose every candidate, node_modules included.
+    for (let i = 0; i < 15000; i++) {
+      fs.writeFileSync(path.join(root, 'src', `f${i}.log`), 'ignored\n', 'utf8');
+    }
+    fs.mkdirSync(path.join(root, 'node_modules'));
+    fs.writeFileSync(path.join(root, 'node_modules', 'package.json'), '{}\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
+      { name: 'node_modules', isDefault: true },
+    ]);
+  }, 60000);
+
+  it('returns a root-level ignored file named like a git flag without hanging', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '/--stdin\n', 'utf8');
+    fs.writeFileSync(path.join(root, '--stdin'), 'tricky\n', 'utf8');
+
+    // The default 5s test timeout is the hang tripwire: the old per-candidate
+    // `git check-ignore` re-verification parsed `--stdin` as a flag and waited
+    // on stdin forever.
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
+      { name: '--stdin', isDefault: false },
+    ]);
+  });
+
+  it('does not show a dot-directory whose contents alone are ignored', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, '.gitignore'), '*.log\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.hidden'));
+    fs.writeFileSync(path.join(root, '.hidden', 'app.log'), 'ignored\n', 'utf8');
+
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([]);
+  });
+
+  it('filters case variants of reserved names when core.ignorecase is true', async () => {
+    const root = initRepository();
+    git(root, ['config', 'core.ignorecase', 'true']);
+    fs.writeFileSync(
+      path.join(root, '.gitignore'),
+      '.worktrees/\nnode_modules/\n.claude/\n',
+      'utf8',
+    );
+    fs.mkdirSync(path.join(root, '.WORKTREES'));
+    fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.CLAUDE'));
+    fs.writeFileSync(path.join(root, '.CLAUDE', 'settings.json'), '{}\n', 'utf8');
+    fs.mkdirSync(path.join(root, 'Node_Modules'));
+    fs.writeFileSync(path.join(root, 'Node_Modules', 'package.json'), '{}\n', 'utf8');
+
+    // .WORKTREES / .CLAUDE must never be offered (self-referential symlink
+    // loop / bwrap breakage); Node_Modules is a legitimate candidate and is
+    // recognized as a default despite the case difference.
+    await expect(getSymlinkCandidates(root)).resolves.toEqual([
+      { name: 'Node_Modules', isDefault: true },
+    ]);
+  });
 });
 
 describe('createWorktree', () => {
@@ -269,5 +342,44 @@ describe('createWorktree', () => {
 
     expect(fs.existsSync(path.join(result.path, 'foo', 'tracked.txt'))).toBe(true);
     expect(fs.existsSync(path.join(result.path, 'foo', 'bar'))).toBe(false);
+  });
+
+  it('creates a symlink for a name containing a `..` substring', async () => {
+    const root = initRepository();
+    fs.mkdirSync(path.join(root, 'foo..bar'));
+    fs.writeFileSync(path.join(root, 'foo..bar', 'file.txt'), 'data\n', 'utf8');
+
+    const result = await createWorktree(root, 'task-dotdot', ['foo..bar']);
+    const target = path.join(result.path, 'foo..bar');
+
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(target)).toBe(fs.realpathSync(path.join(root, 'foo..bar')));
+  });
+
+  it('refuses a case variant of the worktree container when core.ignorecase is true', async () => {
+    const root = initRepository();
+    git(root, ['config', 'core.ignorecase', 'true']);
+    fs.mkdirSync(path.join(root, '.WORKTREES'));
+    fs.writeFileSync(path.join(root, '.WORKTREES', 'task.txt'), 'managed worktree\n', 'utf8');
+
+    // Even if the UI (or a bug above it) passes a reserved name through, the
+    // backend must not link the worktree container into its own child.
+    const result = await createWorktree(root, 'task-reserved', ['.WORKTREES']);
+
+    expect(fs.existsSync(path.join(result.path, '.WORKTREES'))).toBe(false);
+  });
+});
+
+describe('ensureSymlinkExcludes', () => {
+  it('escapes gitignore wildcards so similarly-named files stay visible', async () => {
+    const root = initRepository();
+    fs.writeFileSync(path.join(root, 'star*file'), 'a\n', 'utf8');
+    fs.writeFileSync(path.join(root, 'starZZfile'), 'b\n', 'utf8');
+
+    ensureSymlinkExcludes(root, ['star*file']);
+
+    const status = git(root, ['status', '--porcelain']);
+    expect(status).not.toContain('star*file');
+    expect(status).toContain('starZZfile');
   });
 });

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -1038,17 +1038,31 @@ export async function removeWorktree(
 
 // --- IPC command functions ---
 
-export async function getGitIgnoredDirs(projectRoot: string): Promise<GitIgnoredEntry[]> {
+export async function getSymlinkCandidates(projectRoot: string): Promise<GitIgnoredEntry[]> {
   const { stdout } = await exec(
     'git',
-    ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
+    ['ls-files', '-z', '--others', '--ignored', '--exclude-standard', '--directory'],
     { cwd: projectRoot },
   );
-  return stdout
-    .split('\n')
+  const candidates = stdout
+    .split('\0')
     .filter(Boolean)
     .map((entry) => (entry.endsWith('/') ? entry.slice(0, -1) : entry))
-    .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name))
+    .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name));
+
+  const checked = await Promise.all(
+    candidates.map(async (name) => {
+      try {
+        await exec('git', ['check-ignore', '-q', name], { cwd: projectRoot });
+        return name;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return checked
+    .filter((name): name is string => name !== null)
     .map((name) => ({ name, isDefault: DEFAULT_SYMLINK_CANDIDATES.has(name) }));
 }
 

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -189,16 +189,21 @@ export function isValidSymlinkName(name: string): boolean {
 /** Escape a filename so it matches literally as a gitignore pattern. */
 function escapeGitignoreLiteral(name: string): string {
   const escaped = name.replace(/[\\*?[\]]/g, '\\$&');
-  return escaped.startsWith('!') || escaped.startsWith('#') ? `\\${escaped}` : escaped;
+  const anchored = escaped.startsWith('!') || escaped.startsWith('#') ? `\\${escaped}` : escaped;
+  // Gitignore strips unescaped trailing spaces — escape each so a name like
+  // `foo ` matches itself instead of `foo`.
+  return anchored.replace(/ +$/, (spaces) => '\\ '.repeat(spaces.length));
 }
 
 /** Whether the repo treats paths case-insensitively (macOS default). */
 async function getCoreIgnoreCase(repoRoot: string): Promise<boolean> {
   try {
-    const { stdout } = await exec('git', ['config', '--get', 'core.ignorecase'], {
+    // --bool normalizes yes/on/1 and case variants to true/false; an invalid
+    // value exits non-zero and lands in the catch below.
+    const { stdout } = await exec('git', ['config', '--bool', '--get', 'core.ignorecase'], {
       cwd: repoRoot,
     });
-    return stdout.trim().toLowerCase() === 'true';
+    return stdout.trim() === 'true';
   } catch {
     return false;
   }

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -171,6 +171,48 @@ const seededSandboxExcludes = new Set<string>();
  */
 const SYMLINK_EXCLUDE_HEADER = '# parallel-code: worktree symlinks';
 
+/**
+ * Single name-validation rule shared by the symlink producer
+ * (`getSymlinkCandidates`) and consumer (`createWorktree`) — anything the
+ * dialog can offer must be creatable, and anything creatable must pass here.
+ * `..` is only rejected as a full name: as a substring (`foo..bar`) it is a
+ * legal filename, not a traversal.
+ */
+export function isValidSymlinkName(name: string): boolean {
+  if (name.length === 0 || name === '.' || name === '..') return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  // CR/LF would inject arbitrary rules when written to .git/info/exclude.
+  if (name.includes('\n') || name.includes('\r')) return false;
+  return true;
+}
+
+/** Escape a filename so it matches literally as a gitignore pattern. */
+function escapeGitignoreLiteral(name: string): string {
+  const escaped = name.replace(/[\\*?[\]]/g, '\\$&');
+  return escaped.startsWith('!') || escaped.startsWith('#') ? `\\${escaped}` : escaped;
+}
+
+/** Whether the repo treats paths case-insensitively (macOS default). */
+async function getCoreIgnoreCase(repoRoot: string): Promise<boolean> {
+  try {
+    const { stdout } = await exec('git', ['config', '--get', 'core.ignorecase'], {
+      cwd: repoRoot,
+    });
+    return stdout.trim().toLowerCase() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Reserved/default names are all-lowercase; fold the candidate when the fs is case-insensitive. */
+function isReservedSymlinkName(name: string, ignoreCase: boolean): boolean {
+  return INTERNAL_SYMLINK_EXCLUSIONS.has(ignoreCase ? name.toLowerCase() : name);
+}
+
+function isDefaultSymlinkCandidate(name: string, ignoreCase: boolean): boolean {
+  return DEFAULT_SYMLINK_CANDIDATES.has(ignoreCase ? name.toLowerCase() : name);
+}
+
 // --- Internal helpers ---
 
 async function detectMainBranch(repoRoot: string): Promise<string> {
@@ -799,14 +841,20 @@ export async function createWorktree(
   if (baseBranch) worktreeArgs.push(baseBranch);
   await exec('git', worktreeArgs, { cwd: repoRoot });
 
-  // Symlink selected directories. `.claude` is handled separately below — it
-  // can't be a symlink because Claude Code's bwrap sandbox binds specific
-  // entries inside it, and bwrap refuses to bind-mount at symlink paths.
+  // Symlink selected directories. Reserved names (`.claude`, the `.worktrees`
+  // container, sandbox bind-mount artifacts) are rejected here as a defensive
+  // backstop — the backend does not trust the UI's candidate list. `.claude`
+  // in particular can never be a symlink: Claude Code's bwrap sandbox binds
+  // specific entries inside it and refuses to bind-mount at symlink paths.
+  // Comparisons fold case when the repo's core.ignorecase says the filesystem
+  // is case-insensitive, so `.WORKTREES`/`.CLAUDE` variants can't slip through.
+  const ignoreCase = await getCoreIgnoreCase(repoRoot);
   const createdSymlinks: string[] = [];
   for (const name of symlinkDirs) {
-    if (name === '.claude') continue;
-    // Reject names that could escape the worktree directory
-    if (name.includes('/') || name.includes('\\') || name.includes('..') || name === '.') continue;
+    // Reject names that could escape the worktree directory or inject rules
+    // into .git/info/exclude
+    if (!isValidSymlinkName(name)) continue;
+    if (isReservedSymlinkName(name, ignoreCase)) continue;
     const source = path.join(repoRoot, name);
     const target = path.join(worktreePath, name);
     try {
@@ -936,7 +984,14 @@ export function ensureSandboxExcludes(worktreePath: string): void {
  * duplicating already-present entries.
  */
 export function ensureSymlinkExcludes(worktreePath: string, symlinkNames: string[]): void {
-  if (symlinkNames.length === 0) return;
+  // Names containing CR/LF would inject arbitrary ignore rules — refuse them
+  // outright rather than writing a corrupted exclude file.
+  const validNames = symlinkNames.filter((name) => {
+    if (isValidSymlinkName(name)) return true;
+    console.warn(`Refusing to exclude invalid symlink name: ${JSON.stringify(name)}`);
+    return false;
+  });
+  if (validNames.length === 0) return;
 
   const excludePath = resolveGitInfoExcludePath(worktreePath);
   if (!excludePath) return;
@@ -953,9 +1008,13 @@ export function ensureSymlinkExcludes(worktreePath: string, symlinkNames: string
 
   // Root-anchored, no trailing slash — matches the symlink file itself, not
   // just directories, so `node_modules/` gitignore entries can't sneak through.
-  const toAdd = symlinkNames
-    .map((name) => `/${name}`)
-    .filter((pattern) => !existing.includes(pattern));
+  // Names are escaped to gitignore literals so `*`/`?` in a filename can't act
+  // as wildcards against unrelated files. Dedup is per-line exact match —
+  // substring matching would let an existing `/foobar` swallow a needed `/foo`.
+  const existingLines = new Set(splitContentLines(existing));
+  const toAdd = validNames
+    .map((name) => `/${escapeGitignoreLiteral(name)}`)
+    .filter((pattern) => !existingLines.has(pattern));
 
   if (toAdd.length === 0) return;
 
@@ -1040,31 +1099,35 @@ export async function removeWorktree(
 
 export async function getSymlinkCandidates(projectRoot: string): Promise<GitIgnoredEntry[]> {
   try {
+    const ignoreCase = await getCoreIgnoreCase(projectRoot);
+    // Single git call returning the full candidate set: root-level, ignored,
+    // untracked. The `:(glob)` pathspec magic keeps `*` from crossing `/`, so
+    // `:(glob)*` matches only root-level non-dot entries and `:(glob).*`
+    // catches root-level dotfiles (glob `*` skips a leading dot). Output size
+    // is bounded by the root entry count, nested ignored files inside tracked
+    // directories never appear, and `--others` excludes tracked files — so no
+    // per-candidate check-ignore re-verification is needed.
     const { stdout } = await exec(
       'git',
-      ['ls-files', '-z', '--others', '--ignored', '--exclude-standard', '--directory'],
-      { cwd: projectRoot },
+      [
+        'ls-files',
+        '-z',
+        '--others',
+        '--ignored',
+        '--exclude-standard',
+        '--directory',
+        '--',
+        ':(glob)*',
+        ':(glob).*',
+      ],
+      { cwd: projectRoot, maxBuffer: MAX_BUFFER },
     );
-    const candidates = stdout
+    return stdout
       .split('\0')
       .filter(Boolean)
       .map((entry) => (entry.endsWith('/') ? entry.slice(0, -1) : entry))
-      .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name));
-
-    const checked = await Promise.all(
-      candidates.map(async (name) => {
-        try {
-          await exec('git', ['check-ignore', '-q', name], { cwd: projectRoot });
-          return name;
-        } catch {
-          return null;
-        }
-      }),
-    );
-
-    return checked
-      .filter((name): name is string => name !== null)
-      .map((name) => ({ name, isDefault: DEFAULT_SYMLINK_CANDIDATES.has(name) }));
+      .filter((name) => isValidSymlinkName(name) && !isReservedSymlinkName(name, ignoreCase))
+      .map((name) => ({ name, isDefault: isDefaultSymlinkCandidate(name, ignoreCase) }));
   } catch (err) {
     // Degrade, never fail: a missing git binary or broken repo must not block
     // task creation — the worktree is simply created without symlinks.

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -1039,31 +1039,38 @@ export async function removeWorktree(
 // --- IPC command functions ---
 
 export async function getSymlinkCandidates(projectRoot: string): Promise<GitIgnoredEntry[]> {
-  const { stdout } = await exec(
-    'git',
-    ['ls-files', '-z', '--others', '--ignored', '--exclude-standard', '--directory'],
-    { cwd: projectRoot },
-  );
-  const candidates = stdout
-    .split('\0')
-    .filter(Boolean)
-    .map((entry) => (entry.endsWith('/') ? entry.slice(0, -1) : entry))
-    .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name));
+  try {
+    const { stdout } = await exec(
+      'git',
+      ['ls-files', '-z', '--others', '--ignored', '--exclude-standard', '--directory'],
+      { cwd: projectRoot },
+    );
+    const candidates = stdout
+      .split('\0')
+      .filter(Boolean)
+      .map((entry) => (entry.endsWith('/') ? entry.slice(0, -1) : entry))
+      .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name));
 
-  const checked = await Promise.all(
-    candidates.map(async (name) => {
-      try {
-        await exec('git', ['check-ignore', '-q', name], { cwd: projectRoot });
-        return name;
-      } catch {
-        return null;
-      }
-    }),
-  );
+    const checked = await Promise.all(
+      candidates.map(async (name) => {
+        try {
+          await exec('git', ['check-ignore', '-q', name], { cwd: projectRoot });
+          return name;
+        } catch {
+          return null;
+        }
+      }),
+    );
 
-  return checked
-    .filter((name): name is string => name !== null)
-    .map((name) => ({ name, isDefault: DEFAULT_SYMLINK_CANDIDATES.has(name) }));
+    return checked
+      .filter((name): name is string => name !== null)
+      .map((name) => ({ name, isDefault: DEFAULT_SYMLINK_CANDIDATES.has(name) }));
+  } catch (err) {
+    // Degrade, never fail: a missing git binary or broken repo must not block
+    // task creation — the worktree is simply created without symlinks.
+    console.warn(`Failed to probe symlink candidates in ${projectRoot}:`, err);
+    return [];
+  }
 }
 
 export async function getMainBranch(projectRoot: string): Promise<string> {

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -4,7 +4,11 @@ import fs from 'fs';
 import path from 'path';
 import type { BrowserWindow } from 'electron';
 import { debug as logDebug } from '../log.js';
-import { appendGitInfoExcludeBlockAtPath, resolveGitInfoExcludePath } from './git-exclude.js';
+import {
+  appendGitInfoExcludeBlockAtPath,
+  normalizeExcludeLine,
+  resolveGitInfoExcludePath,
+} from './git-exclude.js';
 import type { ChangedFile, CommitInfo, FileDiffResult, GitIgnoredEntry } from './shared-types.js';
 
 export type { ChangedFile, CommitInfo, FileDiffResult, GitIgnoredEntry } from './shared-types.js';
@@ -1014,9 +1018,11 @@ export function ensureSymlinkExcludes(worktreePath: string, symlinkNames: string
   // Root-anchored, no trailing slash — matches the symlink file itself, not
   // just directories, so `node_modules/` gitignore entries can't sneak through.
   // Names are escaped to gitignore literals so `*`/`?` in a filename can't act
-  // as wildcards against unrelated files. Dedup is per-line exact match —
-  // substring matching would let an existing `/foobar` swallow a needed `/foo`.
-  const existingLines = new Set(splitContentLines(existing));
+  // as wildcards against unrelated files. Dedup compares Git-normalized lines
+  // (CRLF and unescaped trailing ASCII spaces stripped) — exact match would
+  // rewrite a hand-written `/foo ` line, and substring matching would let an
+  // existing `/foobar` swallow a needed `/foo`.
+  const existingLines = new Set(splitContentLines(existing).map(normalizeExcludeLine));
   const toAdd = validNames
     .map((name) => `/${escapeGitignoreLiteral(name)}`)
     .filter((pattern) => !existingLines.has(pattern));
@@ -1031,6 +1037,9 @@ export function ensureSymlinkExcludes(worktreePath: string, symlinkNames: string
     `${header}${toAdd.join('\n')}\n`,
     (err) => console.warn(`Failed to append to ${excludePath}:`, err),
     existing,
+    // `toAdd` already holds exactly the missing lines — the helper's
+    // single-marker recheck must not gate this multi-line block.
+    true,
   );
 }
 

--- a/electron/ipc/git.ts
+++ b/electron/ipc/git.ts
@@ -5,9 +5,9 @@ import path from 'path';
 import type { BrowserWindow } from 'electron';
 import { debug as logDebug } from '../log.js';
 import { appendGitInfoExcludeBlockAtPath, resolveGitInfoExcludePath } from './git-exclude.js';
-import type { ChangedFile, CommitInfo, FileDiffResult } from './shared-types.js';
+import type { ChangedFile, CommitInfo, FileDiffResult, GitIgnoredEntry } from './shared-types.js';
 
-export type { ChangedFile, CommitInfo, FileDiffResult } from './shared-types.js';
+export type { ChangedFile, CommitInfo, FileDiffResult, GitIgnoredEntry } from './shared-types.js';
 
 const _exec = promisify(execFile);
 
@@ -122,6 +122,7 @@ const SYMLINK_CANDIDATES = [
   '.env',
   'node_modules',
 ];
+const DEFAULT_SYMLINK_CANDIDATES = new Set(SYMLINK_CANDIDATES);
 
 /**
  * Entries inside `.claude/` that must NOT be seeded from the main repo's
@@ -155,6 +156,11 @@ const SANDBOX_EXCLUDE_PATTERNS = [
   '/.zprofile',
   '/.zshrc',
 ];
+const INTERNAL_SYMLINK_EXCLUSIONS = new Set([
+  '.claude',
+  '.worktrees',
+  ...SANDBOX_EXCLUDE_PATTERNS.map((pattern) => pattern.slice(1)),
+]);
 const SANDBOX_EXCLUDE_HEADER = '# parallel-code: sandbox bind-mount artifacts';
 const seededSandboxExcludes = new Set<string>();
 
@@ -1032,23 +1038,18 @@ export async function removeWorktree(
 
 // --- IPC command functions ---
 
-export async function getGitIgnoredDirs(projectRoot: string): Promise<string[]> {
-  const results: string[] = [];
-  for (const name of SYMLINK_CANDIDATES) {
-    const dirPath = path.join(projectRoot, name);
-    try {
-      await fs.promises.stat(dirPath); // throws if entry doesn't exist
-    } catch {
-      continue;
-    }
-    try {
-      await exec('git', ['check-ignore', '-q', name], { cwd: projectRoot });
-      results.push(name);
-    } catch {
-      /* not ignored */
-    }
-  }
-  return results;
+export async function getGitIgnoredDirs(projectRoot: string): Promise<GitIgnoredEntry[]> {
+  const { stdout } = await exec(
+    'git',
+    ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
+    { cwd: projectRoot },
+  );
+  return stdout
+    .split('\n')
+    .filter(Boolean)
+    .map((entry) => (entry.endsWith('/') ? entry.slice(0, -1) : entry))
+    .filter((name) => !name.includes('/') && !INTERNAL_SYMLINK_EXCLUSIONS.has(name))
+    .map((name) => ({ name, isDefault: DEFAULT_SYMLINK_CANDIDATES.has(name) }));
 }
 
 export async function getMainBranch(projectRoot: string): Promise<string> {

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -41,7 +41,7 @@ import { startRemoteServer, getMCPLogs, type RemoteProject } from '../remote/ser
 import { atomicWriteFileSync } from '../mcp/atomic.js';
 import { buildMcpLaunchArgs } from '../mcp/agent-args.js';
 import {
-  getGitIgnoredDirs,
+  getSymlinkCandidates,
   getMainBranch,
   getCurrentBranch,
   getChangedFiles,
@@ -591,7 +591,7 @@ export function registerAllHandlers(win: BrowserWindow): void {
     return getFileDiffFromBranch(projectRoot, branchName, args.filePath, optionalBaseBranch(args));
   });
   ipcMain.handle(IPC.GetGitignoredDirs, (_e, args) => {
-    return getGitIgnoredDirs(projectRootArg(args));
+    return getSymlinkCandidates(projectRootArg(args));
   });
   ipcMain.handle(IPC.ListImportableWorktrees, (_e, args) => {
     return listImportableWorktrees(projectRootArg(args));

--- a/electron/ipc/shared-types.ts
+++ b/electron/ipc/shared-types.ts
@@ -27,6 +27,11 @@ export interface CreateTaskResult {
   worktree_path: string;
 }
 
+export interface GitIgnoredEntry {
+  name: string;
+  isDefault: boolean;
+}
+
 export interface ChangedFile {
   path: string;
   lines_added: number;

--- a/electron/ipc/shared-types.ts
+++ b/electron/ipc/shared-types.ts
@@ -27,10 +27,13 @@ export interface CreateTaskResult {
   worktree_path: string;
 }
 
-export interface GitIgnoredEntry {
+export interface SymlinkCandidate {
   name: string;
   isDefault: boolean;
 }
+
+/** Legacy name used by renderer IPC consumers. */
+export type GitIgnoredEntry = SymlinkCandidate;
 
 export interface ChangedFile {
   path: string;

--- a/src/components/NewTaskDialog.test.ts
+++ b/src/components/NewTaskDialog.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { scrollCoordinatorIntoView } from './scrollCoordinatorIntoView';
+import { createSymlinkCandidateState } from '../lib/symlink-candidates';
+import type { GitIgnoredEntry } from '../ipc/types';
 
 interface FakeScrollContainer {
   scrollTop: number;
@@ -42,5 +44,113 @@ describe('scrollCoordinatorIntoView', () => {
     el.scrollTop = 800;
     scrollCoordinatorIntoView(true, el);
     expect(el.scrollTop).toBe(800);
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const PROJECT_A_ENTRIES: GitIgnoredEntry[] = [
+  { name: 'node_modules', isDefault: true },
+  { name: 'dist', isDefault: false },
+];
+const PROJECT_B_ENTRIES: GitIgnoredEntry[] = [{ name: '.env', isDefault: true }];
+
+describe('createSymlinkCandidateState', () => {
+  it('loads candidates and selects the defaults', async () => {
+    const state = createSymlinkCandidateState(async () => PROJECT_A_ENTRIES);
+
+    await state.load('/project-a', true);
+
+    expect(state.dirs()).toEqual(['node_modules', 'dist']);
+    expect([...state.selected()]).toEqual(['node_modules']);
+    expect(state.loading()).toBe(false);
+  });
+
+  it('resets the selection to defaults when reloaded (cancel → reopen)', async () => {
+    const state = createSymlinkCandidateState(async () => PROJECT_A_ENTRIES);
+    await state.load('/project-a', true);
+    state.toggle('dist');
+    expect(state.selected().has('dist')).toBe(true);
+
+    await state.load('/project-a', true);
+
+    expect(state.selected().has('dist')).toBe(false);
+    expect([...state.selected()]).toEqual(['node_modules']);
+  });
+
+  it('clears dirs and selection up front, before the fetch resolves', async () => {
+    const pending = deferred<GitIgnoredEntry[]>();
+    let calls = 0;
+    const state = createSymlinkCandidateState(() =>
+      calls++ === 0 ? Promise.resolve(PROJECT_A_ENTRIES) : pending.promise,
+    );
+    await state.load('/project-a', true);
+    state.toggle('dist');
+
+    const loadPromise = state.load('/project-b', true);
+
+    expect(state.dirs()).toEqual([]);
+    expect(state.selected().size).toBe(0);
+    expect(state.loading()).toBe(true);
+    pending.resolve(PROJECT_B_ENTRIES);
+    await loadPromise;
+    expect(state.dirs()).toEqual(['.env']);
+  });
+
+  it('drops a stale response from a previous project instead of overwriting state', async () => {
+    const slowA = deferred<GitIgnoredEntry[]>();
+    const state = createSymlinkCandidateState((projectRoot) =>
+      projectRoot === '/project-a' ? slowA.promise : Promise.resolve(PROJECT_B_ENTRIES),
+    );
+
+    const staleLoad = state.load('/project-a', true);
+    expect(state.loading()).toBe(true);
+    await state.load('/project-b', true);
+    expect(state.dirs()).toEqual(['.env']);
+
+    // The late project-A response arrives after project B already loaded.
+    slowA.resolve(PROJECT_A_ENTRIES);
+    await staleLoad;
+
+    expect(state.dirs()).toEqual(['.env']);
+    expect([...state.selected()]).toEqual(['.env']);
+    expect(state.loading()).toBe(false);
+  });
+
+  it('clears state without loading for non-git projects or a missing path', async () => {
+    let fetched = 0;
+    const state = createSymlinkCandidateState(async () => {
+      fetched += 1;
+      return PROJECT_A_ENTRIES;
+    });
+    await state.load('/project-a', true);
+
+    await state.load(undefined, true);
+    expect(state.dirs()).toEqual([]);
+    expect(state.selected().size).toBe(0);
+    expect(state.loading()).toBe(false);
+
+    await state.load('/project-a', false);
+    expect(state.dirs()).toEqual([]);
+    expect(fetched).toBe(1);
+  });
+
+  it('drops an in-flight response when invalidated (dialog closed)', async () => {
+    const pending = deferred<GitIgnoredEntry[]>();
+    const state = createSymlinkCandidateState(() => pending.promise);
+
+    const loadPromise = state.load('/project-a', true);
+    state.invalidate();
+    expect(state.loading()).toBe(false);
+    pending.resolve(PROJECT_A_ENTRIES);
+    await loadPromise;
+
+    expect(state.dirs()).toEqual([]);
   });
 });

--- a/src/components/NewTaskDialog.test.ts
+++ b/src/components/NewTaskDialog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { scrollCoordinatorIntoView } from './scrollCoordinatorIntoView';
-import { createSymlinkCandidateState } from '../lib/symlink-candidates';
+import {
+  createSymlinkCandidateState,
+  shouldProbeSymlinkCandidates,
+  symlinkProbeBlocksSubmit,
+} from '../lib/symlink-candidates';
 import type { GitIgnoredEntry } from '../ipc/types';
 
 interface FakeScrollContainer {
@@ -152,5 +156,37 @@ describe('createSymlinkCandidateState', () => {
     await loadPromise;
 
     expect(state.dirs()).toEqual([]);
+  });
+});
+
+describe('symlink probe gating by git isolation mode', () => {
+  // Direct-mode tasks never send symlinkDirs, so probing candidates there
+  // would be a wasted IPC whose pending state must not block submit either.
+  it('probes only for git projects in worktree mode', () => {
+    expect(shouldProbeSymlinkCandidates(true, 'worktree')).toBe(true);
+    expect(shouldProbeSymlinkCandidates(true, 'direct')).toBe(false);
+    expect(shouldProbeSymlinkCandidates(false, 'worktree')).toBe(false);
+    expect(shouldProbeSymlinkCandidates(false, 'direct')).toBe(false);
+  });
+
+  it('blocks submit on a pending probe only in worktree mode', () => {
+    expect(symlinkProbeBlocksSubmit('worktree', true)).toBe(true);
+    expect(symlinkProbeBlocksSubmit('worktree', false)).toBe(false);
+    expect(symlinkProbeBlocksSubmit('direct', true)).toBe(false);
+    expect(symlinkProbeBlocksSubmit('direct', false)).toBe(false);
+  });
+
+  it('a skipped probe never fetches and never enters the loading state', async () => {
+    let fetched = 0;
+    const state = createSymlinkCandidateState(async () => {
+      fetched += 1;
+      return PROJECT_A_ENTRIES;
+    });
+
+    await state.load('/project-a', shouldProbeSymlinkCandidates(true, 'direct'));
+
+    expect(fetched).toBe(0);
+    expect(state.loading()).toBe(false);
+    expect(symlinkProbeBlocksSubmit('direct', state.loading())).toBe(false);
   });
 });

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -49,7 +49,7 @@ import { BranchCombobox } from './BranchCombobox';
 import { ProjectSelect } from './ProjectSelect';
 import { SymlinkDirPicker } from './SymlinkDirPicker';
 import { scrollCoordinatorIntoView } from './scrollCoordinatorIntoView';
-import type { AgentDef } from '../ipc/types';
+import type { AgentDef, GitIgnoredEntry } from '../ipc/types';
 import { DEFAULT_DOCKER_IMAGE, PROJECT_DOCKERFILE_RELATIVE_PATH } from '../lib/docker';
 import {
   clampCoordinatorConcurrentTasks,
@@ -608,10 +608,14 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
 
     void (async () => {
       try {
-        const dirs = await invoke<string[]>(IPC.GetGitignoredDirs, { projectRoot: path });
+        const entries = await invoke<GitIgnoredEntry[]>(IPC.GetGitignoredDirs, {
+          projectRoot: path,
+        });
         if (cancelled) return;
-        setIgnoredDirs(dirs);
-        setSelectedDirs(new Set(dirs)); // all checked by default
+        setIgnoredDirs(entries.map((entry) => entry.name));
+        setSelectedDirs(
+          new Set(entries.filter((entry) => entry.isDefault).map((entry) => entry.name)),
+        );
       } catch {
         if (cancelled) return;
         setIgnoredDirs([]);

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -41,6 +41,7 @@ import {
 import { SegmentedButtons } from './SegmentedButtons';
 import { autoTaskNameFromPrompt, nextDefaultTaskName } from '../lib/clean-task-name';
 import { extractGitHubUrl } from '../lib/github-url';
+import { createSymlinkCandidateState } from '../lib/symlink-candidates';
 import { theme, sectionLabelStyle, bannerStyle } from '../lib/theme';
 import { isMac } from '../lib/platform';
 import { AgentSelector } from './AgentSelector';
@@ -385,8 +386,9 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   const [selectedProjectId, setSelectedProjectId] = createSignal<string | null>(null);
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
-  const [ignoredDirs, setIgnoredDirs] = createSignal<string[]>([]);
-  const [selectedDirs, setSelectedDirs] = createSignal<Set<string>>(new Set());
+  const symlinkCandidates = createSymlinkCandidateState((projectRoot) =>
+    invoke<GitIgnoredEntry[]>(IPC.GetGitignoredDirs, { projectRoot }),
+  );
   const [gitIsolation, setGitIsolation] = createSignal<GitIsolationMode>('worktree');
   const [baseBranch, setBaseBranch] = createSignal('');
   const [branches, setBranches] = createSignal<string[]>([]);
@@ -593,38 +595,22 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
     ),
   );
 
-  // Fetch gitignored dirs when project changes
+  // Fetch gitignored dirs whenever the dialog opens or the project changes.
+  // Reading props.open makes the list reload on every open, so cancelling and
+  // reopening always starts from the default selection — each task's symlink
+  // choices are an explicit opt-in. The candidate state clears itself before
+  // fetching and drops stale responses, so a previous project's checkmarks
+  // can never leak into the next one.
   createEffect(() => {
+    const open = props.open;
     const pid = selectedProjectId();
-    const path = pid ? getProjectPath(pid) : undefined;
+    const path = open && pid ? getProjectPath(pid) : undefined;
     const isGit = pid ? projectIsGitRepo(pid) : true;
-    let cancelled = false;
 
-    if (!path || !isGit) {
-      setIgnoredDirs([]);
-      setSelectedDirs(new Set<string>());
-      return;
-    }
-
-    void (async () => {
-      try {
-        const entries = await invoke<GitIgnoredEntry[]>(IPC.GetGitignoredDirs, {
-          projectRoot: path,
-        });
-        if (cancelled) return;
-        setIgnoredDirs(entries.map((entry) => entry.name));
-        setSelectedDirs(
-          new Set(entries.filter((entry) => entry.isDefault).map((entry) => entry.name)),
-        );
-      } catch {
-        if (cancelled) return;
-        setIgnoredDirs([]);
-        setSelectedDirs(new Set<string>());
-      }
-    })();
+    void symlinkCandidates.load(path, isGit);
 
     onCleanup(() => {
-      cancelled = true;
+      symlinkCandidates.invalidate();
     });
   });
 
@@ -904,6 +890,10 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
       !!selectedProjectId() &&
       !loading() &&
       !branchesLoading() &&
+      // Block submit until the symlink candidate list for THIS project has
+      // resolved — otherwise stale checkmarks could be submitted against a
+      // project whose candidates haven't loaded yet.
+      !symlinkCandidates.loading() &&
       branchOk &&
       !branchPrefixConflict()
     );
@@ -977,7 +967,7 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
         projectId,
         gitIsolation: gitIsolation(),
         baseBranch: baseBranch(),
-        symlinkDirs: gitIsolation() === 'worktree' ? [...selectedDirs()] : undefined,
+        symlinkDirs: gitIsolation() === 'worktree' ? [...symlinkCandidates.selected()] : undefined,
         branchPrefixOverride: gitIsolation() === 'worktree' ? prefix : undefined,
         initialPrompt: isFromDrop ? undefined : p,
         githubUrl: ghUrl,
@@ -1366,16 +1356,11 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
             setMaxConcurrentTasks={setMaxConcurrentTasks}
           />
 
-          <Show when={ignoredDirs().length > 0 && gitIsolation() === 'worktree'}>
+          <Show when={symlinkCandidates.dirs().length > 0 && gitIsolation() === 'worktree'}>
             <SymlinkDirPicker
-              dirs={ignoredDirs()}
-              selectedDirs={selectedDirs()}
-              onToggle={(dir) => {
-                const next = new Set(selectedDirs());
-                if (next.has(dir)) next.delete(dir);
-                else next.add(dir);
-                setSelectedDirs(next);
-              }}
+              dirs={symlinkCandidates.dirs()}
+              selectedDirs={symlinkCandidates.selected()}
+              onToggle={symlinkCandidates.toggle}
             />
           </Show>
 

--- a/src/components/NewTaskDialog.tsx
+++ b/src/components/NewTaskDialog.tsx
@@ -41,7 +41,11 @@ import {
 import { SegmentedButtons } from './SegmentedButtons';
 import { autoTaskNameFromPrompt, nextDefaultTaskName } from '../lib/clean-task-name';
 import { extractGitHubUrl } from '../lib/github-url';
-import { createSymlinkCandidateState } from '../lib/symlink-candidates';
+import {
+  createSymlinkCandidateState,
+  shouldProbeSymlinkCandidates,
+  symlinkProbeBlocksSubmit,
+} from '../lib/symlink-candidates';
 import { theme, sectionLabelStyle, bannerStyle } from '../lib/theme';
 import { isMac } from '../lib/platform';
 import { AgentSelector } from './AgentSelector';
@@ -600,14 +604,17 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
   // reopening always starts from the default selection — each task's symlink
   // choices are an explicit opt-in. The candidate state clears itself before
   // fetching and drops stale responses, so a previous project's checkmarks
-  // can never leak into the next one.
+  // can never leak into the next one. Reading gitIsolation makes the probe
+  // re-run when the mode changes; direct-mode tasks never send symlinkDirs,
+  // so no probe is issued for them at all.
   createEffect(() => {
     const open = props.open;
     const pid = selectedProjectId();
     const path = open && pid ? getProjectPath(pid) : undefined;
     const isGit = pid ? projectIsGitRepo(pid) : true;
+    const shouldProbe = shouldProbeSymlinkCandidates(isGit, gitIsolation());
 
-    void symlinkCandidates.load(path, isGit);
+    void symlinkCandidates.load(path, shouldProbe);
 
     onCleanup(() => {
       symlinkCandidates.invalidate();
@@ -892,8 +899,9 @@ export function NewTaskDialog(props: NewTaskDialogProps) {
       !branchesLoading() &&
       // Block submit until the symlink candidate list for THIS project has
       // resolved — otherwise stale checkmarks could be submitted against a
-      // project whose candidates haven't loaded yet.
-      !symlinkCandidates.loading() &&
+      // project whose candidates haven't loaded yet. Direct-mode submits
+      // never send symlinkDirs, so a pending probe doesn't block them.
+      !symlinkProbeBlocksSubmit(gitIsolation(), symlinkCandidates.loading()) &&
       branchOk &&
       !branchPrefixConflict()
     );

--- a/src/components/SymlinkDirPicker.tsx
+++ b/src/components/SymlinkDirPicker.tsx
@@ -23,6 +23,9 @@ export function SymlinkDirPicker(props: SymlinkDirPickerProps) {
       >
         Symlink into worktree
       </label>
+      <span style={{ 'font-size': '12px', color: theme.fgMuted }}>
+        Checked entries are written to .git/info/exclude and apply to all worktrees.
+      </span>
       <div
         style={{
           display: 'flex',
@@ -32,6 +35,8 @@ export function SymlinkDirPicker(props: SymlinkDirPickerProps) {
           background: theme.bgElevated,
           'border-radius': '6px',
           border: `1px solid ${theme.border}`,
+          'max-height': '160px',
+          'overflow-y': 'auto',
         }}
       >
         <For each={props.dirs}>

--- a/src/components/SymlinkDirPicker.tsx
+++ b/src/components/SymlinkDirPicker.tsx
@@ -3,7 +3,7 @@ import { theme } from '../lib/theme';
 
 interface SymlinkDirPickerProps {
   dirs: string[];
-  selectedDirs: Set<string>;
+  selectedDirs: ReadonlySet<string>;
   onToggle: (dir: string) => void;
 }
 

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -8,6 +8,7 @@ export type {
   CoverageSummary,
   CreateTaskResult,
   FileDiffResult,
+  GitIgnoredEntry,
   ImportableWorktree,
   MergeResult,
   MergeStatus,

--- a/src/lib/symlink-candidates.ts
+++ b/src/lib/symlink-candidates.ts
@@ -1,7 +1,24 @@
 import { createSignal } from 'solid-js';
 import type { GitIgnoredEntry } from '../ipc/types';
+import type { GitIsolationMode } from '../store/types';
 
 export type SymlinkCandidatesFetcher = (projectRoot: string) => Promise<GitIgnoredEntry[]>;
+
+/**
+ * Symlink candidates only matter for worktree tasks — direct-mode submits
+ * never send symlinkDirs, so probing there would be a wasted IPC.
+ */
+export function shouldProbeSymlinkCandidates(
+  isGitRepo: boolean,
+  isolation: GitIsolationMode,
+): boolean {
+  return isGitRepo && isolation === 'worktree';
+}
+
+/** A pending probe only blocks submit when its result would actually be used. */
+export function symlinkProbeBlocksSubmit(isolation: GitIsolationMode, loading: boolean): boolean {
+  return isolation === 'worktree' && loading;
+}
 
 /**
  * Checkbox state for the New Task dialog's symlink-dir picker.

--- a/src/lib/symlink-candidates.ts
+++ b/src/lib/symlink-candidates.ts
@@ -1,0 +1,62 @@
+import { createSignal } from 'solid-js';
+import type { GitIgnoredEntry } from '../ipc/types';
+
+export type SymlinkCandidatesFetcher = (projectRoot: string) => Promise<GitIgnoredEntry[]>;
+
+/**
+ * Checkbox state for the New Task dialog's symlink-dir picker.
+ *
+ * Lifecycle contract:
+ * - Every load clears the previous dirs AND selection up front, so a stale
+ *   project can never submit its checkmarks into a new task.
+ * - A monotonically increasing request id invalidates in-flight responses:
+ *   a late reply from a previous project (or a closed dialog) is dropped
+ *   instead of overwriting the current project's state.
+ * - `loading()` is true from the moment a fetch starts until its fresh
+ *   response lands, so the dialog can block submit on an unresolved list.
+ */
+export function createSymlinkCandidateState(fetchCandidates: SymlinkCandidatesFetcher) {
+  const [dirs, setDirs] = createSignal<string[]>([]);
+  const [selected, setSelected] = createSignal<ReadonlySet<string>>(new Set());
+  const [loading, setLoading] = createSignal(false);
+  let requestId = 0;
+
+  /** Drop any in-flight response (dialog closed, effect re-run). */
+  function invalidate(): void {
+    requestId += 1;
+    setLoading(false);
+  }
+
+  async function load(projectRoot: string | undefined, isGitRepo: boolean): Promise<void> {
+    const id = ++requestId;
+    // Clear before the async fetch — not just when skipping — so nothing
+    // stale is visible (or submittable) while the new list is in flight.
+    setDirs([]);
+    setSelected(new Set<string>());
+    if (!projectRoot || !isGitRepo) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const entries = await fetchCandidates(projectRoot);
+      if (id !== requestId) return; // stale — a newer load owns the state
+      setDirs(entries.map((entry) => entry.name));
+      setSelected(new Set(entries.filter((entry) => entry.isDefault).map((entry) => entry.name)));
+    } catch {
+      // The backend already degrades to [] on git failures; a transport
+      // failure here just leaves the cleared (empty) state in place.
+    } finally {
+      if (id === requestId) setLoading(false);
+    }
+  }
+
+  function toggle(dir: string): void {
+    const next = new Set(selected());
+    if (next.has(dir)) next.delete(dir);
+    else next.add(dir);
+    setSelected(next);
+  }
+
+  return { dirs, selected, loading, load, invalidate, toggle };
+}

--- a/src/store/remoteTaskHandler.ts
+++ b/src/store/remoteTaskHandler.ts
@@ -8,6 +8,7 @@ import { store } from './core';
 import { createTask } from './tasks';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
+import type { GitIgnoredEntry } from '../ipc/types';
 
 interface RendererRequest {
   reqId: string;
@@ -52,9 +53,12 @@ async function handleCreateTask(req: CreateTaskRequest): Promise<void> {
       baseBranch =
         project.defaultBaseBranch ??
         (await invoke<string>(IPC.GetMainBranch, { projectRoot: project.path }));
-      // Match the desktop New Task default: symlink all gitignored dirs (e.g.
-      // node_modules) into the worktree so the agent has a working environment.
-      symlinkDirs = await invoke<string[]>(IPC.GetGitignoredDirs, { projectRoot: project.path });
+      // Match the desktop New Task default without opting remote users into
+      // newly discovered entries that have no confirmation UI.
+      const ignoredEntries = await invoke<GitIgnoredEntry[]>(IPC.GetGitignoredDirs, {
+        projectRoot: project.path,
+      });
+      symlinkDirs = ignoredEntries.filter((entry) => entry.isDefault).map((entry) => entry.name);
     }
 
     const taskId = await createTask({


### PR DESCRIPTION
# Description

Related to #231. This is PR 1 of 2 and only widens candidate enumeration; persisted per-project selection and symlink-vs-copy behavior remain follow-up work.

## Summary

- Discover every fully ignored top-level file or directory with a single `git ls-files --others --ignored --exclude-standard --directory` call.
- Keep the existing eight candidates checked by default while newly discovered entries start unchecked.
- Prevent ignored files nested inside tracked directories from producing ineffective top-level checkboxes.
- Keep remote task creation on the existing safe behavior by passing only default candidates.

## Implementation details

`GetGitignoredDirs` now returns `{ name, isDefault }[]`. The backend owns the default-candidate classification, so the desktop and remote consumers do not duplicate the hardcoded list.

Enumeration preserves Git's path order and filters Parallel Code-managed entries that should never be symlink choices:

- `.claude`, because it is seeded by copying for Claude's bwrap sandbox rather than symlinked.
- `.worktrees`, because it is Parallel Code's managed worktree container. The similarly named `.worktree` remains a valid user entry.
- The nine sandbox bind-mount artifact basenames, such as `.mcp.json` and `.ripgreprc`. Parallel Code writes these patterns to `.git/info/exclude`; without filtering, its own bookkeeping would reappear as phantom picker options.

The New Task dialog renders all returned entries but initially selects only those marked `isDefault`. Remote task creation also uses only the default subset because it has no confirmation UI for newly discovered entries.

## Tests

Added integration coverage against real temporary Git repositories for:

- default and newly discovered ignored directories;
- ignored top-level files;
- ignored files nested under tracked directories;
- non-ignored default candidates;
- `.claude`, `.worktrees`, and all nine sandbox artifact exclusions;
- preservation of the user-owned singular `.worktree` name;
- `createWorktree` symlink creation and nested-name rejection.


## Notes and follow-ups

- `.git/info/exclude` growth remains intentionally one-way and has no new marker-block machinery. Newly discovered entries are unchecked, so new root-anchored exclusions are appended only after explicit desktop opt-in and remain idempotent.
- MCP coordinator and arena retain their existing hardcoded symlink lists. This asymmetry predates this change; unification belongs with PR 2's persisted per-project selection.
- PR 2 will cover persisted symlink-vs-copy selection and will be discussed on #231 before implementation.