### PR TITLE
Fix keybinding migration notice layout reflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -815,75 +815,6 @@ function App() {
             <FocusModeTaskIndicators />
           </div>
         </Show>
-        <Show when={!store.keybindingMigrationDismissed}>
-          <div
-            style={{
-              background: theme.bgInput,
-              border: `1px solid ${theme.border}`,
-              'border-bottom': `1px solid ${theme.border}`,
-              padding: '8px 16px',
-              display: 'flex',
-              'align-items': 'center',
-              'justify-content': 'space-between',
-              'font-size': '13px',
-              color: theme.fg,
-              'flex-shrink': '0',
-            }}
-          >
-            <span>
-              Keyboard shortcuts are now configurable.{' '}
-              <button
-                type="button"
-                onClick={() => {
-                  toggleHelpDialog(true);
-                  dismissMigrationBanner();
-                }}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  padding: '0',
-                  font: 'inherit',
-                  color: theme.accent,
-                  cursor: 'pointer',
-                  'text-decoration': 'underline',
-                }}
-              >
-                Pick a preset for your coding agent
-              </button>{' '}
-              or{' '}
-              <button
-                type="button"
-                onClick={() => dismissMigrationBanner()}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  padding: '0',
-                  font: 'inherit',
-                  color: theme.fgMuted,
-                  cursor: 'pointer',
-                  'text-decoration': 'underline',
-                }}
-              >
-                dismiss
-              </button>
-              .
-            </span>
-            <button
-              onClick={() => dismissMigrationBanner()}
-              style={{
-                background: 'transparent',
-                border: 'none',
-                color: theme.fgMuted,
-                cursor: 'pointer',
-                'font-size': '16px',
-                padding: '0 4px',
-                'line-height': '1',
-              }}
-            >
-              &times;
-            </button>
-          </div>
-        </Show>
         <main style={{ flex: '1', display: 'flex', overflow: 'hidden' }}>
           <Show when={store.sidebarVisible}>
             <Sidebar />
