### PR TITLE
fix(shortcuts): show feedback for unsupported git actions

### DIFF
--- a/src/store/focus.test.ts
+++ b/src/store/focus.test.ts
@@ -20,6 +20,7 @@ type MockStore = {
   showPromptInput: boolean;
   sidebarVisible: boolean;
   taskSplitMode: Record<string, boolean>;
+  pendingAction: { type: 'close' | 'merge' | 'push'; taskId: string } | null;
 };
 
 type MockTask = {
@@ -56,6 +57,10 @@ vi.mock('./navigation', () => ({
   }),
 }));
 
+vi.mock('./notification', () => ({
+  showNotification: vi.fn(),
+}));
+
 vi.mock('./sidebar-order', () => ({
   computeSidebarTaskOrder: vi.fn(() => mockStore.taskOrder),
 }));
@@ -70,8 +75,10 @@ import {
   navigateColumn,
   navigateRow,
   scrollTaskElementIntoView,
+  setPendingAction,
   setTaskFocusedPanel,
 } from './focus';
+import { showNotification } from './notification';
 
 function setTask(id: string, overrides: Record<string, unknown> = {}): void {
   mockStore.tasks[id] = {
@@ -87,6 +94,7 @@ function setTask(id: string, overrides: Record<string, unknown> = {}): void {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   const harness = expectDefined(core.harness, 'mock store harness');
   mockStore = harness.reset({
     activeTaskId: 'task-1',
@@ -107,6 +115,7 @@ beforeEach(() => {
     showPromptInput: true,
     sidebarVisible: true,
     taskSplitMode: {},
+    pendingAction: null,
   });
 
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
@@ -211,6 +220,29 @@ describe('focus navigation neighbor map', () => {
     navigateRow('down');
 
     expect(mockStore.focusedPanel['task-1']).toBe('shell:0');
+  });
+});
+
+describe('setPendingAction', () => {
+  it.each([
+    ['merge', 'Merge'],
+    ['push', 'Push'],
+  ] as const)('shows feedback instead of queuing %s for a direct task', (type, label) => {
+    setTask('task-1', { gitIsolation: 'direct' });
+
+    setPendingAction({ type, taskId: 'task-1' });
+
+    expect(showNotification).toHaveBeenCalledWith(`${label} is only available for worktree tasks`);
+    expect(mockStore.pendingAction).toBeNull();
+  });
+
+  it('queues git actions for worktree tasks', () => {
+    setTask('task-1', { gitIsolation: 'worktree' });
+
+    setPendingAction({ type: 'merge', taskId: 'task-1' });
+
+    expect(showNotification).not.toHaveBeenCalled();
+    expect(mockStore.pendingAction).toEqual({ type: 'merge', taskId: 'task-1' });
   });
 });
 

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -1,6 +1,7 @@
 import { batch } from 'solid-js';
 import { store, setStore } from './core';
 import { setActiveTask } from './navigation';
+import { showNotification } from './notification';
 import { computeSidebarTaskOrder } from './sidebar-order';
 import { uncollapseTask } from './tasks';
 import {
@@ -480,6 +481,15 @@ export function navigateTask(direction: 'left' | 'right'): void {
 export function setPendingAction(
   action: { type: 'close' | 'merge' | 'push'; taskId: string } | null,
 ): void {
+  if (action && (action.type === 'merge' || action.type === 'push')) {
+    const task = store.tasks[action.taskId];
+    if (task && task.gitIsolation !== 'worktree') {
+      const label = action.type === 'merge' ? 'Merge' : 'Push';
+      showNotification(`${label} is only available for worktree tasks`);
+      return;
+    }
+  }
+
   setStore('pendingAction', action);
 }
 


### PR DESCRIPTION
## Summary

- show a brief notification when merge or push shortcuts target a non-worktree task
- keep the existing pending-action flow unchanged for worktree tasks
- add focused coverage for both unsupported and supported git actions

## Why

The keyboard handlers queue merge and push actions without checking git isolation. The task panel only opens those dialogs for worktree tasks, so using either shortcut on a direct task previously did nothing and gave no feedback.

This addresses the silent no-op shortcuts item in #214.

## Validation

- `npm test -- src/store/focus.test.ts`
- `npm run check`
- `npm run lint:dead`
- `npm run lint:arch`
- `npm test` (100 files passed, 2 skipped; 1625 tests passed, 23 skipped)
