### PR TITLE
feat(mobile): edit task notes and fit terminal to width

### DIFF
--- a/electron/ipc/channel-manifest.json
+++ b/electron/ipc/channel-manifest.json
@@ -81,6 +81,8 @@
   "GeneratePairingPin": "generate_pairing_pin",
   "Remote_GetProjectsRequest": "remote_get_projects_request",
   "Remote_CreateTaskRequest": "remote_create_task_request",
+  "Remote_GetNotesRequest": "remote_get_notes_request",
+  "Remote_SetNotesRequest": "remote_set_notes_request",
   "Remote_RendererReply": "remote_renderer_reply",
   "PlanContent": "plan_content",
   "ReadPlanContent": "read_plan_content",

--- a/electron/ipc/channel-manifest.json
+++ b/electron/ipc/channel-manifest.json
@@ -83,6 +83,7 @@
   "Remote_CreateTaskRequest": "remote_create_task_request",
   "Remote_GetNotesRequest": "remote_get_notes_request",
   "Remote_SetNotesRequest": "remote_set_notes_request",
+  "Remote_UpdateTaskStatus": "remote_update_task_status",
   "Remote_RendererReply": "remote_renderer_reply",
   "PlanContent": "plan_content",
   "ReadPlanContent": "read_plan_content",

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -1211,6 +1211,10 @@ export function registerAllHandlers(win: BrowserWindow): void {
     getProjects: () => callRenderer<RemoteProject[]>(IPC.Remote_GetProjectsRequest, {}),
     createTaskFromMobile: (req: { projectId: string; name: string; prompt: string }) =>
       callRenderer<{ taskId: string }>(IPC.Remote_CreateTaskRequest, req),
+    getTaskNotes: (taskId: string) =>
+      callRenderer<{ notes: string }>(IPC.Remote_GetNotesRequest, { taskId }).then((r) => r.notes),
+    setTaskNotes: (taskId: string, notes: string) =>
+      callRenderer<{ ok: boolean }>(IPC.Remote_SetNotesRequest, { taskId, notes }).then(() => {}),
   };
 
   ipcMain.handle(IPC.GeneratePairingPin, () => {

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -15,6 +15,7 @@ import {
   countRunningAgents,
   killAllAgents,
   getAgentMeta,
+  notifyAgentListChanged,
   isDockerAvailable,
   dockerImageExists,
   buildDockerImage,
@@ -38,6 +39,7 @@ import {
 } from './pr-checks.js';
 import { readCoverageSummary } from './coverage.js';
 import { startRemoteServer, getMCPLogs, type RemoteProject } from '../remote/server.js';
+import type { RemoteAttentionState } from '../remote/protocol.js';
 import { atomicWriteFileSync } from '../mcp/atomic.js';
 import { buildMcpLaunchArgs } from '../mcp/agent-args.js';
 import {
@@ -403,6 +405,11 @@ export function registerAllHandlers(win: BrowserWindow): void {
   // --- Remote access state ---
   let remoteServer: Awaited<ReturnType<typeof startRemoteServer>> | null = null;
   const taskNames = new Map<string, string>();
+  // Renderer-derived per-task attention (needs input, working, ready, …), pushed
+  // from the renderer via Remote_UpdateTaskStatus so the mobile overview can show
+  // the same richer status as the desktop. The renderer owns this computation
+  // (it depends on reactive terminal/git/steps state), so main just caches it.
+  const taskAttention = new Map<string, RemoteAttentionState>();
 
   // --- MCP coordinator (lazy — only loaded when coordinator mode is enabled) ---
   type CoordinatorType = import('../mcp/coordinator.js').Coordinator;
@@ -1215,7 +1222,33 @@ export function registerAllHandlers(win: BrowserWindow): void {
       callRenderer<{ notes: string }>(IPC.Remote_GetNotesRequest, { taskId }).then((r) => r.notes),
     setTaskNotes: (taskId: string, notes: string) =>
       callRenderer<{ ok: boolean }>(IPC.Remote_SetNotesRequest, { taskId, notes }).then(() => {}),
+    getTaskAttention: (taskId: string): RemoteAttentionState => taskAttention.get(taskId) ?? 'idle',
   };
+
+  const VALID_ATTENTION: ReadonlySet<RemoteAttentionState> = new Set([
+    'idle',
+    'active',
+    'needs_input',
+    'error',
+    'ready',
+    'review',
+  ]);
+
+  // Renderer pushes the full per-task attention snapshot whenever it changes.
+  // We replace the cache and re-broadcast the agent list so connected phones
+  // update immediately (attention changes don't fire PTY spawn/exit events).
+  ipcMain.handle(IPC.Remote_UpdateTaskStatus, (_e, args: { statuses?: Record<string, string> }) => {
+    const statuses = args?.statuses;
+    if (!statuses || typeof statuses !== 'object') return;
+    taskAttention.clear();
+    for (const [taskId, value] of Object.entries(statuses)) {
+      if (typeof taskId === 'string' && VALID_ATTENTION.has(value as RemoteAttentionState)) {
+        taskAttention.set(taskId, value as RemoteAttentionState);
+      }
+    }
+    // Only bother rebroadcasting when a phone could be listening.
+    if (remoteServer) notifyAgentListChanged();
+  });
 
   ipcMain.handle(IPC.GeneratePairingPin, () => {
     if (!remoteServer) throw new Error('Remote server is not running');

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -85,6 +85,8 @@ const ALLOWED_CHANNELS = new Set([
   'generate_pairing_pin',
   'remote_get_projects_request',
   'remote_create_task_request',
+  'remote_get_notes_request',
+  'remote_set_notes_request',
   'remote_renderer_reply',
   'plan_content',
   'read_plan_content',

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -87,6 +87,7 @@ const ALLOWED_CHANNELS = new Set([
   'remote_create_task_request',
   'remote_get_notes_request',
   'remote_set_notes_request',
+  'remote_update_task_status',
   'remote_renderer_reply',
   'plan_content',
   'read_plan_content',

--- a/electron/remote/notes-route.test.ts
+++ b/electron/remote/notes-route.test.ts
@@ -1,0 +1,226 @@
+// HTTP access control + validation for the mobile task-notes route
+// (GET/PUT /api/mobile/notes/:taskId). These guard security-relevant
+// regressions: a malformed percent-escape once crashed the main process, and
+// a prototype-chain taskId could pollute Object.prototype via the store.
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import http from 'node:http';
+
+vi.mock('../ipc/pty.js', () => ({
+  writeToAgent: vi.fn(),
+  resizeAgent: vi.fn(),
+  killAgent: vi.fn(),
+  subscribeToAgent: vi.fn(),
+  unsubscribeFromAgent: vi.fn(),
+  getAgentScrollback: vi.fn(() => null),
+  getActiveAgentIds: vi.fn(() => []),
+  getAgentMeta: vi.fn(() => null),
+  getAgentCols: vi.fn(() => 80),
+  onPtyEvent: vi.fn(() => vi.fn()),
+}));
+
+const { startRemoteServer } = await import('./server.js');
+
+type StartOpts = Parameters<typeof startRemoteServer>[0];
+
+let port = 0;
+let mobileToken = '';
+let coordinatorToken = '';
+let subtaskToken = '';
+let stop: () => Promise<void>;
+let getTaskNotes: Mock<(taskId: string) => Promise<string>>;
+let setTaskNotes: Mock<(taskId: string, notes: string) => Promise<void>>;
+
+async function start(extra: Partial<StartOpts> = {}): Promise<void> {
+  const srv = await startRemoteServer({
+    port: 0,
+    host: '127.0.0.1',
+    staticDir: '/nonexistent',
+    getTaskName: (id) => id,
+    getAgentStatus: () => ({ status: 'exited', exitCode: null, lastLine: '' }),
+    getCoordinator: () => null,
+    getTaskNotes,
+    setTaskNotes,
+    ...extra,
+  });
+  port = srv.port;
+  mobileToken = srv.mobileToken;
+  coordinatorToken = srv.token;
+  subtaskToken = srv.subtaskToken;
+  stop = srv.stop;
+}
+
+beforeEach(() => {
+  getTaskNotes = vi.fn(async (_taskId: string) => 'stored notes');
+  setTaskNotes = vi.fn(async (_taskId: string, _notes: string) => {});
+});
+
+afterEach(async () => {
+  await stop();
+});
+
+interface Res {
+  status: number;
+  json: unknown;
+}
+
+/** Raw HTTP request so the exact (possibly malformed) path reaches the server. */
+function request(
+  method: string,
+  path: string,
+  opts: { token?: string; body?: unknown } = {},
+): Promise<Res> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+    let payload: string | undefined;
+    if (opts.body !== undefined) {
+      payload = typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body);
+      headers['Content-Type'] = 'application/json';
+    }
+    const req = http.request({ host: '127.0.0.1', port, method, path, headers }, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        let json: unknown = undefined;
+        try {
+          json = data ? JSON.parse(data) : undefined;
+        } catch {
+          json = data;
+        }
+        resolve({ status: res.statusCode ?? 0, json });
+      });
+    });
+    req.on('error', reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+describe('GET /api/mobile/notes/:taskId', () => {
+  beforeEach(() => start());
+
+  it('returns 401 without a token', async () => {
+    const res = await request('GET', '/api/mobile/notes/task-1');
+    expect(res.status).toBe(401);
+    expect(getTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a coordinator token', async () => {
+    const res = await request('GET', '/api/mobile/notes/task-1', { token: coordinatorToken });
+    expect(res.status).toBe(403);
+    expect(getTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a subtask token', async () => {
+    const res = await request('GET', '/api/mobile/notes/task-1', { token: subtaskToken });
+    expect(res.status).toBe(403);
+    expect(getTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('returns the notes for a mobile token', async () => {
+    const res = await request('GET', '/api/mobile/notes/task-1', { token: mobileToken });
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ notes: 'stored notes' });
+    expect(getTaskNotes).toHaveBeenCalledWith('task-1');
+  });
+
+  it('decodes a percent-encoded task id', async () => {
+    const res = await request('GET', '/api/mobile/notes/task%2F1', { token: mobileToken });
+    expect(res.status).toBe(200);
+    expect(getTaskNotes).toHaveBeenCalledWith('task/1');
+  });
+});
+
+describe('GET/PUT notes — malformed and dangerous task ids', () => {
+  beforeEach(() => start());
+
+  it('returns 400 (not a crash) on a malformed percent-escape', async () => {
+    const res = await request('GET', '/api/mobile/notes/%', { token: mobileToken });
+    expect(res.status).toBe(400);
+    expect(getTaskNotes).not.toHaveBeenCalled();
+    // The server is still alive after the malformed request.
+    const ok = await request('GET', '/api/mobile/notes/task-1', { token: mobileToken });
+    expect(ok.status).toBe(200);
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects the prototype-chain task id %s with 400',
+    async (key) => {
+      const res = await request('PUT', `/api/mobile/notes/${key}`, {
+        token: mobileToken,
+        body: { notes: 'pwned' },
+      });
+      expect(res.status).toBe(400);
+      expect(setTaskNotes).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('PUT /api/mobile/notes/:taskId', () => {
+  beforeEach(() => start());
+
+  it('saves notes for a mobile token', async () => {
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: mobileToken,
+      body: { notes: 'hello world' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ ok: true });
+    expect(setTaskNotes).toHaveBeenCalledWith('task-1', 'hello world');
+  });
+
+  it('returns 403 for a coordinator token', async () => {
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: coordinatorToken,
+      body: { notes: 'x' },
+    });
+    expect(res.status).toBe(403);
+    expect(setTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string notes body with 400', async () => {
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: mobileToken,
+      body: { notes: 123 },
+    });
+    expect(res.status).toBe(400);
+    expect(setTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('rejects notes larger than 100 KB with 400', async () => {
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: mobileToken,
+      body: { notes: 'x'.repeat(100 * 1024 + 1) },
+    });
+    expect(res.status).toBe(400);
+    expect(setTaskNotes).not.toHaveBeenCalled();
+  });
+
+  it('accepts multi-line notes up to the limit', async () => {
+    const notes = 'line\n'.repeat(1000);
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: mobileToken,
+      body: { notes },
+    });
+    expect(res.status).toBe(200);
+    expect(setTaskNotes).toHaveBeenCalledWith('task-1', notes);
+  });
+});
+
+describe('notes route without a renderer bridge', () => {
+  beforeEach(() => start({ getTaskNotes: undefined, setTaskNotes: undefined }));
+
+  it('returns 503 for GET when notes are unavailable', async () => {
+    const res = await request('GET', '/api/mobile/notes/task-1', { token: mobileToken });
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 for PUT when notes are unavailable', async () => {
+    const res = await request('PUT', '/api/mobile/notes/task-1', {
+      token: mobileToken,
+      body: { notes: 'x' },
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/electron/remote/protocol.ts
+++ b/electron/remote/protocol.ts
@@ -1,3 +1,11 @@
+/**
+ * Task attention state, mirrored from the desktop's TaskAttentionState so the
+ * mobile overview can show the same richer status ("needs input", "working",
+ * etc.) rather than just running/exited. Kept as a string union at this shared
+ * boundary; the renderer maps its TaskAttentionState onto these values.
+ */
+export type RemoteAttentionState = 'idle' | 'active' | 'needs_input' | 'error' | 'ready' | 'review';
+
 /** Agent summary sent in the agents list. */
 export interface RemoteAgent {
   agentId: string;
@@ -6,6 +14,8 @@ export interface RemoteAgent {
   status: 'running' | 'exited';
   exitCode: number | null;
   lastLine: string;
+  /** Richer, renderer-derived task status. Defaults to 'idle' when unknown. */
+  attention: RemoteAttentionState;
 }
 
 // --- Server -> Client messages ---

--- a/electron/remote/server.ts
+++ b/electron/remote/server.ts
@@ -676,7 +676,9 @@ export function startRemoteServer(opts: {
   /** Renderer-derived task attention state (needs input, working, ready, …). */
   getTaskAttention?: (taskId: string) => RemoteAttentionState;
 }): Promise<RemoteServer> {
-  // Fall back to 'idle' when the caller doesn't wire attention (e.g. MCP-only start).
+  // Defensive default for the optional signature: every real caller wires
+  // attention via mobileTaskBridge, so 'idle' is only used if a future caller
+  // omits it.
   const getTaskAttention: (taskId: string) => RemoteAttentionState =
     opts.getTaskAttention ?? (() => 'idle');
   const token = randomBytes(24).toString('base64url');
@@ -856,6 +858,12 @@ export function startRemoteServer(opts: {
         } catch {
           return jsonEnd(400, { error: 'invalid task id' });
         }
+        // Reject prototype-chain keys at the boundary. The renderer also guards
+        // with Object.hasOwn, but blocking here keeps a mobile-token request
+        // from ever reaching a setStore path with a dangerous key.
+        if (taskId === '__proto__' || taskId === 'constructor' || taskId === 'prototype') {
+          return jsonEnd(400, { error: 'invalid task id' });
+        }
 
         if (req.method === 'GET') {
           if (!opts.getTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
@@ -869,10 +877,12 @@ export function startRemoteServer(opts: {
         if (req.method === 'PUT') {
           const setTaskNotes = opts.setTaskNotes;
           if (!setTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
-          // Cap the body above MAX_NOTES_BYTES so the byte check below is the
-          // effective limit (readJsonBody's 64 KB default would otherwise reject
-          // valid large notes first with a generic "Body too large").
-          readJsonBody(req, MAX_NOTES_BYTES + 4096)
+          // Cap the body generously above MAX_NOTES_BYTES so the precise byte
+          // check below is the effective limit (readJsonBody's 64 KB default
+          // would otherwise reject valid large notes with a generic "Body too
+          // large"). The 2x headroom covers JSON escaping of quotes/newlines in
+          // a full-size note; the exact limit is enforced on the decoded string.
+          readJsonBody(req, MAX_NOTES_BYTES * 2 + 4096)
             .then((body) => {
               if (typeof body.notes !== 'string')
                 return jsonEnd(400, { error: 'notes must be a string' });

--- a/electron/remote/server.ts
+++ b/electron/remote/server.ts
@@ -847,7 +847,15 @@ export function startRemoteServer(opts: {
       if (notesMatch) {
         if (tokenClass !== 'mobile' && tokenClass !== 'paired')
           return jsonEnd(403, { error: 'forbidden' });
-        const taskId = decodeURIComponent(notesMatch[1]);
+        // decodeURIComponent throws URIError on a malformed escape (e.g. "%").
+        // This handler has no outer try/catch, so an unguarded throw here would
+        // take down the main process — reject with 400 instead.
+        let taskId: string;
+        try {
+          taskId = decodeURIComponent(notesMatch[1]);
+        } catch {
+          return jsonEnd(400, { error: 'invalid task id' });
+        }
 
         if (req.method === 'GET') {
           if (!opts.getTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
@@ -861,7 +869,10 @@ export function startRemoteServer(opts: {
         if (req.method === 'PUT') {
           const setTaskNotes = opts.setTaskNotes;
           if (!setTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
-          readJsonBody(req)
+          // Cap the body above MAX_NOTES_BYTES so the byte check below is the
+          // effective limit (readJsonBody's 64 KB default would otherwise reject
+          // valid large notes first with a generic "Body too large").
+          readJsonBody(req, MAX_NOTES_BYTES + 4096)
             .then((body) => {
               if (typeof body.notes !== 'string')
                 return jsonEnd(400, { error: 'notes must be a string' });

--- a/electron/remote/server.ts
+++ b/electron/remote/server.ts
@@ -18,7 +18,12 @@ import {
   getAgentCols,
   onPtyEvent,
 } from '../ipc/pty.js';
-import { parseClientMessage, type ServerMessage, type RemoteAgent } from './protocol.js';
+import {
+  parseClientMessage,
+  type ServerMessage,
+  type RemoteAgent,
+  type RemoteAttentionState,
+} from './protocol.js';
 import type { Coordinator } from '../mcp/coordinator.js';
 import { validateBranchName } from '../mcp/validation.js';
 import type { ApiTaskDetail, LandSelfInput, SubtaskVerification } from '../mcp/types.js';
@@ -211,6 +216,7 @@ function buildAgentList(
     exitCode: number | null;
     lastLine: string;
   },
+  getTaskAttention: (taskId: string) => RemoteAttentionState,
 ): RemoteAgent[] {
   const byTask = new Map<string, RemoteAgent>();
   for (const agentId of getActiveAgentIds()) {
@@ -226,6 +232,7 @@ function buildAgentList(
       status: info.status,
       exitCode: info.exitCode,
       lastLine: info.lastLine,
+      attention: getTaskAttention(meta.taskId),
     };
     // Prefer running agents over exited ones for the same task
     const existing = byTask.get(meta.taskId);
@@ -666,7 +673,12 @@ export function startRemoteServer(opts: {
   getTaskNotes?: (taskId: string) => Promise<string>;
   /** Persist a task's notes (renderer-backed). */
   setTaskNotes?: (taskId: string, notes: string) => Promise<void>;
+  /** Renderer-derived task attention state (needs input, working, ready, …). */
+  getTaskAttention?: (taskId: string) => RemoteAttentionState;
 }): Promise<RemoteServer> {
+  // Fall back to 'idle' when the caller doesn't wire attention (e.g. MCP-only start).
+  const getTaskAttention: (taskId: string) => RemoteAttentionState =
+    opts.getTaskAttention ?? (() => 'idle');
   const token = randomBytes(24).toString('base64url');
   const subtaskToken = randomBytes(24).toString('base64url');
   const mobileToken = randomBytes(24).toString('base64url');
@@ -894,7 +906,7 @@ export function startRemoteServer(opts: {
       }
 
       if (url.pathname === '/api/agents' && req.method === 'GET') {
-        const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+        const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
         res.writeHead(200, { ...SECURITY_HEADERS, 'Content-Type': 'application/json' });
         res.end(JSON.stringify(list));
         return;
@@ -1088,12 +1100,12 @@ export function startRemoteServer(opts: {
   }
 
   const unsubSpawn = onPtyEvent('spawn', () => {
-    const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+    const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
     broadcast({ type: 'agents', list });
   });
 
   const unsubListChanged = onPtyEvent('list-changed', () => {
-    const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+    const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
     broadcast({ type: 'agents', list });
   });
 
@@ -1105,7 +1117,7 @@ export function startRemoteServer(opts: {
       clientSubs.get(client)?.delete(agentId);
     }
     setTimeout(() => {
-      const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+      const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
       broadcast({ type: 'agents', list });
     }, 100);
   });
@@ -1118,7 +1130,7 @@ export function startRemoteServer(opts: {
     if (classifyToken(req) === 'coordinator') {
       authenticatedClients.add(ws);
       clientTokenTypes.set(ws, 'coordinator');
-      const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+      const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
       ws.send(JSON.stringify({ type: 'agents', list } satisfies ServerMessage));
     } else {
       // Close unauthenticated connections after 5 seconds
@@ -1143,7 +1155,7 @@ export function startRemoteServer(opts: {
           clientTokenTypes.set(ws, tokenType);
           const timer = authTimers.get(ws);
           if (timer) clearTimeout(timer);
-          const list = buildAgentList(opts.getTaskName, opts.getAgentStatus);
+          const list = buildAgentList(opts.getTaskName, opts.getAgentStatus, getTaskAttention);
           ws.send(JSON.stringify({ type: 'agents', list } satisfies ServerMessage));
         } else {
           ws.close(4001, 'Unauthorized');

--- a/electron/remote/server.ts
+++ b/electron/remote/server.ts
@@ -33,6 +33,7 @@ export interface MCPLogEntry {
 const MAX_LOG_ENTRIES = 200;
 const REST_COORDINATOR_SENTINEL = 'api';
 const MAX_REST_PROMPT_BYTES = 16 * 1024;
+const MAX_NOTES_BYTES = 100 * 1024;
 // Device pairing: a mobile client proves it can see the desktop by entering a
 // short-lived PIN, which elevates it to a "paired" token allowed to create tasks.
 const PAIRING_PIN_TTL_MS = 5 * 60_000;
@@ -661,6 +662,10 @@ export function startRemoteServer(opts: {
     name: string;
     prompt: string;
   }) => Promise<{ taskId: string }>;
+  /** Read a task's notes (renderer-backed). */
+  getTaskNotes?: (taskId: string) => Promise<string>;
+  /** Persist a task's notes (renderer-backed). */
+  setTaskNotes?: (taskId: string, notes: string) => Promise<void>;
 }): Promise<RemoteServer> {
   const token = randomBytes(24).toString('base64url');
   const subtaskToken = randomBytes(24).toString('base64url');
@@ -813,6 +818,45 @@ export function startRemoteServer(opts: {
                 return jsonEnd(400, { error: 'projectId must be a non-empty string' });
               createTask({ projectId, name, prompt })
                 .then((r) => jsonEnd(201, { taskId: r.taskId }))
+                .catch((err) => jsonEnd(500, { error: String(err) }));
+            })
+            .catch(() => jsonEnd(400, { error: 'bad request' }));
+          return;
+        }
+
+        return jsonEnd(405, { error: 'method not allowed' });
+      }
+
+      // --- Task notes (mobile + paired) ---
+      // Read/write the notes textarea shown on the desktop task panel. Available
+      // to the read-only mobile token too: editing notes is low-risk and mirrors
+      // the "interact with your terminals" capability the mobile token already has.
+      const notesMatch = url.pathname.match(/^\/api\/mobile\/notes\/([^/]+)$/);
+      if (notesMatch) {
+        if (tokenClass !== 'mobile' && tokenClass !== 'paired')
+          return jsonEnd(403, { error: 'forbidden' });
+        const taskId = decodeURIComponent(notesMatch[1]);
+
+        if (req.method === 'GET') {
+          if (!opts.getTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
+          opts
+            .getTaskNotes(taskId)
+            .then((notes) => jsonEnd(200, { notes }))
+            .catch((err) => jsonEnd(500, { error: String(err) }));
+          return;
+        }
+
+        if (req.method === 'PUT') {
+          const setTaskNotes = opts.setTaskNotes;
+          if (!setTaskNotes) return jsonEnd(503, { error: 'notes unavailable' });
+          readJsonBody(req)
+            .then((body) => {
+              if (typeof body.notes !== 'string')
+                return jsonEnd(400, { error: 'notes must be a string' });
+              if (Buffer.byteLength(body.notes, 'utf8') > MAX_NOTES_BYTES)
+                return jsonEnd(400, { error: `notes must be ${MAX_NOTES_BYTES} bytes or fewer` });
+              setTaskNotes(taskId, body.notes)
+                .then(() => jsonEnd(200, { ok: true }))
                 .catch((err) => jsonEnd(500, { error: String(err) }));
             })
             .catch(() => jsonEnd(400, { error: 'bad request' }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import { startDesktopNotificationWatcher } from './store/desktopNotifications';
 import { startPrChecksSubscription } from './store/pr-checks';
 import { startUpdateSubscription } from './store/updates';
 import { startRemoteTaskHandlers } from './store/remoteTaskHandler';
+import { startRemoteStatusSync } from './store/remoteStatusSync';
 
 const MIN_WINDOW_DIMENSION = 100;
 
@@ -525,6 +526,7 @@ function App() {
     const stopPrChecksSubscription = startPrChecksSubscription();
     const stopUpdateSubscription = startUpdateSubscription();
     const stopRemoteTaskHandlers = startRemoteTaskHandlers();
+    const stopRemoteStatusSync = startRemoteStatusSync();
 
     // Listen for plan content pushed from backend plan watcher
     const offPlanContent = window.electron.ipcRenderer.on(IPC.PlanContent, (data: unknown) => {
@@ -722,6 +724,7 @@ function App() {
       stopPrChecksSubscription();
       stopUpdateSubscription();
       stopRemoteTaskHandlers();
+      stopRemoteStatusSync();
       offPlanContent();
       offStepsContent();
       unlistenFocusChanged?.();

--- a/src/remote/AgentDetail.tsx
+++ b/src/remote/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { onMount, onCleanup, createSignal, Show, For } from 'solid-js';
+import { onMount, onCleanup, createSignal, createEffect, Show, For } from 'solid-js';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { TERMINAL_SCROLLBACK_LINES, base64ToUint8Array } from '../lib/terminalConstants';
@@ -127,10 +127,14 @@ export function AgentDetail(props: AgentDetailProps) {
     }
   }
 
-  async function openNotes(): Promise<void> {
+  function openNotes(): void {
+    // Just switch tabs; the effect below loads the notes. This also covers the
+    // case where taskId() is momentarily undefined (e.g. right after a WS
+    // reconnect) — the effect re-runs and loads once the agent reappears.
     setView('notes');
-    const id = taskId();
-    if (!id) return;
+  }
+
+  async function loadNotes(id: string): Promise<void> {
     setNotesLoading(true);
     setNotesError(null);
     try {
@@ -143,6 +147,16 @@ export function AgentDetail(props: AgentDetailProps) {
       setNotesLoading(false);
     }
   }
+
+  // Load notes when the Notes tab is showing and a task id is available. Guarded
+  // by notesDirty so reopening the tab never discards unsaved local edits, and
+  // it retries automatically if taskId resolves after the tab was opened.
+  createEffect(() => {
+    if (view() !== 'notes') return;
+    const id = taskId();
+    if (!id || notesDirty()) return;
+    void loadNotes(id);
+  });
 
   async function handleSaveNotes(): Promise<void> {
     const id = taskId();

--- a/src/remote/AgentDetail.tsx
+++ b/src/remote/AgentDetail.tsx
@@ -102,15 +102,15 @@ export function AgentDetail(props: AgentDetailProps) {
     }
   }
 
-  // Re-fit the terminal to the container. In auto mode the font tracks the
-  // desktop column count; in manual mode the columns track the chosen font.
+  // Re-fit the terminal to the container. The rendered column count always
+  // stays pinned to the desktop PTY width (`serverCols`) since the mobile
+  // client can't resize the PTY and the output is formatted for that width;
+  // only the font size changes. In auto mode autoFitFont picks the font that
+  // makes serverCols fill the width; in manual mode it no-ops and keeps the
+  // user's chosen font (so a larger font simply shows fewer visible columns).
   function refit(): void {
     if (!term) return;
-    if (manualFont()) {
-      fitAddon?.fit();
-      return;
-    }
-    autoFitFont();
+    autoFitFont(); // no-op while manualFont() is true
     fitAddon?.fit();
     const cols = serverCols();
     if (cols > 0) term.resize(cols, term.rows);
@@ -123,7 +123,7 @@ export function AgentDetail(props: AgentDetailProps) {
     setTermFontSize(next);
     if (term) {
       term.options.fontSize = next;
-      fitAddon?.fit();
+      refit();
     }
   }
 
@@ -279,10 +279,15 @@ export function AgentDetail(props: AgentDetailProps) {
       termContainer.removeEventListener('touchmove', onTouchMove);
       termContainer.removeEventListener('touchend', onTouchEnd);
       observer.disconnect();
+      // Cancel any queued refit so it can't run against the disposed terminal.
+      cancelAnimationFrame(resizeRaf);
       unsubscribeAgent(props.agentId);
       cleanupScrollback();
       cleanupOutput();
       term?.dispose();
+      // Null it so a stray rAF (e.g. the tab-switch refit) short-circuits in
+      // refit()/handlers instead of touching a disposed xterm instance.
+      term = undefined;
     });
   });
 

--- a/src/remote/AgentDetail.tsx
+++ b/src/remote/AgentDetail.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { TERMINAL_SCROLLBACK_LINES, base64ToUint8Array } from '../lib/terminalConstants';
 import { createTerminalHttpLinkHandler } from '../lib/terminalLinks';
 import { fetchNotes, saveNotes } from './api';
+import { agentStatusDisplay } from './attention';
 import {
   subscribeAgent,
   unsubscribeAgent,
@@ -365,14 +366,35 @@ export function AgentDetail(props: AgentDetailProps) {
         >
           {props.taskName}
         </span>
-        <div
-          style={{
-            width: '8px',
-            height: '8px',
-            'border-radius': '50%',
-            background: agentInfo()?.status === 'running' ? '#2fd198' : '#678197',
+        <Show when={agentInfo()} fallback={<div style={{ width: '8px' }} />}>
+          {(info) => {
+            const display = () => agentStatusDisplay(info());
+            return (
+              <div
+                style={{ display: 'flex', 'align-items': 'center', gap: '6px', 'flex-shrink': '0' }}
+              >
+                <span
+                  style={{
+                    'font-size': '12px',
+                    'font-weight': display().glow ? '600' : '400',
+                    color: display().color,
+                  }}
+                >
+                  {display().label}
+                </span>
+                <div
+                  style={{
+                    width: '8px',
+                    height: '8px',
+                    'border-radius': '50%',
+                    background: display().color,
+                    'box-shadow': display().glow ? `0 0 0 3px ${display().color}33` : 'none',
+                  }}
+                />
+              </div>
+            );
           }}
-        />
+        </Show>
       </div>
 
       {/* Terminal / Notes tabs */}

--- a/src/remote/AgentDetail.tsx
+++ b/src/remote/AgentDetail.tsx
@@ -3,6 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { TERMINAL_SCROLLBACK_LINES, base64ToUint8Array } from '../lib/terminalConstants';
 import { createTerminalHttpLinkHandler } from '../lib/terminalLinks';
+import { fetchNotes, saveNotes } from './api';
 import {
   subscribeAgent,
   unsubscribeAgent,
@@ -20,6 +21,22 @@ const KEYS: Record<number, string> = {};
 });
 function key(c: number): string {
   return KEYS[c];
+}
+
+const TERM_FONT_FAMILY = "'JetBrains Mono', 'Courier New', monospace";
+
+// Measure the average monospace advance width per 1px of font-size. Used to pick
+// a font size that makes the desktop's column count exactly fill the phone's
+// width, so the terminal uses all available horizontal space instead of leaving
+// a gap (desktop narrower than phone) or overflowing (desktop wider).
+let measureCanvas: HTMLCanvasElement | undefined;
+function charWidthPerPx(): number {
+  if (!measureCanvas) measureCanvas = document.createElement('canvas');
+  const ctx = measureCanvas.getContext('2d');
+  if (!ctx) return 0.6;
+  ctx.font = `100px ${TERM_FONT_FAMILY}`;
+  // Average over a run of glyphs to smooth out sub-pixel rounding.
+  return ctx.measureText('MMMMMMMMMM').width / 10 / 100;
 }
 
 interface AgentDetailProps {
@@ -43,11 +60,105 @@ export function AgentDetail(props: AgentDetailProps) {
   const [inputText, setInputText] = createSignal('');
   const [atBottom, setAtBottom] = createSignal(true);
   const [termFontSize, setTermFontSize] = createSignal(10);
+  // Desktop PTY column count (from scrollback). The mobile client can't resize
+  // the PTY, so the terminal must adapt its font to this width, not vice versa.
+  const [serverCols, setServerCols] = createSignal(0);
+  // Once the user picks a font with A-/A+, stop auto-fitting so their choice sticks.
+  const [manualFont, setManualFont] = createSignal(false);
+
+  // Notes editing
+  const [view, setView] = createSignal<'terminal' | 'notes'>('terminal');
+  const [notesText, setNotesText] = createSignal('');
+  const [notesLoading, setNotesLoading] = createSignal(false);
+  const [notesSaving, setNotesSaving] = createSignal(false);
+  const [notesError, setNotesError] = createSignal<string | null>(null);
+  const [notesDirty, setNotesDirty] = createSignal(false);
+  const [notesSaved, setNotesSaved] = createSignal(false);
 
   const MIN_FONT = 6;
   const MAX_FONT = 24;
 
   const agentInfo = () => agents().find((a) => a.agentId === props.agentId);
+  const taskId = () => agentInfo()?.taskId;
+
+  // Pick the largest font (within bounds) that fits `serverCols` columns into the
+  // available width, then render exactly that many columns — filling the width.
+  function autoFitFont(): void {
+    if (!term || !termContainer || manualFont()) return;
+    const cols = serverCols();
+    if (cols <= 0) return;
+    const cs = getComputedStyle(termContainer);
+    const padX = parseFloat(cs.paddingLeft || '0') + parseFloat(cs.paddingRight || '0');
+    // Small safety margin so metric rounding never overflows into a wrapped line.
+    const avail = termContainer.clientWidth - padX - 4;
+    const perChar = charWidthPerPx();
+    if (avail <= 0 || perChar <= 0) return;
+    let fs = Math.floor(avail / (cols * perChar));
+    fs = Math.max(MIN_FONT, Math.min(MAX_FONT, fs));
+    if (term.options.fontSize !== fs) {
+      term.options.fontSize = fs;
+      setTermFontSize(fs);
+    }
+  }
+
+  // Re-fit the terminal to the container. In auto mode the font tracks the
+  // desktop column count; in manual mode the columns track the chosen font.
+  function refit(): void {
+    if (!term) return;
+    if (manualFont()) {
+      fitAddon?.fit();
+      return;
+    }
+    autoFitFont();
+    fitAddon?.fit();
+    const cols = serverCols();
+    if (cols > 0) term.resize(cols, term.rows);
+  }
+
+  function changeFont(delta: number): void {
+    const next = Math.max(MIN_FONT, Math.min(MAX_FONT, termFontSize() + delta));
+    if (next === termFontSize()) return;
+    setManualFont(true);
+    setTermFontSize(next);
+    if (term) {
+      term.options.fontSize = next;
+      fitAddon?.fit();
+    }
+  }
+
+  async function openNotes(): Promise<void> {
+    setView('notes');
+    const id = taskId();
+    if (!id) return;
+    setNotesLoading(true);
+    setNotesError(null);
+    try {
+      const n = await fetchNotes(id);
+      // Don't clobber unsaved local edits if the user reopens the tab.
+      if (!notesDirty()) setNotesText(n);
+    } catch (e) {
+      setNotesError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setNotesLoading(false);
+    }
+  }
+
+  async function handleSaveNotes(): Promise<void> {
+    const id = taskId();
+    if (!id || notesSaving()) return;
+    setNotesSaving(true);
+    setNotesError(null);
+    try {
+      await saveNotes(id, notesText());
+      setNotesDirty(false);
+      setNotesSaved(true);
+      setTimeout(() => setNotesSaved(false), 1500);
+    } catch (e) {
+      setNotesError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setNotesSaving(false);
+    }
+  }
 
   onMount(() => {
     if (!termContainer) return;
@@ -101,10 +212,12 @@ export function AgentDetail(props: AgentDetailProps) {
       setAtBottom(isBottom);
     });
 
+    // eslint-disable-next-line solid/reactivity -- output subscription is not a reactive context; refit reads current signal values intentionally
     const cleanupScrollback = onScrollback(props.agentId, (data, cols) => {
-      if (term && cols > 0) {
-        term.resize(cols, term.rows);
-      }
+      if (cols > 0) setServerCols(cols);
+      // Fit the font/geometry to the desktop's column count so the terminal
+      // fills the available width.
+      refit();
       // Clear before writing — on reconnect the server re-sends the full
       // scrollback buffer, so we must avoid duplicate content.
       term?.clear();
@@ -122,13 +235,13 @@ export function AgentDetail(props: AgentDetailProps) {
     let resizeRaf = 0;
     const observer = new ResizeObserver(() => {
       cancelAnimationFrame(resizeRaf);
-      resizeRaf = requestAnimationFrame(() => fitAddon?.fit());
+      resizeRaf = requestAnimationFrame(() => refit());
     });
     observer.observe(termContainer);
 
     // Refit terminal when soft keyboard opens/closes on mobile
     if (window.visualViewport) {
-      const onViewportResize = () => fitAddon?.fit();
+      const onViewportResize = () => refit();
       window.visualViewport.addEventListener('resize', onViewportResize);
       onCleanup(() => window.visualViewport?.removeEventListener('resize', onViewportResize));
     }
@@ -262,6 +375,54 @@ export function AgentDetail(props: AgentDetailProps) {
         />
       </div>
 
+      {/* Terminal / Notes tabs */}
+      <div
+        style={{
+          display: 'flex',
+          'flex-shrink': '0',
+          'border-bottom': '1px solid #223040',
+          background: '#12181f',
+          position: 'relative',
+          'z-index': '10',
+        }}
+      >
+        <For
+          each={[
+            { id: 'terminal' as const, label: 'Terminal' },
+            { id: 'notes' as const, label: 'Notes' },
+          ]}
+        >
+          {(tab) => (
+            <button
+              onClick={() => {
+                if (tab.id === 'notes') {
+                  void openNotes();
+                } else {
+                  setView('terminal');
+                  // The terminal was display:none while Notes was open; re-fit
+                  // once it's laid out again so it fills the width.
+                  requestAnimationFrame(() => refit());
+                }
+              }}
+              style={{
+                flex: '1',
+                padding: '10px 0',
+                background: 'none',
+                border: 'none',
+                'border-bottom': view() === tab.id ? '2px solid #2ec8ff' : '2px solid transparent',
+                color: view() === tab.id ? '#d7e4f0' : '#678197',
+                'font-size': '14px',
+                'font-weight': '500',
+                cursor: 'pointer',
+                'touch-action': 'manipulation',
+              }}
+            >
+              {tab.label}
+            </button>
+          )}
+        </For>
+      </div>
+
       {/* Connection status banner */}
       <Show when={status() !== 'connected'}>
         <div
@@ -279,7 +440,8 @@ export function AgentDetail(props: AgentDetailProps) {
       </Show>
 
       {/* Terminal — overflow:hidden clips xterm.js overlays so they don't
-           capture touch events over the header/input areas */}
+           capture touch events over the header/input areas. Kept mounted (hidden,
+           not unmounted) when the Notes tab is active so output keeps streaming. */}
       <div
         ref={termContainer}
         style={{
@@ -288,11 +450,103 @@ export function AgentDetail(props: AgentDetailProps) {
           padding: '4px',
           position: 'relative',
           overflow: 'hidden',
+          display: view() === 'terminal' ? 'block' : 'none',
         }}
       />
 
+      {/* Notes editor */}
+      <Show when={view() === 'notes'}>
+        <div
+          style={{
+            flex: '1',
+            'min-height': '0',
+            display: 'flex',
+            'flex-direction': 'column',
+            background: '#0b0f14',
+          }}
+        >
+          <Show when={notesError()}>
+            <div
+              style={{
+                padding: '8px 14px',
+                background: '#7f1d1d',
+                color: '#fca5a5',
+                'font-size': '13px',
+                'flex-shrink': '0',
+              }}
+            >
+              {notesError()}
+            </div>
+          </Show>
+          <textarea
+            value={notesText()}
+            disabled={notesLoading()}
+            onInput={(e) => {
+              setNotesText(e.currentTarget.value);
+              setNotesDirty(true);
+            }}
+            placeholder={notesLoading() ? 'Loading notes…' : 'Notes for this task…'}
+            style={{
+              flex: '1',
+              'min-height': '0',
+              width: '100%',
+              background: '#0b0f14',
+              border: 'none',
+              padding: '12px 14px',
+              color: '#d7e4f0',
+              'font-size': '15px',
+              'font-family': "'JetBrains Mono', 'Courier New', monospace",
+              'line-height': '1.5',
+              resize: 'none',
+              outline: 'none',
+              'box-sizing': 'border-box',
+            }}
+          />
+          <div
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '10px',
+              padding: '10px 14px max(10px, env(safe-area-inset-bottom)) 14px',
+              'border-top': '1px solid #223040',
+              background: '#12181f',
+              'flex-shrink': '0',
+            }}
+          >
+            <span style={{ 'font-size': '13px', color: '#678197' }}>
+              {notesSaving()
+                ? 'Saving…'
+                : notesSaved()
+                  ? 'Saved'
+                  : notesDirty()
+                    ? 'Unsaved changes'
+                    : ''}
+            </span>
+            <button
+              type="button"
+              disabled={notesSaving() || notesLoading() || !taskId()}
+              onClick={() => void handleSaveNotes()}
+              style={{
+                'margin-left': 'auto',
+                background: notesSaving() || notesLoading() || !taskId() ? '#1a2430' : '#2ec8ff',
+                color: notesSaving() || notesLoading() || !taskId() ? '#678197' : '#031018',
+                border: 'none',
+                'border-radius': '10px',
+                padding: '10px 22px',
+                'font-size': '15px',
+                'font-weight': '600',
+                cursor: notesSaving() || notesLoading() || !taskId() ? 'default' : 'pointer',
+                'touch-action': 'manipulation',
+              }}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </Show>
+
       {/* Scroll to bottom FAB */}
-      <Show when={!atBottom()}>
+      <Show when={view() === 'terminal' && !atBottom()}>
         <button
           onClick={scrollToBottom}
           style={{
@@ -323,7 +577,7 @@ export function AgentDetail(props: AgentDetailProps) {
         style={{
           'border-top': '1px solid #223040',
           padding: '8px 10px max(8px, env(safe-area-inset-bottom)) 10px',
-          display: 'flex',
+          display: view() === 'terminal' ? 'flex' : 'none',
           'flex-direction': 'column',
           gap: '6px',
           'flex-shrink': '0',
@@ -439,14 +693,7 @@ export function AgentDetail(props: AgentDetailProps) {
           </For>
           <div style={{ 'margin-left': 'auto', display: 'flex', gap: '6px' }}>
             <button
-              onClick={() => {
-                const next = Math.max(MIN_FONT, termFontSize() - 1);
-                setTermFontSize(next);
-                if (term) {
-                  term.options.fontSize = next;
-                  fitAddon?.fit();
-                }
-              }}
+              onClick={() => changeFont(-1)}
               disabled={termFontSize() <= MIN_FONT}
               style={{
                 background: '#1a2430',
@@ -466,14 +713,7 @@ export function AgentDetail(props: AgentDetailProps) {
               A-
             </button>
             <button
-              onClick={() => {
-                const next = Math.min(MAX_FONT, termFontSize() + 1);
-                setTermFontSize(next);
-                if (term) {
-                  term.options.fontSize = next;
-                  fitAddon?.fit();
-                }
-              }}
+              onClick={() => changeFont(1)}
               disabled={termFontSize() >= MAX_FONT}
               style={{
                 background: '#1a2430',

--- a/src/remote/AgentDetail.tsx
+++ b/src/remote/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { onMount, onCleanup, createSignal, createEffect, Show, For } from 'solid-js';
+import { onMount, onCleanup, createSignal, createEffect, untrack, Show, For } from 'solid-js';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { TERMINAL_SCROLLBACK_LINES, base64ToUint8Array } from '../lib/terminalConstants';
@@ -148,13 +148,16 @@ export function AgentDetail(props: AgentDetailProps) {
     }
   }
 
-  // Load notes when the Notes tab is showing and a task id is available. Guarded
-  // by notesDirty so reopening the tab never discards unsaved local edits, and
-  // it retries automatically if taskId resolves after the tab was opened.
+  // Load notes when the Notes tab is shown (or the task id resolves after the
+  // tab was opened). Depends only on view() and taskId(); notesDirty is read
+  // untracked as a guard — reopening the tab never discards unsaved edits, and,
+  // crucially, saving (which flips notesDirty false) does NOT retrigger a
+  // redundant reload.
   createEffect(() => {
     if (view() !== 'notes') return;
     const id = taskId();
-    if (!id || notesDirty()) return;
+    if (!id) return;
+    if (untrack(notesDirty)) return;
     void loadNotes(id);
   });
 
@@ -204,7 +207,7 @@ export function AgentDetail(props: AgentDetailProps) {
 
     term = new Terminal({
       fontSize: 10,
-      fontFamily: "'JetBrains Mono', 'Courier New', monospace",
+      fontFamily: TERM_FONT_FAMILY,
       theme: { background: '#0b0f14' },
       scrollback: TERMINAL_SCROLLBACK_LINES,
       cursorBlink: false,
@@ -260,6 +263,11 @@ export function AgentDetail(props: AgentDetailProps) {
       window.visualViewport.addEventListener('resize', onViewportResize);
       onCleanup(() => window.visualViewport?.removeEventListener('resize', onViewportResize));
     }
+
+    // The initial auto-fit may measure the fallback font if JetBrains Mono
+    // hasn't loaded yet; re-fit once it's ready so the font size is correct.
+    // eslint-disable-next-line solid/reactivity -- promise callback is not a reactive context; refit reads current signal values intentionally
+    document.fonts?.ready.then(() => refit()).catch(() => {});
 
     // Manual touch scrolling for mobile — xterm.js doesn't handle this well
     let touchStartY = 0;
@@ -525,6 +533,9 @@ export function AgentDetail(props: AgentDetailProps) {
             onInput={(e) => {
               setNotesText(e.currentTarget.value);
               setNotesDirty(true);
+              // Clear a lingering "Saved" so editing right after a save doesn't
+              // keep showing "Saved" over genuine unsaved changes.
+              setNotesSaved(false);
             }}
             placeholder={notesLoading() ? 'Loading notes…' : 'Notes for this task…'}
             style={{

--- a/src/remote/AgentList.tsx
+++ b/src/remote/AgentList.tsx
@@ -1,5 +1,6 @@
 import { For, Show, createMemo } from 'solid-js';
 import { agents, status } from './ws';
+import { agentStatusDisplay } from './attention';
 import type { RemoteAgent } from '../../electron/remote/protocol';
 
 interface AgentListProps {
@@ -10,6 +11,28 @@ interface AgentListProps {
 export function AgentList(props: AgentListProps) {
   const running = createMemo(() => agents().filter((a) => a.status === 'running').length);
   const total = createMemo(() => agents().length);
+  const needsInput = createMemo(() => agents().filter((a) => a.attention === 'needs_input').length);
+
+  // Surface tasks that want attention at the top; keep original order within a
+  // rank so the list doesn't jump around on unrelated status changes.
+  const ATTENTION_RANK: Record<string, number> = {
+    needs_input: 0,
+    error: 1,
+    review: 2,
+    active: 3,
+    ready: 4,
+    idle: 5,
+  };
+  const sortedAgents = createMemo(() =>
+    agents()
+      .map((a, i) => ({ a, i }))
+      .sort((x, y) => {
+        const rx = ATTENTION_RANK[x.a.attention] ?? 5;
+        const ry = ATTENTION_RANK[y.a.attention] ?? 5;
+        return rx - ry || x.i - y.i;
+      })
+      .map((e) => e.a),
+  );
 
   return (
     <div
@@ -34,7 +57,32 @@ export function AgentList(props: AgentListProps) {
         <span style={{ 'font-size': '18px', 'font-weight': '600', color: '#d7e4f0' }}>
           Parallel Code
         </span>
-        <div style={{ display: 'flex', 'align-items': 'center', gap: '12px' }}>
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '10px' }}>
+          <Show when={needsInput() > 0}>
+            <span
+              style={{
+                display: 'inline-flex',
+                'align-items': 'center',
+                gap: '5px',
+                padding: '3px 9px',
+                'border-radius': '999px',
+                background: '#3a2a0d',
+                color: '#ffc569',
+                'font-size': '12px',
+                'font-weight': '600',
+              }}
+            >
+              <span
+                style={{
+                  width: '7px',
+                  height: '7px',
+                  'border-radius': '50%',
+                  background: '#ffc569',
+                }}
+              />
+              {needsInput()} needs input
+            </span>
+          </Show>
           <div style={{ display: 'flex', 'align-items': 'center', gap: '8px' }}>
             <div
               style={{
@@ -144,86 +192,92 @@ export function AgentList(props: AgentListProps) {
           </a>
         </div>
 
-        <For each={agents()}>
-          {(agent: RemoteAgent) => (
-            <div
-              onClick={() => props.onSelect(agent.agentId, agent.taskName)}
-              style={{
-                background: '#0f141b',
-                border: '1px solid #223040',
-                'border-radius': '12px',
-                padding: '14px 16px',
-                cursor: 'pointer',
-                display: 'flex',
-                'flex-direction': 'column',
-                gap: '6px',
-                'touch-action': 'manipulation',
-                transition: 'background 0.16s ease',
-              }}
-            >
+        <For each={sortedAgents()}>
+          {(agent: RemoteAgent) => {
+            const display = () => agentStatusDisplay(agent);
+            return (
               <div
+                onClick={() => props.onSelect(agent.agentId, agent.taskName)}
                 style={{
+                  background: '#0f141b',
+                  border: display().glow ? `1px solid ${display().color}66` : '1px solid #223040',
+                  'border-radius': '12px',
+                  padding: '14px 16px',
+                  cursor: 'pointer',
                   display: 'flex',
-                  'align-items': 'center',
-                  'justify-content': 'space-between',
+                  'flex-direction': 'column',
+                  gap: '6px',
+                  'touch-action': 'manipulation',
+                  transition: 'background 0.16s ease',
                 }}
               >
                 <div
                   style={{
                     display: 'flex',
                     'align-items': 'center',
+                    'justify-content': 'space-between',
                     gap: '8px',
-                    'min-width': '0',
-                    flex: '1',
                   }}
                 >
                   <div
                     style={{
-                      width: '8px',
-                      height: '8px',
-                      'border-radius': '50%',
-                      background: agent.status === 'running' ? '#2fd198' : '#678197',
-                      'flex-shrink': '0',
-                    }}
-                  />
-                  <span
-                    style={{
-                      'font-size': '15px',
-                      'font-weight': '500',
-                      color: '#d7e4f0',
-                      overflow: 'hidden',
-                      'text-overflow': 'ellipsis',
-                      'white-space': 'nowrap',
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '8px',
+                      'min-width': '0',
+                      flex: '1',
                     }}
                   >
-                    {agent.taskName}
+                    <div
+                      style={{
+                        width: '8px',
+                        height: '8px',
+                        'border-radius': '50%',
+                        background: display().color,
+                        'box-shadow': display().glow ? `0 0 0 3px ${display().color}33` : 'none',
+                        'flex-shrink': '0',
+                      }}
+                    />
+                    <span
+                      style={{
+                        'font-size': '15px',
+                        'font-weight': '500',
+                        color: '#d7e4f0',
+                        overflow: 'hidden',
+                        'text-overflow': 'ellipsis',
+                        'white-space': 'nowrap',
+                      }}
+                    >
+                      {agent.taskName}
+                    </span>
+                  </div>
+                  <span
+                    style={{
+                      'font-size': '13px',
+                      'font-weight': display().glow ? '600' : '400',
+                      color: display().color,
+                      'flex-shrink': '0',
+                    }}
+                  >
+                    {display().label}
                   </span>
                 </div>
-                <span
+
+                <div
                   style={{
-                    'font-size': '13px',
-                    color: agent.status === 'running' ? '#2fd198' : '#678197',
-                    'flex-shrink': '0',
+                    'font-size': '12px',
+                    'font-family': "'JetBrains Mono', 'Courier New', monospace",
+                    color: '#678197',
+                    'white-space': 'nowrap',
+                    overflow: 'hidden',
+                    'text-overflow': 'ellipsis',
                   }}
                 >
-                  {agent.status}
-                </span>
+                  {agent.agentId}
+                </div>
               </div>
-
-              <div
-                style={{
-                  'font-size': '12px',
-                  'font-family': "'JetBrains Mono', 'Courier New', monospace",
-                  color: '#678197',
-                  'white-space': 'nowrap',
-                  overflow: 'hidden',
-                  'text-overflow': 'ellipsis',
-                }}
-              >
-                {agent.agentId}
-              </div>
-            </div>
-          )}
+            );
+          }}
         </For>
       </div>
     </div>

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -1,5 +1,6 @@
 // REST helpers for the mobile SPA. Data flows over the WebSocket (see ws.ts);
-// these cover the request/response actions: pairing and task creation.
+// these cover the request/response actions: pairing, task creation, and
+// reading/saving task notes.
 
 import { getToken, getPairedToken } from './auth';
 

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -75,3 +75,24 @@ export async function createTask(input: {
   });
   return r.taskId;
 }
+
+/** Fetch the notes for a task. Works with the base connection token. */
+export async function fetchNotes(taskId: string): Promise<string> {
+  const token = getToken();
+  if (!token) throw new ApiError('Not connected', 401);
+  const r = await request<{ notes: string }>(`/api/mobile/notes/${encodeURIComponent(taskId)}`, {
+    token,
+  });
+  return r.notes;
+}
+
+/** Save the notes for a task. Works with the base connection token. */
+export async function saveNotes(taskId: string, notes: string): Promise<void> {
+  const token = getToken();
+  if (!token) throw new ApiError('Not connected', 401);
+  await request<{ ok: boolean }>(`/api/mobile/notes/${encodeURIComponent(taskId)}`, {
+    method: 'PUT',
+    body: { notes },
+    token,
+  });
+}

--- a/src/remote/attention.test.ts
+++ b/src/remote/attention.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { agentStatusDisplay } from './attention';
+import type { RemoteAttentionState } from '../../electron/remote/protocol';
+
+describe('agentStatusDisplay', () => {
+  it('maps each attention state to a label', () => {
+    const expected: Record<RemoteAttentionState, string> = {
+      needs_input: 'Needs input',
+      active: 'Working',
+      error: 'Error',
+      review: 'Review',
+      ready: 'Ready',
+      idle: 'Idle',
+    };
+    for (const [attention, label] of Object.entries(expected)) {
+      const d = agentStatusDisplay({
+        status: 'running',
+        attention: attention as RemoteAttentionState,
+      });
+      expect(d.label).toBe(label);
+      expect(d.color).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it('glows the attention-worthy states only', () => {
+    const glowing: RemoteAttentionState[] = ['needs_input', 'active', 'error', 'review'];
+    const calm: RemoteAttentionState[] = ['ready', 'idle'];
+    for (const a of glowing) {
+      expect(agentStatusDisplay({ status: 'running', attention: a }).glow).toBe(true);
+    }
+    for (const a of calm) {
+      expect(agentStatusDisplay({ status: 'running', attention: a }).glow).toBe(false);
+    }
+  });
+
+  it('distinguishes an exited idle agent from a live one', () => {
+    expect(agentStatusDisplay({ status: 'running', attention: 'idle' }).label).toBe('Idle');
+    expect(agentStatusDisplay({ status: 'exited', attention: 'idle' }).label).toBe('Exited');
+  });
+
+  it('lets a non-idle attention win over an exited process', () => {
+    // An errored task that also exited should read as "Error", not "Exited".
+    expect(agentStatusDisplay({ status: 'exited', attention: 'error' }).label).toBe('Error');
+  });
+});

--- a/src/remote/attention.ts
+++ b/src/remote/attention.ts
@@ -28,7 +28,7 @@ const BY_ATTENTION: Partial<Record<RemoteAttentionState, StatusDisplay>> = {
   needs_input: { label: 'Needs input', color: AMBER, glow: true },
   active: { label: 'Working', color: BLUE, glow: true },
   error: { label: 'Error', color: RED, glow: true },
-  review: { label: 'Review', color: PURPLE, glow: false },
+  review: { label: 'Review', color: PURPLE, glow: true },
   ready: { label: 'Ready', color: GREEN, glow: false },
 };
 

--- a/src/remote/attention.ts
+++ b/src/remote/attention.ts
@@ -1,0 +1,45 @@
+// Maps a RemoteAgent's status onto a mobile-friendly label + colour, mirroring
+// the desktop's StatusDot palette so the overview reads the same on both.
+//
+// `attention` (renderer-derived) is the primary signal; the running/exited
+// process state only matters to distinguish an idle-but-alive agent ("Idle")
+// from one whose process has ended ("Exited").
+
+import type { RemoteAgent, RemoteAttentionState } from '../../electron/remote/protocol';
+
+export interface StatusDisplay {
+  label: string;
+  color: string;
+  /** Draw a glow ring — reserved for states that want the user's attention. */
+  glow: boolean;
+}
+
+// Colours chosen to match the mobile SPA's existing palette and the desktop
+// StatusDot: amber = needs input, blue = working, red = error, purple = review,
+// green = ready, grey = idle/exited.
+const AMBER = '#ffc569';
+const BLUE = '#2ec8ff';
+const RED = '#ff5f73';
+const PURPLE = '#c084fc';
+const GREEN = '#2fd198';
+const GREY = '#678197';
+
+const BY_ATTENTION: Partial<Record<RemoteAttentionState, StatusDisplay>> = {
+  needs_input: { label: 'Needs input', color: AMBER, glow: true },
+  active: { label: 'Working', color: BLUE, glow: true },
+  error: { label: 'Error', color: RED, glow: true },
+  review: { label: 'Review', color: PURPLE, glow: false },
+  ready: { label: 'Ready', color: GREEN, glow: false },
+};
+
+export function agentStatusDisplay(
+  agent: Pick<RemoteAgent, 'status' | 'attention'>,
+): StatusDisplay {
+  const known = BY_ATTENTION[agent.attention];
+  if (known) return known;
+  // attention is 'idle' (or unknown): distinguish a live idle agent from an
+  // exited one so the overview doesn't mislabel a finished process as idle.
+  return agent.status === 'exited'
+    ? { label: 'Exited', color: GREY, glow: false }
+    : { label: 'Idle', color: GREY, glow: false };
+}

--- a/src/remote/attention.ts
+++ b/src/remote/attention.ts
@@ -1,9 +1,10 @@
 // Maps a RemoteAgent's status onto a mobile-friendly label + colour, mirroring
 // the desktop's StatusDot palette so the overview reads the same on both.
 //
-// `attention` (renderer-derived) is the primary signal; the running/exited
-// process state only matters to distinguish an idle-but-alive agent ("Idle")
-// from one whose process has ended ("Exited").
+// `attention` (renderer-derived) is the primary signal. The status==='exited'
+// arm is a defensive fallback: the agent list is currently built only from live
+// PTY sessions, so exited agents drop out rather than reaching here — but the
+// branch keeps the label correct if that wiring ever changes.
 
 import type { RemoteAgent, RemoteAttentionState } from '../../electron/remote/protocol';
 

--- a/src/store/remoteStatusSync.ts
+++ b/src/store/remoteStatusSync.ts
@@ -8,7 +8,7 @@
 // main-side cache, and electron/remote/server.ts buildAgentList for how the
 // cached attention is attached to each RemoteAgent.
 
-import { createEffect, onCleanup } from 'solid-js';
+import { createEffect, createRoot } from 'solid-js';
 import { store } from './store';
 import { getTaskAttentionState } from './taskStatus';
 import { fireAndForget } from '../lib/ipc';
@@ -19,27 +19,31 @@ export function startRemoteStatusSync(): () => void {
   // Serialized snapshot of the last push, so we only send on actual change.
   let lastSerialized = '';
 
-  createEffect(() => {
-    // Only sync while the remote (Connect Phone) server is running — otherwise
-    // no phone is listening and the push is wasted. Reading `enabled` here also
-    // makes the effect re-run (and resume syncing) when the server starts.
-    if (!store.remoteAccess.enabled) {
-      lastSerialized = '';
-      return;
-    }
+  // createRoot gives the effect an explicit owner whose disposer we return, so
+  // the sync actually stops when the caller invokes it. Called from an async
+  // onMount past the first await, the ambient owner is already gone, so relying
+  // on onCleanup/owner-disposal alone would leave the effect running forever.
+  return createRoot((dispose) => {
+    createEffect(() => {
+      // Only sync while the remote (Connect Phone) server is running — otherwise
+      // no phone is listening and the push is wasted. Reading `enabled` here also
+      // makes the effect re-run (and resume syncing) when the server starts.
+      if (!store.remoteAccess.enabled) {
+        lastSerialized = '';
+        return;
+      }
 
-    const statuses: Record<string, RemoteAttentionState> = {};
-    for (const taskId of [...store.taskOrder, ...store.collapsedTaskOrder]) {
-      statuses[taskId] = getTaskAttentionState(taskId);
-    }
+      const statuses: Record<string, RemoteAttentionState> = {};
+      for (const taskId of [...store.taskOrder, ...store.collapsedTaskOrder]) {
+        statuses[taskId] = getTaskAttentionState(taskId);
+      }
 
-    const serialized = JSON.stringify(statuses);
-    if (serialized === lastSerialized) return;
-    lastSerialized = serialized;
-    fireAndForget(IPC.Remote_UpdateTaskStatus, { statuses });
+      const serialized = JSON.stringify(statuses);
+      if (serialized === lastSerialized) return;
+      lastSerialized = serialized;
+      fireAndForget(IPC.Remote_UpdateTaskStatus, { statuses });
+    });
+
+    return dispose;
   });
-
-  const cleanup = (): void => {};
-  onCleanup(cleanup);
-  return cleanup;
 }

--- a/src/store/remoteStatusSync.ts
+++ b/src/store/remoteStatusSync.ts
@@ -1,0 +1,45 @@
+// Pushes the desktop's per-task attention state (working, needs input, ready,
+// error, …) to the main process so the mobile overview can show the same
+// richer status instead of just running/exited. The renderer owns this
+// computation because it depends on reactive terminal/git/steps state; main
+// simply caches the latest snapshot and re-broadcasts it to connected phones.
+//
+// See electron/ipc/register.ts (Remote_UpdateTaskStatus handler) for the
+// main-side cache, and electron/remote/server.ts buildAgentList for how the
+// cached attention is attached to each RemoteAgent.
+
+import { createEffect, onCleanup } from 'solid-js';
+import { store } from './store';
+import { getTaskAttentionState } from './taskStatus';
+import { fireAndForget } from '../lib/ipc';
+import { IPC } from '../../electron/ipc/channels';
+import type { RemoteAttentionState } from '../../electron/remote/protocol';
+
+export function startRemoteStatusSync(): () => void {
+  // Serialized snapshot of the last push, so we only send on actual change.
+  let lastSerialized = '';
+
+  createEffect(() => {
+    // Only sync while the remote (Connect Phone) server is running — otherwise
+    // no phone is listening and the push is wasted. Reading `enabled` here also
+    // makes the effect re-run (and resume syncing) when the server starts.
+    if (!store.remoteAccess.enabled) {
+      lastSerialized = '';
+      return;
+    }
+
+    const statuses: Record<string, RemoteAttentionState> = {};
+    for (const taskId of [...store.taskOrder, ...store.collapsedTaskOrder]) {
+      statuses[taskId] = getTaskAttentionState(taskId);
+    }
+
+    const serialized = JSON.stringify(statuses);
+    if (serialized === lastSerialized) return;
+    lastSerialized = serialized;
+    fireAndForget(IPC.Remote_UpdateTaskStatus, { statuses });
+  });
+
+  const cleanup = (): void => {};
+  onCleanup(cleanup);
+  return cleanup;
+}

--- a/src/store/remoteTaskHandler.test.ts
+++ b/src/store/remoteTaskHandler.test.ts
@@ -1,0 +1,42 @@
+/* eslint-disable solid/reactivity -- these tests read the store proxy synchronously to exercise isKnownTask; no reactive tracking is involved. */
+import { describe, it, expect } from 'vitest';
+import { createStore } from 'solid-js/store';
+import { isKnownTask } from './remoteTaskHandler';
+
+// Guards the prototype-pollution fix: a mobile HTTP request supplies the task
+// id, and Solid's store proxy resolves inherited keys to prototype objects.
+// isKnownTask must accept only real own task entries so that a later
+// updateTaskNotes -> setStore('tasks', id, 'notes', …) can never target
+// Object.prototype / Function.prototype via an inherited key.
+describe('isKnownTask', () => {
+  const [store] = createStore<{ tasks: Record<string, { notes: string }> }>({
+    tasks: { 'task-1': { notes: '' }, 'task-2': { notes: 'x' } },
+  });
+
+  it('accepts real own task ids', () => {
+    expect(isKnownTask(store.tasks, 'task-1')).toBe(true);
+    expect(isKnownTask(store.tasks, 'task-2')).toBe(true);
+  });
+
+  it('rejects missing ids', () => {
+    expect(isKnownTask(store.tasks, 'nope')).toBe(false);
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'rejects the inherited/dangerous key %s',
+    (key) => {
+      expect(isKnownTask(store.tasks, key)).toBe(false);
+    },
+  );
+
+  it('would be fooled by a truthiness guard on the same proxy (documents why hasOwn is needed)', () => {
+    // These inherited keys read back truthy through the store proxy, which is
+    // exactly the trap the old `if (!store.tasks[id])` guard fell into.
+    const proxied = store.tasks as Record<string, unknown>;
+    expect(Boolean(proxied['constructor'])).toBe(true);
+    expect(Boolean(proxied['toString'])).toBe(true);
+    // …yet isKnownTask correctly rejects them.
+    expect(isKnownTask(store.tasks, 'constructor')).toBe(false);
+    expect(isKnownTask(store.tasks, 'toString')).toBe(false);
+  });
+});

--- a/src/store/remoteTaskHandler.ts
+++ b/src/store/remoteTaskHandler.ts
@@ -81,18 +81,25 @@ async function handleCreateTask(req: CreateTaskRequest): Promise<void> {
   }
 }
 
+// Use Object.hasOwn, not truthiness: taskId comes from a mobile HTTP request,
+// and Solid's store proxy passes `__proto__`/`constructor` through to
+// Object.prototype, so `store.tasks['__proto__']` is a truthy non-task object.
+// A truthiness guard would let setStore('tasks','__proto__','notes',…) pollute
+// Object.prototype. hasOwn only matches real, own task entries.
+function hasTask(taskId: string): boolean {
+  return Object.hasOwn(store.tasks, taskId);
+}
+
 function handleGetNotes(req: GetNotesRequest): void {
-  const task = store.tasks[req.taskId];
-  if (!task) {
+  if (!hasTask(req.taskId)) {
     reply(req.reqId, false, undefined, 'Task not found');
     return;
   }
-  reply(req.reqId, true, { notes: task.notes ?? '' });
+  reply(req.reqId, true, { notes: store.tasks[req.taskId].notes ?? '' });
 }
 
 function handleSetNotes(req: SetNotesRequest): void {
-  const task = store.tasks[req.taskId];
-  if (!task) {
+  if (!hasTask(req.taskId)) {
     reply(req.reqId, false, undefined, 'Task not found');
     return;
   }

--- a/src/store/remoteTaskHandler.ts
+++ b/src/store/remoteTaskHandler.ts
@@ -81,17 +81,22 @@ async function handleCreateTask(req: CreateTaskRequest): Promise<void> {
   }
 }
 
-// Use Object.hasOwn, not truthiness: taskId comes from a mobile HTTP request,
-// and Solid's store proxy passes `__proto__`/`constructor` through to
-// Object.prototype, so `store.tasks['__proto__']` is a truthy non-task object.
-// A truthiness guard would let setStore('tasks','__proto__','notes',…) pollute
-// Object.prototype. hasOwn only matches real, own task entries.
-function hasTask(taskId: string): boolean {
-  return Object.hasOwn(store.tasks, taskId);
+/**
+ * True only when `taskId` is a real, own entry of the tasks record.
+ *
+ * Uses Object.hasOwn, NOT truthiness: `taskId` arrives from a mobile HTTP
+ * request, and Solid's store proxy resolves inherited keys (`__proto__`,
+ * `constructor`, `toString`, …) to prototype objects, which are truthy but are
+ * not tasks. A truthiness guard would let updateTaskNotes → setStore('tasks',
+ * '__proto__', 'notes', …) pollute Object.prototype. hasOwn reports only own
+ * properties, so it rejects every inherited/dangerous/missing key.
+ */
+export function isKnownTask(tasks: Record<string, unknown>, taskId: string): boolean {
+  return Object.hasOwn(tasks, taskId);
 }
 
 function handleGetNotes(req: GetNotesRequest): void {
-  if (!hasTask(req.taskId)) {
+  if (!isKnownTask(store.tasks, req.taskId)) {
     reply(req.reqId, false, undefined, 'Task not found');
     return;
   }
@@ -99,7 +104,7 @@ function handleGetNotes(req: GetNotesRequest): void {
 }
 
 function handleSetNotes(req: SetNotesRequest): void {
-  if (!hasTask(req.taskId)) {
+  if (!isKnownTask(store.tasks, req.taskId)) {
     reply(req.reqId, false, undefined, 'Task not found');
     return;
   }

--- a/src/store/remoteTaskHandler.ts
+++ b/src/store/remoteTaskHandler.ts
@@ -5,7 +5,7 @@
 // main-side bridge.
 
 import { store } from './core';
-import { createTask } from './tasks';
+import { createTask, updateTaskNotes } from './tasks';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 
@@ -17,6 +17,15 @@ interface CreateTaskRequest extends RendererRequest {
   projectId: string;
   name: string;
   prompt: string;
+}
+
+interface GetNotesRequest extends RendererRequest {
+  taskId: string;
+}
+
+interface SetNotesRequest extends RendererRequest {
+  taskId: string;
+  notes: string;
 }
 
 function reply(reqId: string, ok: boolean, data?: unknown, error?: string): void {
@@ -72,6 +81,25 @@ async function handleCreateTask(req: CreateTaskRequest): Promise<void> {
   }
 }
 
+function handleGetNotes(req: GetNotesRequest): void {
+  const task = store.tasks[req.taskId];
+  if (!task) {
+    reply(req.reqId, false, undefined, 'Task not found');
+    return;
+  }
+  reply(req.reqId, true, { notes: task.notes ?? '' });
+}
+
+function handleSetNotes(req: SetNotesRequest): void {
+  const task = store.tasks[req.taskId];
+  if (!task) {
+    reply(req.reqId, false, undefined, 'Task not found');
+    return;
+  }
+  updateTaskNotes(req.taskId, req.notes);
+  reply(req.reqId, true, { ok: true });
+}
+
 /** Subscribe to mobile task-creation requests. Returns an unsubscribe fn. */
 export function startRemoteTaskHandlers(): () => void {
   const offProjects = window.electron.ipcRenderer.on(
@@ -86,8 +114,22 @@ export function startRemoteTaskHandlers(): () => void {
       if (data && typeof data === 'object') void handleCreateTask(data as CreateTaskRequest);
     },
   );
+  const offGetNotes = window.electron.ipcRenderer.on(
+    IPC.Remote_GetNotesRequest,
+    (data: unknown) => {
+      if (data && typeof data === 'object') handleGetNotes(data as GetNotesRequest);
+    },
+  );
+  const offSetNotes = window.electron.ipcRenderer.on(
+    IPC.Remote_SetNotesRequest,
+    (data: unknown) => {
+      if (data && typeof data === 'object') handleSetNotes(data as SetNotesRequest);
+    },
+  );
   return () => {
     offProjects();
     offCreate();
+    offGetNotes();
+    offSetNotes();
   };
 }


### PR DESCRIPTION
Add a Terminal/Notes tab switcher to the mobile agent detail view so
notes can be read and edited from a phone. Notes round-trip through the
existing renderer bridge: new REST routes GET/PUT /api/mobile/notes/:taskId
(mobile + paired tokens) forward to the renderer store via IPC, reusing
the same path as mobile task creation.

Also make the mobile terminal use the full available width. The client
cannot resize the desktop PTY, so instead of rendering at whatever column
count fits the phone (leaving a gap or overflowing), it now picks the
largest font size that makes the desktop's column count fill the width.
A-/A+ switch to manual sizing and stop the auto-fit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XJB5pJs7MhMxSN2uC2LgZ8