@@ -929,6 +860,44 @@ function App() {
           open={store.showSettingsDialog}
           onClose={() => toggleSettingsDialog(false)}
         />
+        <Show when={!store.keybindingMigrationDismissed}>
+          <div
+            class="keybinding-migration-notice"
+            role="region"
+            aria-label="Keyboard shortcuts update"
+          >
+            <span>
+              Keyboard shortcuts are now configurable.{' '}
+              <button
+                type="button"
+                class="keybinding-migration-notice-action"
+                onClick={() => {
+                  toggleHelpDialog(true);
+                  dismissMigrationBanner();
+                }}
+              >
+                Pick a preset for your coding agent
+              </button>{' '}
+              or{' '}
+              <button
+                type="button"
+                class="keybinding-migration-notice-action secondary"
+                onClick={() => dismissMigrationBanner()}
+              >
+                dismiss
+              </button>
+              .
+            </span>
+            <button
+              type="button"
+              class="keybinding-migration-notice-close"
+              aria-label="Dismiss keyboard shortcuts update"
+              onClick={() => dismissMigrationBanner()}
+            >
+              &times;
+            </button>
+          </div>
+        </Show>
         <Show when={store.showArena}>
           <ArenaOverlay onClose={closeArena} />
         </Show>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -815,6 +815,44 @@ function App() {
             <FocusModeTaskIndicators />
           </div>
         </Show>
+        <Show when={!store.keybindingMigrationDismissed}>
+          <div
+            class="keybinding-migration-notice"
+            role="region"
+            aria-label="Keyboard shortcuts update"
+          >
+            <span>
+              Keyboard shortcuts are now configurable.{' '}
+              <button
+                type="button"
+                class="keybinding-migration-notice-action"
+                onClick={() => {
+                  toggleHelpDialog(true);
+                  dismissMigrationBanner();
+                }}
+              >
+                Pick a preset for your coding agent
+              </button>{' '}
+              or{' '}
+              <button
+                type="button"
+                class="keybinding-migration-notice-action secondary"
+                onClick={() => dismissMigrationBanner()}
+              >
+                dismiss
+              </button>
+              .
+            </span>
+            <button
+              type="button"
+              class="keybinding-migration-notice-close"
+              aria-label="Dismiss keyboard shortcuts update"
+              onClick={() => dismissMigrationBanner()}
+            >
+              &times;
+            </button>
+          </div>
+        </Show>
         <main style={{ flex: '1', display: 'flex', overflow: 'hidden' }}>
           <Show when={store.sidebarVisible}>
             <Sidebar />
@@ -860,44 +898,6 @@ function App() {
           open={store.showSettingsDialog}
           onClose={() => toggleSettingsDialog(false)}
         />
-        <Show when={!store.keybindingMigrationDismissed}>
-          <div
-            class="keybinding-migration-notice"
-            role="region"
-            aria-label="Keyboard shortcuts update"
-          >
-            <span>
-              Keyboard shortcuts are now configurable.{' '}
-              <button
-                type="button"
-                class="keybinding-migration-notice-action"
-                onClick={() => {
-                  toggleHelpDialog(true);
-                  dismissMigrationBanner();
-                }}
-              >
-                Pick a preset for your coding agent
-              </button>{' '}
-              or{' '}
-              <button
-                type="button"
-                class="keybinding-migration-notice-action secondary"
-                onClick={() => dismissMigrationBanner()}
-              >
-                dismiss
-              </button>
-              .
-            </span>
-            <button
-              type="button"
-              class="keybinding-migration-notice-close"
-              aria-label="Dismiss keyboard shortcuts update"
-              onClick={() => dismissMigrationBanner()}
-            >
-              &times;
-            </button>
-          </div>
-        </Show>
         <Show when={store.showArena}>
           <ArenaOverlay onClose={closeArena} />
         </Show>

--- a/src/keybinding-migration-notice.test.ts
+++ b/src/keybinding-migration-notice.test.ts
@@ -12,9 +12,10 @@ describe('keybinding migration notice', () => {
     expect(rule).not.toBeNull();
     expect(rule?.[1]).toMatch(/position:\s*fixed\s*;/);
     expect(rule?.[1]).toMatch(/width:\s*min\(560px,\s*calc\(100vw - 32px\)\)\s*;/);
-    expect(app.indexOf('<Show when={!store.keybindingMigrationDismissed}>')).toBeGreaterThan(
-      app.indexOf('</main>'),
-    );
+    expect(app).toContain('class="keybinding-migration-notice"');
+    const notice = app.indexOf('<Show when={!store.keybindingMigrationDismissed}>');
+    expect(notice).toBeGreaterThan(-1);
+    expect(notice).toBeLessThan(app.indexOf('<main '));
   });
 
   it('keeps the notice and dismiss control accessible', () => {

--- a/src/keybinding-migration-notice.test.ts
+++ b/src/keybinding-migration-notice.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const app = readFileSync(resolve(__dirname, 'App.tsx'), 'utf8');
+const css = readFileSync(resolve(__dirname, 'styles.css'), 'utf8');
+
+describe('keybinding migration notice', () => {
+  it('stays outside the main layout flow', () => {
+    const rule = css.match(/\.keybinding-migration-notice\s*\{([^}]*)\}/);
+
+    expect(rule).not.toBeNull();
+    expect(rule?.[1]).toMatch(/position:\s*fixed\s*;/);
+    expect(rule?.[1]).toMatch(/width:\s*min\(560px,\s*calc\(100vw - 32px\)\)\s*;/);
+    expect(app.indexOf('<Show when={!store.keybindingMigrationDismissed}>')).toBeGreaterThan(
+      app.indexOf('</main>'),
+    );
+  });
+
+  it('keeps the notice and dismiss control accessible', () => {
+    expect(app).toContain('role="region"');
+    expect(app).toContain('aria-label="Keyboard shortcuts update"');
+    expect(app).toContain('aria-label="Dismiss keyboard shortcuts update"');
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1901,6 +1901,54 @@ body.dragging-task * {
   -webkit-backdrop-filter: none;
 }
 
+.keybinding-migration-notice {
+  position: fixed;
+  top: 46px;
+  left: 50%;
+  z-index: 1900;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  box-sizing: border-box;
+  width: min(560px, calc(100vw - 32px));
+  padding: 12px 14px;
+  transform: translateX(-50%);
+  border: 1px solid var(--island-border);
+  border-radius: 8px;
+  background: var(--island-bg);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.keybinding-migration-notice-action,
+.keybinding-migration-notice-close {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+}
+
+.keybinding-migration-notice-action {
+  padding: 0;
+  text-decoration: underline;
+}
+
+.keybinding-migration-notice-action.secondary,
+.keybinding-migration-notice-close {
+  color: var(--fg-muted);
+}
+
+.keybinding-migration-notice-close {
+  flex: 0 0 auto;
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+}
+
 /* Monaco diff: hidden unchanged regions — make the collapse bar obvious and clickable */
 .monaco-editor .diff-hidden-lines .center {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- move the keybinding migration notice outside the main flex layout
- render it as a fixed, responsive notification so showing or dismissing it does not resize task columns and terminals
- preserve the preset and dismiss actions, with accessible labels
- add regression coverage for the fixed-position layout contract

Addresses the keybinding-migration banner reflow item in #214.

## Validation
- `npm test` (101 files passed, 2 skipped; 1,627 tests passed, 23 skipped)
- `npm run check`
- `npm run lint:dead`
- `npm run lint:arch`
- `npm run build:frontend`