### PR TITLE
feat(accessibility): add terminal screen reader mode

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import { themeToCss, detectThemeTone } from '../lib/custom-theme';
 import {
   store,
   setTerminalFont,
+  setTerminalScreenReaderMode,
   setAutoTrustFolders,
   setShowPlans,
   setShowPromptInput,
@@ -461,6 +462,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
               checked={store.fontSmoothing}
               onChange={setFontSmoothing}
               description="Enable antialiasing and geometric text rendering"
+              align="flex-start"
+            />
+            <SettingsCheckboxRow
+              label="Terminal screen reader mode"
+              checked={store.terminalScreenReaderMode}
+              onChange={setTerminalScreenReaderMode}
+              description="Expose terminal output to assistive technologies. May reduce rendering performance."
               align="flex-start"
             />
           </SettingsSection>

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -416,6 +416,7 @@ export function TerminalView(props: TerminalViewProps) {
       cursorBlink: true,
       fontSize: initialFontSize,
       fontFamily: getTerminalFontFamily(store.terminalFont),
+      screenReaderMode: store.terminalScreenReaderMode,
       theme: activeTerminalTheme(),
       allowProposedApi: true,
       scrollback: TERMINAL_SCROLLBACK_LINES,
@@ -1105,6 +1106,12 @@ export function TerminalView(props: TerminalViewProps) {
     if (!term || !fitAddon) return;
     term.options.fontFamily = getTerminalFontFamily(font);
     markDirty(props.agentId);
+  });
+
+  createEffect(() => {
+    const screenReaderMode = store.terminalScreenReaderMode;
+    if (!term) return;
+    term.options.screenReaderMode = screenReaderMode;
   });
 
   createEffect(() => {

--- a/src/store/autosave.test.ts
+++ b/src/store/autosave.test.ts
@@ -30,6 +30,15 @@ describe('autosave snapshot includes new-task-default fields', () => {
     setStore('defaultPropagateSkipPermissions', false);
   });
 
+  it('terminalScreenReaderMode changes the snapshot', () => {
+    setStore('terminalScreenReaderMode', false);
+    const before = persistedSnapshot();
+    setStore('terminalScreenReaderMode', true);
+    const after = persistedSnapshot();
+    expect(before).not.toBe(after);
+    setStore('terminalScreenReaderMode', false);
+  });
+
   it('showSteps is not tracked separately (migrated to defaultStepsEnabled)', () => {
     expect('showSteps' in store).toBe(false);
   });

--- a/src/store/autosave.ts
+++ b/src/store/autosave.ts
@@ -21,6 +21,7 @@ export function persistedSnapshot(): string {
     mergedLinesAdded: store.mergedLinesAdded,
     mergedLinesRemoved: store.mergedLinesRemoved,
     terminalFont: store.terminalFont,
+    terminalScreenReaderMode: store.terminalScreenReaderMode,
     themePreset: store.themePreset,
     windowState: store.windowState,
     autoTrustFolders: store.autoTrustFolders,

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -37,6 +37,7 @@ export const [store, setStore] = createStore<AppStore>({
   mergedLinesAdded: 0,
   mergedLinesRemoved: 0,
   terminalFont: DEFAULT_TERMINAL_FONT,
+  terminalScreenReaderMode: false,
   themePreset: 'islands-dark',
   appearanceMode: 'dark',
   lightThemePreset: 'islands-light',

--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -80,6 +80,7 @@ beforeEach(() => {
   setStore('customAgents', []);
   setStore('coordinatorControlHintDismissed', false);
   setStore('autoStartRemoteAccess', false);
+  setStore('terminalScreenReaderMode', false);
 });
 
 describe('resolveIncomingPanelUserSize', () => {
@@ -487,6 +488,53 @@ describe('loadState theme persistence', () => {
     await loadState();
     expect(store.appearanceMode).toBe('dark');
     expect(store.darkThemePreset).toBe('islands-dark');
+  });
+});
+
+describe('terminal screen reader mode persistence', () => {
+  it('defaults to false when absent from saved state', async () => {
+    mockInvoke.mockResolvedValueOnce(basePayload());
+
+    await loadState();
+
+    expect(store.terminalScreenReaderMode).toBe(false);
+  });
+
+  it('restores an enabled screen reader mode', async () => {
+    mockInvoke.mockResolvedValueOnce(basePayload({ terminalScreenReaderMode: true }));
+
+    await loadState();
+
+    expect(store.terminalScreenReaderMode).toBe(true);
+  });
+
+  it.each(['true', 1, null])('rejects a non-boolean persisted value (%s)', async (value) => {
+    setStore('terminalScreenReaderMode', true);
+    mockInvoke.mockResolvedValueOnce(basePayload({ terminalScreenReaderMode: value }));
+
+    await loadState();
+
+    expect(store.terminalScreenReaderMode).toBe(false);
+  });
+
+  it('omits the disabled default when saving', async () => {
+    setStore('terminalScreenReaderMode', false);
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    await saveState();
+
+    const saved = JSON.parse(mockInvoke.mock.calls[0][1].json);
+    expect(saved.terminalScreenReaderMode).toBeUndefined();
+  });
+
+  it('persists the enabled setting', async () => {
+    setStore('terminalScreenReaderMode', true);
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    await saveState();
+
+    const saved = JSON.parse(mockInvoke.mock.calls[0][1].json);
+    expect(saved.terminalScreenReaderMode).toBe(true);
   });
 });
 

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -183,6 +183,7 @@ export async function saveState(): Promise<void> {
     mergedLinesAdded: store.mergedLinesAdded,
     mergedLinesRemoved: store.mergedLinesRemoved,
     terminalFont: store.terminalFont,
+    terminalScreenReaderMode: store.terminalScreenReaderMode || undefined,
     themePreset: store.themePreset,
     showPromptInput: store.showPromptInput,
     fontSmoothing: store.fontSmoothing,
@@ -351,6 +352,7 @@ interface LegacyPersistedState {
   mergedLinesAdded?: unknown;
   mergedLinesRemoved?: unknown;
   terminalFont?: unknown;
+  terminalScreenReaderMode?: unknown;
   themePreset?: unknown;
   showPromptInput?: unknown;
   fontSmoothing?: unknown;
@@ -497,6 +499,8 @@ export async function loadState(): Promise<void> {
         typeof raw.terminalFont === 'string' && raw.terminalFont.trim()
           ? raw.terminalFont
           : DEFAULT_TERMINAL_FONT;
+      s.terminalScreenReaderMode =
+        typeof raw.terminalScreenReaderMode === 'boolean' ? raw.terminalScreenReaderMode : false;
       s.themePreset = isLookPreset(raw.themePreset) ? raw.themePreset : 'minimal';
       s.showPromptInput = typeof raw.showPromptInput === 'boolean' ? raw.showPromptInput : true;
       s.fontSmoothing = typeof raw.fontSmoothing === 'boolean' ? raw.fontSmoothing : true;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -117,6 +117,7 @@ export {
   toggleTaskFocusMode,
   setTaskSplitMode,
   setTerminalFont,
+  setTerminalScreenReaderMode,
   applyAppearanceMode,
   markCustomThemesReady,
   setAppearanceMode,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -249,6 +249,7 @@ export interface PersistedState {
   mergedLinesAdded?: number;
   mergedLinesRemoved?: number;
   terminalFont?: string;
+  terminalScreenReaderMode?: boolean;
   themePreset?: LookPreset;
   showPromptInput?: boolean;
   fontSmoothing?: boolean;
@@ -346,6 +347,7 @@ export interface AppStore {
   mergedLinesAdded: number;
   mergedLinesRemoved: number;
   terminalFont: string;
+  terminalScreenReaderMode: boolean;
   themePreset: LookPreset;
   showPromptInput: boolean;
   fontSmoothing: boolean;

--- a/src/store/ui.test.ts
+++ b/src/store/ui.test.ts
@@ -9,6 +9,7 @@ type MockStore = {
   panelUserSize: Record<string, number>;
   projectsCollapsed: boolean;
   sidebarFocusedProjectId: string | null;
+  terminalScreenReaderMode: boolean;
 };
 
 let mockStore: MockStore;
@@ -63,6 +64,7 @@ import {
   setPanelUserSize,
   deletePanelUserSize,
   setProjectsCollapsed,
+  setTerminalScreenReaderMode,
 } from './ui';
 
 beforeEach(() => {
@@ -78,6 +80,7 @@ beforeEach(() => {
     panelUserSize: {},
     projectsCollapsed: false,
     sidebarFocusedProjectId: null,
+    terminalScreenReaderMode: false,
   });
 
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
@@ -193,5 +196,13 @@ describe('setProjectsCollapsed', () => {
 
     expect(mockStore.projectsCollapsed).toBe(true);
     expect(mockStore.sidebarFocusedProjectId).toBeNull();
+  });
+});
+
+describe('setTerminalScreenReaderMode', () => {
+  it('updates the global terminal accessibility option', () => {
+    setTerminalScreenReaderMode(true);
+
+    expect(mockStore.terminalScreenReaderMode).toBe(true);
   });
 });

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -86,6 +86,10 @@ export function setTerminalFont(terminalFont: string): void {
   setStore('terminalFont', terminalFont);
 }
 
+export function setTerminalScreenReaderMode(enabled: boolean): void {
+  setStore('terminalScreenReaderMode', enabled);
+}
+
 export function applyAppearanceMode(): void {
   const isDark = osIsDark();
   const mode = store.appearanceMode;


### PR DESCRIPTION
## Summary
- add an opt-in Terminal screen reader mode setting, disabled by default
- persist and strictly validate the setting across app restarts
- initialize new xterm instances with `screenReaderMode` and update open terminals when the setting changes

## Validation
- `npm run check`
- `npm run check:static`
- `npm run test:security-rules`
- `npm test` (1,633 passed, 23 skipped)
- `npm run build:frontend`

Implements the terminal screen-reader mode portion of #211.