### PR TITLE
feat(sidebar): pin tasks waiting for input to the top, make task names readable

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -20,6 +20,7 @@ import {
   setShowPromptInput,
   setShowSidebarTips,
   setShowSidebarProgress,
+  setSidebarNeedsInputFirst,
   setFontSmoothing,
   setDesktopNotificationsEnabled,
   setVerboseLogging,
@@ -443,6 +444,12 @@ export function SettingsDialog(props: SettingsDialogProps) {
               checked={store.showPromptInput}
               onChange={setShowPromptInput}
               description="When hidden, the terminal occupies the full panel and auto-focuses on activation"
+            />
+            <SettingsCheckboxRow
+              label="Pin tasks that need input to the top of the sidebar"
+              checked={store.sidebarNeedsInputFirst}
+              onChange={setSidebarNeedsInputFirst}
+              description="Tasks waiting on an answer appear directly under New Task, most recent question first"
             />
             <SettingsCheckboxRow
               label="Show progress section in sidebar"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   setPanelUserSize,
   toggleSettingsDialog,
   setProjectsCollapsed,
+  setSidebarNeedsInputFirst,
   uncollapseTask,
   isProjectMissing,
   showNotification,
@@ -32,6 +33,7 @@ import {
   getCoordinatorChildren,
   isCoordinatedChild,
 } from '../store/sidebar-order';
+import { computeNeedsInputTasks } from '../store/sidebar-attention';
 import { ConnectPhoneModal } from './ConnectPhoneModal';
 import { RemoveProjectConfirm } from './RemoveProjectConfirm';
 import { EditProjectDialog } from './EditProjectDialog';
@@ -119,6 +121,7 @@ function CoordinatorIcon() {
 function DirectBranchBadge(props: { branchName: string }) {
   return (
     <span
+      title={`Works directly on ${props.branchName}`}
       style={{
         'font-size': sf(10),
         'font-weight': '600',
@@ -127,12 +130,37 @@ function DirectBranchBadge(props: { branchName: string }) {
         background: `color-mix(in srgb, ${theme.warning} 12%, transparent)`,
         color: theme.warning,
         'flex-shrink': '0',
+        'max-width': '45%',
+        overflow: 'hidden',
+        'text-overflow': 'ellipsis',
+        'white-space': 'nowrap',
         'line-height': '1.5',
       }}
     >
       {props.branchName}
     </span>
   );
+}
+
+/** Task name, wrapping to at most two lines so long names stay readable in a
+ *  narrow sidebar. Full name always available as a tooltip. */
+function TaskName(props: { name: string }) {
+  return (
+    <span class="task-item-name" title={props.name}>
+      {props.name}
+    </span>
+  );
+}
+
+function waitingLabel(since: number | null, nowMs: number): string | null {
+  if (since === null) return null;
+  const seconds = Math.max(0, Math.floor((nowMs - since) / 1_000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
 }
 
 function taskAttentionStyles(
@@ -153,6 +181,149 @@ function taskAttentionStyles(
           ? `1.5px solid color-mix(in srgb, ${offscreenAttention.color()} 38%, transparent)`
           : '1.5px solid transparent',
   };
+}
+
+/** Open the task and land on the panel the user last worked in, so a pinned
+ *  question can be answered without a second click. */
+function jumpToWaitingTask(taskId: string): void {
+  if (store.tasks[taskId]?.collapsed) uncollapseTask(taskId);
+  setActiveTask(taskId);
+  unfocusSidebar();
+  setTaskFocusedPanel(taskId, getTaskFocusedPanel(taskId));
+}
+
+/** One pinned row in the "waiting for you" tray. */
+function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: number }) {
+  const task = () => store.tasks[props.taskId];
+  const project = () => store.projects.find((p) => p.id === task()?.projectId) ?? null;
+  const waited = () => waitingLabel(props.since, props.nowMs);
+
+  return (
+    <Show when={task()}>
+      {(t) => (
+        <div
+          class="task-item sidebar-attention-row"
+          role="button"
+          tabIndex={0}
+          title={`${t().name} — waiting for your input`}
+          onClick={() => jumpToWaitingTask(props.taskId)}
+          onKeyDown={(e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            e.preventDefault();
+            jumpToWaitingTask(props.taskId);
+          }}
+          style={{
+            display: 'flex',
+            'flex-direction': 'column',
+            gap: '2px',
+            padding: '6px 8px',
+            'border-radius': '6px',
+            'font-size': sf(12),
+            color: theme.fg,
+            'font-weight': '500',
+            cursor: 'pointer',
+            background:
+              store.activeTaskId === props.taskId
+                ? `color-mix(in srgb, ${theme.warning} 16%, transparent)`
+                : 'transparent',
+          }}
+        >
+          <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
+            <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" attention="needs_input" />
+            <TaskName name={t().name} />
+            <Show when={waited()}>
+              {(label) => (
+                <span
+                  style={{
+                    'font-size': sf(10),
+                    color: theme.warning,
+                    'flex-shrink': '0',
+                  }}
+                >
+                  {label()}
+                </span>
+              )}
+            </Show>
+          </div>
+          <Show when={project()}>
+            {(p) => (
+              <div
+                style={{
+                  display: 'flex',
+                  'align-items': 'center',
+                  gap: '5px',
+                  'padding-left': '12px',
+                  'font-size': sf(10),
+                  color: theme.fgSubtle,
+                  'min-width': '0',
+                }}
+              >
+                <span
+                  style={{
+                    width: '6px',
+                    height: '6px',
+                    'border-radius': '50%',
+                    background: p().color,
+                    'flex-shrink': '0',
+                  }}
+                />
+                <span
+                  style={{
+                    overflow: 'hidden',
+                    'text-overflow': 'ellipsis',
+                    'white-space': 'nowrap',
+                  }}
+                >
+                  {p().name}
+                </span>
+              </div>
+            )}
+          </Show>
+        </div>
+      )}
+    </Show>
+  );
+}
+
+/** Tasks blocked on an answer, pinned directly under the New Task button with
+ *  the most recent question first. */
+function NeedsInputTray(props: { nowMs: number }) {
+  const entries = createMemo(() => computeNeedsInputTasks());
+
+  return (
+    <Show when={store.sidebarNeedsInputFirst && entries().length > 0}>
+      <div class="sidebar-attention-tray">
+        <div class="sidebar-attention-tray-header">
+          <span
+            style={{
+              'font-size': sf(11),
+              'text-transform': 'uppercase',
+              'letter-spacing': '0.05em',
+              color: theme.warning,
+              'font-weight': '600',
+            }}
+          >
+            Waiting for you ({entries().length})
+          </span>
+          <IconButton
+            icon={
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+            }
+            onClick={() => setSidebarNeedsInputFirst(false)}
+            title="Stop pinning tasks that need input (re-enable in Settings)"
+            size="sm"
+          />
+        </div>
+        <For each={entries()}>
+          {(entry) => (
+            <NeedsInputRow taskId={entry.taskId} since={entry.since} nowMs={props.nowMs} />
+          )}
+        </For>
+      </div>
+    </Show>
+  );
 }
 
 export function TaskRowShell(props: {
@@ -766,6 +937,9 @@ export function Sidebar() {
           </button>
         </Show>
 
+        {/* Tasks waiting on an answer — pinned here so they never scroll away */}
+        <NeedsInputTray nowMs={nowMs()} />
+
         {/* Tasks grouped by project */}
         <div
           ref={taskListRef}
@@ -795,7 +969,7 @@ export function Sidebar() {
           style={{
             display: 'flex',
             'flex-direction': 'column',
-            gap: '1px',
+            gap: '3px',
             flex: '1',
             'min-height': TASKS_LIST_MIN_HEIGHT,
             overflow: 'auto',
@@ -833,7 +1007,18 @@ export function Sidebar() {
                         'flex-shrink': '0',
                       }}
                     />
-                    {project.name} ({totalCount()})
+                    <span
+                      title={project.name}
+                      style={{
+                        overflow: 'hidden',
+                        'text-overflow': 'ellipsis',
+                        'white-space': 'nowrap',
+                        'min-width': '0',
+                      }}
+                    >
+                      {project.name}
+                    </span>
+                    <span style={{ 'flex-shrink': '0' }}>({totalCount()})</span>
                   </span>
                   <For each={activeTasks()}>
                     {(taskId) => (
@@ -1029,10 +1214,10 @@ function CoordinatorFolder(props: TaskEntryProps) {
             taskId={props.taskId}
             class={`task-item${t().closingStatus === 'removing' ? ' task-item-removing' : ' task-item-appearing'}`}
             taskIndex={idx()}
-            title={getDotTooltip(
+            title={`${t().name} — ${getDotTooltip(
               getTaskDotStatus(props.taskId),
               getTaskAttentionState(props.taskId),
-            )}
+            )}`}
             onClick={() => {
               setActiveTask(props.taskId);
               focusSidebar();
@@ -1049,9 +1234,7 @@ function CoordinatorFolder(props: TaskEntryProps) {
                 size="sm"
                 attention={getTaskAttentionState(props.taskId)}
               />
-              <span style={{ overflow: 'hidden', 'text-overflow': 'ellipsis', flex: '1' }}>
-                {t().name}
-              </span>
+              <TaskName name={t().name} />
               <Show when={childCount() > 0}>
                 <span
                   style={{
@@ -1160,10 +1343,10 @@ function CollapsedTaskEntry(props: {
                 size="sm"
                 attention={getTaskAttentionState(props.taskId)}
               />
+              <TaskName name={t().name} />
               <Show when={t().gitIsolation === 'direct'}>
                 <DirectBranchBadge branchName={t().branchName} />
               </Show>
-              <span style={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }}>{t().name}</span>
               <Show when={isCoordinator() && childCount() > 0}>
                 <span
                   style={{
@@ -1234,10 +1417,10 @@ function TaskRow(props: TaskRowProps) {
             taskId={props.taskId}
             class={`task-item${t().closingStatus === 'removing' ? ' task-item-removing' : ' task-item-appearing'}`}
             taskIndex={props.indented ? undefined : idx()}
-            title={getDotTooltip(
+            title={`${t().name} — ${getDotTooltip(
               getTaskDotStatus(props.taskId),
               getTaskAttentionState(props.taskId),
-            )}
+            )}`}
             onClick={() => {
               setActiveTask(props.taskId);
               focusSidebar();
@@ -1256,10 +1439,10 @@ function TaskRow(props: TaskRowProps) {
                 size="sm"
                 attention={getTaskAttentionState(props.taskId)}
               />
+              <TaskName name={t().name} />
               <Show when={t().gitIsolation === 'direct'}>
                 <DirectBranchBadge branchName={t().branchName} />
               </Show>
-              <span style={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }}>{t().name}</span>
               <Show when={offscreenAttention.label()}>
                 {(label) => (
                   <span

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -215,6 +215,7 @@ function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: num
           style={{
             display: 'flex',
             'flex-direction': 'column',
+            'flex-shrink': '0',
             gap: '2px',
             padding: '6px 8px',
             'border-radius': '6px',
@@ -231,54 +232,53 @@ function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: num
           <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
             <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" attention="needs_input" />
             <TaskName name={t().name} />
+          </div>
+          {/* Project and elapsed time share the second line so the name gets
+              the full row width on the first. */}
+          <div
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '5px',
+              'padding-left': '12px',
+              'font-size': sf(10),
+              color: theme.fgSubtle,
+              'min-width': '0',
+            }}
+          >
+            <Show when={project()}>
+              {(p) => (
+                <>
+                  <span
+                    style={{
+                      width: '6px',
+                      height: '6px',
+                      'border-radius': '50%',
+                      background: p().color,
+                      'flex-shrink': '0',
+                    }}
+                  />
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      'text-overflow': 'ellipsis',
+                      'white-space': 'nowrap',
+                    }}
+                  >
+                    {p().name}
+                  </span>
+                </>
+              )}
+            </Show>
             <Show when={waited()}>
               {(label) => (
-                <span
-                  style={{
-                    'font-size': sf(10),
-                    color: theme.warning,
-                    'flex-shrink': '0',
-                  }}
-                >
+                <span style={{ color: theme.warning, 'flex-shrink': '0' }}>
+                  {project() ? '· ' : ''}
                   {label()}
                 </span>
               )}
             </Show>
           </div>
-          <Show when={project()}>
-            {(p) => (
-              <div
-                style={{
-                  display: 'flex',
-                  'align-items': 'center',
-                  gap: '5px',
-                  'padding-left': '12px',
-                  'font-size': sf(10),
-                  color: theme.fgSubtle,
-                  'min-width': '0',
-                }}
-              >
-                <span
-                  style={{
-                    width: '6px',
-                    height: '6px',
-                    'border-radius': '50%',
-                    background: p().color,
-                    'flex-shrink': '0',
-                  }}
-                />
-                <span
-                  style={{
-                    overflow: 'hidden',
-                    'text-overflow': 'ellipsis',
-                    'white-space': 'nowrap',
-                  }}
-                >
-                  {p().name}
-                </span>
-              </div>
-            )}
-          </Show>
         </div>
       )}
     </Show>
@@ -373,6 +373,9 @@ export function TaskRowShell(props: {
         opacity: props.opacity,
         display: 'flex',
         'flex-direction': 'column',
+        // The list is a scrolling flex column; without this, rows whose name
+        // wraps to two lines get shrunk and the second line is clipped.
+        'flex-shrink': '0',
         gap: '1px',
         ...props.style,
       }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -33,7 +33,7 @@ import {
   getCoordinatorChildren,
   isCoordinatedChild,
 } from '../store/sidebar-order';
-import { computeNeedsInputTasks } from '../store/sidebar-attention';
+import { computeNeedsInputTasks, jumpToWaitingTask } from '../store/sidebar-attention';
 import { ConnectPhoneModal } from './ConnectPhoneModal';
 import { RemoveProjectConfirm } from './RemoveProjectConfirm';
 import { EditProjectDialog } from './EditProjectDialog';
@@ -152,8 +152,7 @@ function TaskName(props: { name: string }) {
   );
 }
 
-function waitingLabel(since: number | null, nowMs: number): string | null {
-  if (since === null) return null;
+function waitingLabel(since: number, nowMs: number): string {
   const seconds = Math.max(0, Math.floor((nowMs - since) / 1_000));
   if (seconds < 60) return 'just now';
   const minutes = Math.floor(seconds / 60);
@@ -183,17 +182,13 @@ function taskAttentionStyles(
   };
 }
 
-/** Open the task and land on the panel the user last worked in, so a pinned
- *  question can be answered without a second click. */
-function jumpToWaitingTask(taskId: string): void {
-  if (store.tasks[taskId]?.collapsed) uncollapseTask(taskId);
-  setActiveTask(taskId);
-  unfocusSidebar();
-  setTaskFocusedPanel(taskId, getTaskFocusedPanel(taskId));
-}
-
 /** One pinned row in the "waiting for you" tray. */
-function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: number }) {
+function NeedsInputRow(props: {
+  taskId: string;
+  since: number;
+  panel: string | null;
+  nowMs: number;
+}) {
   const task = () => store.tasks[props.taskId];
   const project = () => store.projects.find((p) => p.id === task()?.projectId) ?? null;
   const waited = () => waitingLabel(props.since, props.nowMs);
@@ -206,11 +201,11 @@ function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: num
           role="button"
           tabIndex={0}
           title={`${t().name} — waiting for your input`}
-          onClick={() => jumpToWaitingTask(props.taskId)}
+          onClick={() => jumpToWaitingTask(props.taskId, props.panel)}
           onKeyDown={(e) => {
             if (e.key !== 'Enter' && e.key !== ' ') return;
             e.preventDefault();
-            jumpToWaitingTask(props.taskId);
+            jumpToWaitingTask(props.taskId, props.panel);
           }}
           style={{
             display: 'flex',
@@ -230,7 +225,16 @@ function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: num
           }}
         >
           <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
-            <StatusDot status={getTaskDotStatus(props.taskId)} size="sm" attention="needs_input" />
+            {/* The task's real attention state, not a hardcoded `needs_input`:
+                since membership is question-driven, a row here can also be
+                errored or awaiting review, and the dot must not contradict the
+                same task's dot in the list below. The tray header carries the
+                "waiting for you" message on its own. */}
+            <StatusDot
+              status={getTaskDotStatus(props.taskId)}
+              size="sm"
+              attention={getTaskAttentionState(props.taskId)}
+            />
             <TaskName name={t().name} />
           </div>
           {/* Project and elapsed time share the second line so the name gets
@@ -270,14 +274,10 @@ function NeedsInputRow(props: { taskId: string; since: number | null; nowMs: num
                 </>
               )}
             </Show>
-            <Show when={waited()}>
-              {(label) => (
-                <span style={{ color: theme.warning, 'flex-shrink': '0' }}>
-                  {project() ? '· ' : ''}
-                  {label()}
-                </span>
-              )}
-            </Show>
+            <span style={{ color: theme.warning, 'flex-shrink': '0' }}>
+              {project() ? '· ' : ''}
+              {waited()}
+            </span>
           </div>
         </div>
       )}
@@ -318,7 +318,12 @@ function NeedsInputTray(props: { nowMs: number }) {
         </div>
         <For each={entries()}>
           {(entry) => (
-            <NeedsInputRow taskId={entry.taskId} since={entry.since} nowMs={props.nowMs} />
+            <NeedsInputRow
+              taskId={entry.taskId}
+              since={entry.since}
+              panel={entry.panel}
+              nowMs={props.nowMs}
+            />
           )}
         </For>
       </div>

--- a/src/components/StatusDot.test.ts
+++ b/src/components/StatusDot.test.ts
@@ -15,6 +15,12 @@ describe('getDotTooltip', () => {
   it('uses attention state before dot status', () => {
     expect(getDotTooltip('ready', 'needs_input')).toBe('Waiting for input');
   });
+
+  // A review-flagged task whose agent is still active is dot status 'busy' with
+  // attention 'review' — the purple dot must not read "Busy".
+  it('describes review attention over a busy dot status', () => {
+    expect(getDotTooltip('busy', 'review')).toBe('Ready for review');
+  });
 });
 
 describe('StatusDot', () => {

--- a/src/components/StatusDot.tsx
+++ b/src/components/StatusDot.tsx
@@ -31,6 +31,9 @@ export function getDotTooltip(status: TaskDotStatus, attention?: TaskAttentionSt
   if (attention === 'active') return 'Active — agent is working';
   if (attention === 'needs_input') return 'Waiting for input';
   if (attention === 'error') return 'Error — agent exited with an error';
+  // Without this, a review-flagged task whose agent is still active falls
+  // through to the dot-status map and reads "Busy" under a purple dot.
+  if (attention === 'review') return 'Ready for review';
   if (attention === 'ready') return 'Ready to merge';
   return {
     busy: 'Busy — agent recently active',

--- a/src/components/TaskAITerminal.tsx
+++ b/src/components/TaskAITerminal.tsx
@@ -10,6 +10,7 @@ import {
   registerFocusFn,
   unregisterFocusFn,
   setTaskFocusedPanel,
+  aiTerminalPanelId,
   isPanelFocused,
   setActiveAgent,
   setActiveTask,
@@ -35,10 +36,6 @@ import type { Task } from '../store/types';
 import type { AgentDef } from '../ipc/types';
 import type { PromptInputHandle } from './PromptInput';
 import { buildTaskAgentArgs, isResumeArgsFailure } from '../lib/agent-args';
-
-function aiTerminalPanelId(agentId: string): string {
-  return `ai-terminal:${agentId}`;
-}
 
 type StepNavApi = { mark: (i: number) => void; jump: (i: number) => boolean };
 

--- a/src/components/TaskShellSection.tsx
+++ b/src/components/TaskShellSection.tsx
@@ -13,6 +13,7 @@ import {
   unregisterFocusFn,
   setActiveTask,
   setTaskFocusedPanel,
+  shellPanelId,
   isPanelFocused,
   isPanelFocusedPrefix,
 } from '../store/store';
@@ -209,7 +210,7 @@ export function TaskShellSection(props: TaskShellSectionProps) {
               let registeredKey: string | undefined;
 
               createEffect(() => {
-                const key = `${props.task.id}:shell:${i()}`;
+                const key = `${props.task.id}:${shellPanelId(i())}`;
                 if (registeredKey && registeredKey !== key) unregisterFocusFn(registeredKey);
                 if (shellFocusFn) registerFocusFn(key, shellFocusFn);
                 registeredKey = key;
@@ -218,7 +219,7 @@ export function TaskShellSection(props: TaskShellSectionProps) {
                 if (registeredKey) unregisterFocusFn(registeredKey);
               });
 
-              const isShellPanelFocused = () => isPanelFocused(props.task.id, `shell:${i()}`);
+              const isShellPanelFocused = () => isPanelFocused(props.task.id, shellPanelId(i()));
 
               return (
                 <div
@@ -230,7 +231,7 @@ export function TaskShellSection(props: TaskShellSectionProps) {
                     position: 'relative',
                     background: theme.taskPanelBg,
                   }}
-                  onClick={() => setTaskFocusedPanel(props.task.id, `shell:${i()}`)}
+                  onClick={() => setTaskFocusedPanel(props.task.id, shellPanelId(i()))}
                 >
                   <button
                     class="shell-terminal-close"

--- a/src/store/autosave.ts
+++ b/src/store/autosave.ts
@@ -30,6 +30,7 @@ export function persistedSnapshot(): string {
     defaultPropagateSkipPermissions: store.defaultPropagateSkipPermissions,
     showSidebarTips: store.showSidebarTips,
     showSidebarProgress: store.showSidebarProgress,
+    sidebarNeedsInputFirst: store.sidebarNeedsInputFirst,
     projectsCollapsed: store.projectsCollapsed,
     desktopNotificationsEnabled: store.desktopNotificationsEnabled,
     inactiveColumnOpacity: store.inactiveColumnOpacity,

--- a/src/store/core.ts
+++ b/src/store/core.ts
@@ -50,6 +50,7 @@ export const [store, setStore] = createStore<AppStore>({
   showPlans: true,
   showSidebarTips: true,
   showSidebarProgress: true,
+  sidebarNeedsInputFirst: true,
   projectsCollapsed: false,
   desktopNotificationsEnabled: false,
   inactiveColumnOpacity: 0.6,

--- a/src/store/focus.ts
+++ b/src/store/focus.ts
@@ -10,7 +10,9 @@ import {
   defaultPanelFor,
   getTaskFocusedPanel,
   isAiTerminalPanel,
+  isShellPanel,
   setTaskFocusedPanel,
+  shellPanelId,
   triggerFocus,
 } from './focused-panel';
 
@@ -18,6 +20,7 @@ import {
 // importers of './focus' keep working without a cycle through focused-panel.
 export {
   AI_TERMINAL_PANEL,
+  aiTerminalPanelId,
   aiTerminalPanels,
   defaultPanelFor,
   getTaskFocusedPanel,
@@ -25,6 +28,7 @@ export {
   registerFocusFn,
   scrollTaskElementIntoView,
   setTaskFocusedPanel,
+  shellPanelId,
   triggerFocus,
   unregisterFocusFn,
 } from './focused-panel';
@@ -50,17 +54,12 @@ export function triggerAction(key: string): void {
 //    left, changed-files/notes/steps/shell anchor the right, and AI panes are
 //    repeated down the left columns so left/right crossings stay consistent.
 
-const SHELL_PANEL_PREFIX = 'shell:';
 const SHELL_TOOLBAR_PANEL_PREFIX = 'shell-toolbar:';
 
 function shellToolbarPanels(task: { projectId: string }): string[] {
   const bookmarkCount =
     store.projects.find((p) => p.id === task.projectId)?.terminalBookmarks?.length ?? 0;
   return Array.from({ length: 1 + bookmarkCount }, (_, i) => `${SHELL_TOOLBAR_PANEL_PREFIX}${i}`);
-}
-
-function isShellPanel(panel: string): boolean {
-  return panel.startsWith(SHELL_PANEL_PREFIX);
 }
 
 function isShellToolbarPanel(panel: string): boolean {
@@ -80,7 +79,7 @@ function pickTargetTerminalFamilyPanel(
 
   if (isShellPanel(current)) {
     if (targetTask.shellAgentIds.length > 0) {
-      return `${SHELL_PANEL_PREFIX}${edgeIndex(targetTask.shellAgentIds.length, entryEdge)}`;
+      return shellPanelId(edgeIndex(targetTask.shellAgentIds.length, entryEdge));
     }
 
     const toolbarPanels = shellToolbarPanels(targetTask);
@@ -123,7 +122,7 @@ function buildGrid(panelId: string): string[][] {
       const leftBottom = store.showPromptInput ? 'prompt' : aiCols[0];
       if (hasShells) {
         grid.push([...aiCols, ...toolbarCols]);
-        grid.push([leftBottom, ...task.shellAgentIds.map((_, i) => `shell:${i}`)]);
+        grid.push([leftBottom, ...task.shellAgentIds.map((_, i) => shellPanelId(i))]);
       } else {
         grid.push([leftBottom, ...toolbarCols]);
       }
@@ -134,7 +133,7 @@ function buildGrid(panelId: string): string[][] {
     grid.push(['notes', 'changed-files']);
     grid.push(toolbarCols);
     if (task.shellAgentIds.length > 0) {
-      grid.push(task.shellAgentIds.map((_, i) => `shell:${i}`));
+      grid.push(task.shellAgentIds.map((_, i) => shellPanelId(i)));
     }
     grid.push(aiCols);
     if (task.stepsEnabled && task.stepsContent?.length) {

--- a/src/store/focused-panel.ts
+++ b/src/store/focused-panel.ts
@@ -26,11 +26,30 @@ export function aiTerminalPanelId(agentId: string): string {
   return `${AI_TERMINAL_PANEL}:${agentId}`;
 }
 
+/** Shell terminals are addressed by position in the task's `shellAgentIds`. */
+const SHELL_PANEL_PREFIX = 'shell:';
+
+export function shellPanelId(index: number): string {
+  return `${SHELL_PANEL_PREFIX}${index}`;
+}
+
+export function isShellPanel(panel: string): boolean {
+  return panel.startsWith(SHELL_PANEL_PREFIX);
+}
+
+export function shellPanelIndex(panel: string): number | null {
+  if (!panel.startsWith(SHELL_PANEL_PREFIX)) return null;
+  // Digits only — `Number('')` is 0 and `Number('1e2')` is 100, so a bare
+  // `shell:` or an exponent would otherwise parse as a real panel index.
+  const rest = panel.slice(SHELL_PANEL_PREFIX.length);
+  return /^\d+$/.test(rest) ? Number(rest) : null;
+}
+
 export function isAiTerminalPanel(panel: string): boolean {
   return panel === AI_TERMINAL_PANEL || panel.startsWith(`${AI_TERMINAL_PANEL}:`);
 }
 
-function agentIdFromAiTerminalPanel(panel: string): string | null {
+export function agentIdFromAiTerminalPanel(panel: string): string | null {
   return panel.startsWith(`${AI_TERMINAL_PANEL}:`)
     ? panel.slice(AI_TERMINAL_PANEL.length + 1)
     : null;

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -191,6 +191,7 @@ export async function saveState(): Promise<void> {
     showPlans: store.showPlans,
     showSidebarTips: store.showSidebarTips,
     showSidebarProgress: store.showSidebarProgress,
+    sidebarNeedsInputFirst: store.sidebarNeedsInputFirst,
     projectsCollapsed: store.projectsCollapsed,
     desktopNotificationsEnabled: store.desktopNotificationsEnabled,
     inactiveColumnOpacity: store.inactiveColumnOpacity,
@@ -360,6 +361,7 @@ interface LegacyPersistedState {
   showSteps?: unknown;
   showSidebarTips?: unknown;
   showSidebarProgress?: unknown;
+  sidebarNeedsInputFirst?: unknown;
   projectsCollapsed?: unknown;
   desktopNotificationsEnabled?: unknown;
   inactiveColumnOpacity?: unknown;
@@ -506,6 +508,8 @@ export async function loadState(): Promise<void> {
       s.showSidebarTips = typeof raw.showSidebarTips === 'boolean' ? raw.showSidebarTips : true;
       s.showSidebarProgress =
         typeof raw.showSidebarProgress === 'boolean' ? raw.showSidebarProgress : true;
+      s.sidebarNeedsInputFirst =
+        typeof raw.sidebarNeedsInputFirst === 'boolean' ? raw.sidebarNeedsInputFirst : true;
       s.projectsCollapsed =
         typeof raw.projectsCollapsed === 'boolean' ? raw.projectsCollapsed : false;
       s.desktopNotificationsEnabled =

--- a/src/store/sidebar-attention.test.ts
+++ b/src/store/sidebar-attention.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { expectDefined, type MockStoreHarness } from './test-helpers';
-import type { TaskAttentionState } from './taskStatus';
+import type { TaskOpenQuestion } from './taskStatus';
+
+type MockTask = { agentIds?: string[]; shellAgentIds?: string[]; collapsed?: boolean };
 
 type MockStore = {
-  tasks: Record<string, object>;
+  tasks: Record<string, MockTask>;
   taskOrder: string[];
   collapsedTaskOrder: string[];
 };
@@ -13,8 +15,7 @@ const core = vi.hoisted(() => ({
 }));
 
 const status = vi.hoisted(() => ({
-  attention: new Map<string, string>(),
-  since: new Map<string, number>(),
+  questions: new Map<string, TaskOpenQuestion>(),
 }));
 
 vi.mock('./core', async () => {
@@ -28,60 +29,230 @@ vi.mock('./core', async () => {
 });
 
 vi.mock('./taskStatus', () => ({
-  getTaskAttentionState: (taskId: string) =>
-    (status.attention.get(taskId) ?? 'idle') as TaskAttentionState,
-  getTaskQuestionSince: (taskId: string) => status.since.get(taskId) ?? null,
+  getTaskOpenQuestion: (taskId: string) => status.questions.get(taskId) ?? null,
 }));
 
-import { computeNeedsInputTasks } from './sidebar-attention';
+// Panel id construction stays real — the tests assert on the ids themselves —
+// while the focus side effects are spied so `jumpToWaitingTask` is observable.
+const nav = vi.hoisted(() => ({
+  setTaskFocusedPanel: vi.fn(),
+  getTaskFocusedPanel: vi.fn(() => 'ai-terminal:last-focused'),
+  setActiveTask: vi.fn(),
+  unfocusSidebar: vi.fn(),
+  uncollapseTask: vi.fn(),
+}));
+
+vi.mock('./focused-panel', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('./focused-panel');
+  return {
+    ...actual,
+    setTaskFocusedPanel: nav.setTaskFocusedPanel,
+    getTaskFocusedPanel: nav.getTaskFocusedPanel,
+  };
+});
+vi.mock('./navigation', () => ({ setActiveTask: nav.setActiveTask }));
+vi.mock('./focus', () => ({ unfocusSidebar: nav.unfocusSidebar }));
+vi.mock('./tasks', () => ({ uncollapseTask: nav.uncollapseTask }));
+
+import { computeNeedsInputTasks, jumpToWaitingTask } from './sidebar-attention';
+import { shellPanelId, shellPanelIndex } from './focused-panel';
 
 let mockStore: MockStore;
 
 beforeEach(() => {
   const harness = expectDefined(core.harness, 'mock store harness');
   mockStore = harness.reset({ tasks: {}, taskOrder: [], collapsedTaskOrder: [] });
-  status.attention.clear();
-  status.since.clear();
+  status.questions.clear();
+  for (const fn of Object.values(nav)) fn.mockClear();
 });
+
+/** Register a task plus the question its agent is asking, in one step. */
+function askingTask(taskId: string, task: MockTask, question: TaskOpenQuestion | null): void {
+  mockStore.tasks[taskId] = { agentIds: [], shellAgentIds: [], ...task };
+  if (question) status.questions.set(taskId, question);
+}
 
 describe('computeNeedsInputTasks', () => {
   it('returns only tasks waiting on an answer, newest question first', () => {
     mockStore.taskOrder = ['task-1', 'task-2', 'task-3'];
-    mockStore.tasks = { 'task-1': {}, 'task-2': {}, 'task-3': {} };
-    status.attention.set('task-1', 'needs_input');
-    status.attention.set('task-2', 'active');
-    status.attention.set('task-3', 'needs_input');
-    status.since.set('task-1', 1_000);
-    status.since.set('task-3', 5_000);
+    askingTask('task-1', { agentIds: ['agent-1'] }, { agentId: 'agent-1', since: 1_000 });
+    askingTask('task-2', { agentIds: ['agent-2'] }, null);
+    askingTask('task-3', { agentIds: ['agent-3'] }, { agentId: 'agent-3', since: 5_000 });
 
     expect(computeNeedsInputTasks()).toEqual([
-      { taskId: 'task-3', since: 5_000 },
-      { taskId: 'task-1', since: 1_000 },
+      { taskId: 'task-3', since: 5_000, panel: 'ai-terminal:agent-3' },
+      { taskId: 'task-1', since: 1_000, panel: 'ai-terminal:agent-1' },
     ]);
   });
 
-  it('includes collapsed tasks and sinks unknown timestamps to the bottom', () => {
+  // The collapsed sweep is inert in the real app (collapsing kills the agents),
+  // so this pins the sweep itself rather than a state a user can reach.
+  it('sweeps collapsed order too, keeping newest-first across both lists', () => {
     mockStore.taskOrder = ['task-1'];
     mockStore.collapsedTaskOrder = ['task-2'];
-    mockStore.tasks = { 'task-1': {}, 'task-2': {} };
-    status.attention.set('task-1', 'needs_input');
-    status.attention.set('task-2', 'needs_input');
-    status.since.set('task-2', 9_000);
+    askingTask('task-1', { agentIds: ['agent-1'] }, { agentId: 'agent-1', since: 1_000 });
+    askingTask('task-2', { agentIds: ['agent-2'] }, { agentId: 'agent-2', since: 9_000 });
 
     expect(computeNeedsInputTasks()).toEqual([
-      { taskId: 'task-2', since: 9_000 },
-      { taskId: 'task-1', since: null },
+      { taskId: 'task-2', since: 9_000, panel: 'ai-terminal:agent-2' },
+      { taskId: 'task-1', since: 1_000, panel: 'ai-terminal:agent-1' },
     ]);
   });
 
   it('skips ids with no task and never lists a task twice', () => {
     mockStore.taskOrder = ['task-1', 'ghost'];
     mockStore.collapsedTaskOrder = ['task-1'];
-    mockStore.tasks = { 'task-1': {} };
-    status.attention.set('task-1', 'needs_input');
-    status.attention.set('ghost', 'needs_input');
-    status.since.set('task-1', 42);
+    askingTask('task-1', { agentIds: ['agent-1'] }, { agentId: 'agent-1', since: 42 });
+    status.questions.set('ghost', { agentId: 'ghost-agent', since: 99 });
 
-    expect(computeNeedsInputTasks()).toEqual([{ taskId: 'task-1', since: 42 }]);
+    expect(computeNeedsInputTasks()).toEqual([
+      { taskId: 'task-1', since: 42, panel: 'ai-terminal:agent-1' },
+    ]);
+  });
+
+  // `getTaskOpenQuestion` is mocked here, so these pin `panelForAskingAgent`'s
+  // resolution, not the error/review masking — that regression is covered for
+  // real against the live question detector in taskStatus.test.ts.
+  it('resolves the panel of an asker that is not the first agent', () => {
+    mockStore.taskOrder = ['task-1'];
+    askingTask(
+      'task-1',
+      { agentIds: ['agent-first', 'agent-asking'] },
+      { agentId: 'agent-asking', since: 7_000 },
+    );
+
+    expect(computeNeedsInputTasks()).toEqual([
+      { taskId: 'task-1', since: 7_000, panel: 'ai-terminal:agent-asking' },
+    ]);
+  });
+
+  it('targets the asking shell by its panel index', () => {
+    mockStore.taskOrder = ['task-1'];
+    askingTask(
+      'task-1',
+      { agentIds: ['agent-1'], shellAgentIds: ['shell-a', 'shell-b'] },
+      { agentId: 'shell-b', since: 3_000 },
+    );
+
+    expect(computeNeedsInputTasks()[0].panel).toBe('shell:1');
+  });
+
+  // Guard, not a reachable state: the real `getTaskOpenQuestion` draws its
+  // agent from the same two arrays `panelForAskingAgent` searches, so the panel
+  // always resolves. Pinned so an unplaceable agent degrades to a listed row
+  // rather than a dropped question.
+  it('degrades to a listed row when the asking agent cannot be placed', () => {
+    mockStore.taskOrder = ['task-1'];
+    askingTask('task-1', { agentIds: ['agent-1'] }, { agentId: 'agent-gone', since: 3_000 });
+
+    expect(computeNeedsInputTasks()).toEqual([{ taskId: 'task-1', since: 3_000, panel: null }]);
+  });
+});
+
+describe('jumpToWaitingTask', () => {
+  it('focuses the asking AI terminal rather than the last focused panel', () => {
+    askingTask('task-1', { agentIds: ['agent-1', 'agent-2'] }, null);
+
+    jumpToWaitingTask('task-1', 'ai-terminal:agent-2');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'ai-terminal:agent-2');
+    expect(nav.getTaskFocusedPanel).not.toHaveBeenCalled();
+  });
+
+  it('focuses the asking shell by its panel index', () => {
+    askingTask('task-1', { agentIds: ['agent-1'], shellAgentIds: ['shell-a', 'shell-b'] }, null);
+
+    jumpToWaitingTask('task-1', 'shell:1');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'shell:1');
+  });
+
+  it('falls back to the last focused panel when the asking agent has no panel', () => {
+    askingTask('task-1', { agentIds: ['agent-1'] }, null);
+
+    jumpToWaitingTask('task-1', null);
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'ai-terminal:last-focused');
+  });
+
+  it('selects the task before focusing the panel, so the asking tab wins', () => {
+    // `setActiveTask` derives its own agent from the recorded focused panel, so
+    // focusing last is what brings a non-selected agent's tab to the front.
+    askingTask('task-1', { agentIds: ['agent-1', 'agent-2'] }, null);
+
+    jumpToWaitingTask('task-1', 'ai-terminal:agent-2');
+
+    const selected = nav.setActiveTask.mock.invocationCallOrder[0];
+    const focused = nav.setTaskFocusedPanel.mock.invocationCallOrder[0];
+    expect(selected).toBeLessThan(focused);
+  });
+
+  it('uncollapses a collapsed task before opening it', () => {
+    askingTask('task-1', { agentIds: ['agent-1'], collapsed: true }, null);
+
+    jumpToWaitingTask('task-1', 'ai-terminal:agent-1');
+
+    expect(nav.uncollapseTask).toHaveBeenCalledWith('task-1');
+    expect(nav.unfocusSidebar).toHaveBeenCalled();
+  });
+
+  it('leaves an expanded task alone', () => {
+    askingTask('task-1', { agentIds: ['agent-1'] }, null);
+
+    jumpToWaitingTask('task-1', 'ai-terminal:agent-1');
+
+    expect(nav.uncollapseTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('jumpToWaitingTask panel validation', () => {
+  // Unreachable today, but this is the one guard that would fail hard rather
+  // than degrade: `uncollapseTask` mints fresh agent ids, so a panel captured
+  // before an uncollapse names an agent that no longer exists.
+  it('falls back when the panel names an agent the task no longer has', () => {
+    askingTask('task-1', { agentIds: ['agent-1'] }, null);
+
+    jumpToWaitingTask('task-1', 'ai-terminal:agent-gone');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'ai-terminal:last-focused');
+  });
+
+  it('falls back when the shell index is out of range', () => {
+    askingTask('task-1', { agentIds: ['agent-1'], shellAgentIds: ['shell-a'] }, null);
+
+    jumpToWaitingTask('task-1', 'shell:3');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'ai-terminal:last-focused');
+  });
+
+  it('keeps a non-terminal panel as-is', () => {
+    askingTask('task-1', { agentIds: ['agent-1'] }, null);
+
+    jumpToWaitingTask('task-1', 'notes');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'notes');
+  });
+});
+
+describe('shell panel id parsing', () => {
+  it('round-trips a built id', () => {
+    expect(shellPanelIndex(shellPanelId(3))).toBe(3);
+  });
+
+  // `Number('')` is 0 and `Number('1e2')` is 100, so a loose parse would let
+  // these validate as real panels in `panelIsLive`.
+  it.each(['shell:', 'shell:1e2', 'shell:-0', 'shell:1.5', 'shell: 1', 'ai-terminal:a'])(
+    'rejects %s',
+    (panel) => {
+      expect(shellPanelIndex(panel)).toBeNull();
+    },
+  );
+
+  it('falls back rather than focusing a malformed shell panel', () => {
+    askingTask('task-1', { agentIds: ['agent-1'], shellAgentIds: ['shell-a'] }, null);
+
+    jumpToWaitingTask('task-1', 'shell:');
+
+    expect(nav.setTaskFocusedPanel).toHaveBeenCalledWith('task-1', 'ai-terminal:last-focused');
   });
 });

--- a/src/store/sidebar-attention.test.ts
+++ b/src/store/sidebar-attention.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { expectDefined, type MockStoreHarness } from './test-helpers';
+import type { TaskAttentionState } from './taskStatus';
+
+type MockStore = {
+  tasks: Record<string, object>;
+  taskOrder: string[];
+  collapsedTaskOrder: string[];
+};
+
+const core = vi.hoisted(() => ({
+  harness: undefined as MockStoreHarness<MockStore> | undefined,
+}));
+
+const status = vi.hoisted(() => ({
+  attention: new Map<string, string>(),
+  since: new Map<string, number>(),
+}));
+
+vi.mock('./core', async () => {
+  const { createMockStoreHarness } = await import('./test-helpers');
+  core.harness = createMockStoreHarness<MockStore>({
+    tasks: {},
+    taskOrder: [],
+    collapsedTaskOrder: [],
+  });
+  return core.harness.moduleMock();
+});
+
+vi.mock('./taskStatus', () => ({
+  getTaskAttentionState: (taskId: string) =>
+    (status.attention.get(taskId) ?? 'idle') as TaskAttentionState,
+  getTaskQuestionSince: (taskId: string) => status.since.get(taskId) ?? null,
+}));
+
+import { computeNeedsInputTasks } from './sidebar-attention';
+
+let mockStore: MockStore;
+
+beforeEach(() => {
+  const harness = expectDefined(core.harness, 'mock store harness');
+  mockStore = harness.reset({ tasks: {}, taskOrder: [], collapsedTaskOrder: [] });
+  status.attention.clear();
+  status.since.clear();
+});
+
+describe('computeNeedsInputTasks', () => {
+  it('returns only tasks waiting on an answer, newest question first', () => {
+    mockStore.taskOrder = ['task-1', 'task-2', 'task-3'];
+    mockStore.tasks = { 'task-1': {}, 'task-2': {}, 'task-3': {} };
+    status.attention.set('task-1', 'needs_input');
+    status.attention.set('task-2', 'active');
+    status.attention.set('task-3', 'needs_input');
+    status.since.set('task-1', 1_000);
+    status.since.set('task-3', 5_000);
+
+    expect(computeNeedsInputTasks()).toEqual([
+      { taskId: 'task-3', since: 5_000 },
+      { taskId: 'task-1', since: 1_000 },
+    ]);
+  });
+
+  it('includes collapsed tasks and sinks unknown timestamps to the bottom', () => {
+    mockStore.taskOrder = ['task-1'];
+    mockStore.collapsedTaskOrder = ['task-2'];
+    mockStore.tasks = { 'task-1': {}, 'task-2': {} };
+    status.attention.set('task-1', 'needs_input');
+    status.attention.set('task-2', 'needs_input');
+    status.since.set('task-2', 9_000);
+
+    expect(computeNeedsInputTasks()).toEqual([
+      { taskId: 'task-2', since: 9_000 },
+      { taskId: 'task-1', since: null },
+    ]);
+  });
+
+  it('skips ids with no task and never lists a task twice', () => {
+    mockStore.taskOrder = ['task-1', 'ghost'];
+    mockStore.collapsedTaskOrder = ['task-1'];
+    mockStore.tasks = { 'task-1': {} };
+    status.attention.set('task-1', 'needs_input');
+    status.attention.set('ghost', 'needs_input');
+    status.since.set('task-1', 42);
+
+    expect(computeNeedsInputTasks()).toEqual([{ taskId: 'task-1', since: 42 }]);
+  });
+});

--- a/src/store/sidebar-attention.ts
+++ b/src/store/sidebar-attention.ts
@@ -1,0 +1,28 @@
+import { store } from './core';
+import { getTaskAttentionState, getTaskQuestionSince } from './taskStatus';
+
+export interface NeedsInputEntry {
+  taskId: string;
+  /** When the question appeared (epoch ms), or null when unknown. */
+  since: number | null;
+}
+
+/** Tasks currently blocked on a human answer, newest question first.
+ *
+ *  Collapsed tasks are included on purpose — a minimized task that starts
+ *  asking is exactly the one that's easy to miss. Tasks with no recorded
+ *  timestamp sink to the bottom in sidebar order (Array#sort is stable). */
+export function computeNeedsInputTasks(): NeedsInputEntry[] {
+  const entries: NeedsInputEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const taskId of [...store.taskOrder, ...store.collapsedTaskOrder]) {
+    if (seen.has(taskId)) continue;
+    seen.add(taskId);
+    if (!store.tasks[taskId]) continue;
+    if (getTaskAttentionState(taskId) !== 'needs_input') continue;
+    entries.push({ taskId, since: getTaskQuestionSince(taskId) });
+  }
+
+  return entries.sort((a, b) => (b.since ?? 0) - (a.since ?? 0));
+}

--- a/src/store/sidebar-attention.ts
+++ b/src/store/sidebar-attention.ts
@@ -1,17 +1,55 @@
+import { batch } from 'solid-js';
 import { store } from './core';
-import { getTaskAttentionState, getTaskQuestionSince } from './taskStatus';
+import { unfocusSidebar } from './focus';
+import {
+  agentIdFromAiTerminalPanel,
+  aiTerminalPanelId,
+  getTaskFocusedPanel,
+  isShellPanel,
+  setTaskFocusedPanel,
+  shellPanelId,
+  shellPanelIndex,
+} from './focused-panel';
+import { setActiveTask } from './navigation';
+import { uncollapseTask } from './tasks';
+import { getTaskOpenQuestion } from './taskStatus';
 
 export interface NeedsInputEntry {
   taskId: string;
-  /** When the question appeared (epoch ms), or null when unknown. */
-  since: number | null;
+  /** When the *newest* open question in the task appeared (epoch ms) — not how
+   *  long the task has been waiting overall. With several agents asking, an
+   *  older unanswered question is not what the row's elapsed label reports. */
+  since: number;
+  /** The panel that is actually asking — `ai-terminal:<agentId>` or
+   *  `shell:<index>` — so opening the row lands on it. Null only if the asking
+   *  agent could not be placed — a guard, not reachable today (see
+   *  `panelForAskingAgent`); the row is still listed, minus the shortcut. */
+  panel: string | null;
+}
+
+/** Which panel hosts the asking agent. AI agents are addressed by id; shells by
+ *  their position in `shellAgentIds`, matching the rest of the panel grid.
+ *
+ *  The null return is belt-and-braces: the asking agent came from these same
+ *  two arrays a moment earlier, so today it always resolves. */
+function panelForAskingAgent(taskId: string, agentId: string): string | null {
+  const task = store.tasks[taskId];
+  if (!task) return null;
+  if (task.agentIds.includes(agentId)) return aiTerminalPanelId(agentId);
+  const shellIndex = task.shellAgentIds.indexOf(agentId);
+  return shellIndex >= 0 ? shellPanelId(shellIndex) : null;
 }
 
 /** Tasks currently blocked on a human answer, newest question first.
  *
- *  Collapsed tasks are included on purpose — a minimized task that starts
- *  asking is exactly the one that's easy to miss. Tasks with no recorded
- *  timestamp sink to the bottom in sidebar order (Array#sort is stable). */
+ *  Membership comes from open-question state directly, not from the task's
+ *  prioritized attention state: a task showing `error` or `review` can still
+ *  have another agent waiting on an answer, and dropping it here would strand
+ *  the question.
+ *
+ *  The `collapsedTaskOrder` sweep yields nothing today — `collapseTask` kills
+ *  every agent and clears its question state — and is kept only so the tray
+ *  keeps working if collapsing ever stops tearing agents down. */
 export function computeNeedsInputTasks(): NeedsInputEntry[] {
   const entries: NeedsInputEntry[] = [];
   const seen = new Set<string>();
@@ -20,9 +58,57 @@ export function computeNeedsInputTasks(): NeedsInputEntry[] {
     if (seen.has(taskId)) continue;
     seen.add(taskId);
     if (!store.tasks[taskId]) continue;
-    if (getTaskAttentionState(taskId) !== 'needs_input') continue;
-    entries.push({ taskId, since: getTaskQuestionSince(taskId) });
+    const question = getTaskOpenQuestion(taskId);
+    if (!question) continue;
+    entries.push({
+      taskId,
+      since: question.since,
+      panel: panelForAskingAgent(taskId, question.agentId),
+    });
   }
 
-  return entries.sort((a, b) => (b.since ?? 0) - (a.since ?? 0));
+  return entries.sort((a, b) => b.since - a.since);
+}
+
+/** Whether the panel still names something the task actually has. Checked at
+ *  jump time rather than trusting the entry: `uncollapseTask` mints fresh agent
+ *  ids, so a panel captured before an uncollapse can name an agent that is gone,
+ *  and focusing it would record a dead panel and fire no focus callback at all —
+ *  the task would open with nothing focused instead of falling back. */
+function panelIsLive(taskId: string, panel: string): boolean {
+  const task = store.tasks[taskId];
+  if (!task) return false;
+  const agentId = agentIdFromAiTerminalPanel(panel);
+  if (agentId !== null) return task.agentIds.includes(agentId);
+  // Test the prefix, not the parse: a malformed `shell:` must be rejected
+  // rather than waved through as some other kind of panel.
+  if (isShellPanel(panel)) {
+    const shellIndex = shellPanelIndex(panel);
+    return shellIndex !== null && shellIndex < task.shellAgentIds.length;
+  }
+  return true;
+}
+
+/** Open a tray row's task and land on the panel that is actually asking, so the
+ *  question can be answered without a second click. `setTaskFocusedPanel`
+ *  selects the agent behind an `ai-terminal:<id>` panel, which brings a
+ *  non-selected agent's tab to the front — hence the ordering here: it must run
+ *  after `setActiveTask`, which would otherwise pick its own agent. `batch`
+ *  keeps that intermediate state off screen: `setActiveTask` resolves its agent
+ *  from the *previously* focused panel, so without it the old tab would render
+ *  as selected for a frame before the asking one takes over.
+ *
+ *  Falls back to the last focused panel when the asking agent could not be
+ *  placed (see `panelForAskingAgent`) or no longer exists. Neither is reachable
+ *  today; the uncollapse likewise mirrors the inert collapsed sweep in
+ *  `computeNeedsInputTasks` and is kept in step with it. */
+export function jumpToWaitingTask(taskId: string, panel: string | null): void {
+  batch(() => {
+    if (store.tasks[taskId]?.collapsed) uncollapseTask(taskId);
+    setActiveTask(taskId);
+    unfocusSidebar();
+    const target =
+      panel !== null && panelIsLive(taskId, panel) ? panel : getTaskFocusedPanel(taskId);
+    setTaskFocusedPanel(taskId, target);
+  });
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -129,6 +129,7 @@ export {
   setShowPromptInput,
   setShowSidebarTips,
   setShowSidebarProgress,
+  setSidebarNeedsInputFirst,
   setProjectsCollapsed,
   setFontSmoothing,
   setDesktopNotificationsEnabled,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -86,6 +86,8 @@ export {
   triggerAction,
   getTaskFocusedPanel,
   setTaskFocusedPanel,
+  aiTerminalPanelId,
+  shellPanelId,
   isPanelFocused,
   isPanelFocusedPrefix,
   focusSidebar,

--- a/src/store/taskStatus.test.ts
+++ b/src/store/taskStatus.test.ts
@@ -92,6 +92,7 @@ import {
   isAgentAskingQuestion,
   isAgentBracketedPasteEnabled,
   getTaskAttentionState,
+  getTaskOpenQuestion,
   getTaskDotStatus,
   taskNeedsAttention,
   markAgentSpawned,
@@ -899,6 +900,76 @@ describe('task attention state', () => {
     markAgentOutput('agent-1', new TextEncoder().encode('\r❯\ropus · /x · ctx:1k/200k'), 'task-1');
 
     expect(isAgentAskingQuestion('agent-1')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// open questions (independent of the prioritized attention state)
+// ---------------------------------------------------------------------------
+describe('getTaskOpenQuestion', () => {
+  it('returns null when nothing in the task is asking', () => {
+    setMockTask('task-1', { agentIds: ['agent-1'] });
+    setMockAgent('agent-1', { status: 'running' });
+
+    expect(getTaskOpenQuestion('task-1')).toBeNull();
+  });
+
+  it('reports the question even when another agent in the task exited non-zero', () => {
+    setMockTask('task-1', { agentIds: ['agent-1', 'agent-2'] });
+    setMockAgent('agent-1', { status: 'exited', exitCode: 1, signal: null });
+    setMockAgent('agent-2', { status: 'running' });
+
+    markAgentOutput('agent-2', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+
+    // The prioritized display status hides the question behind the failure...
+    expect(getTaskAttentionState('task-1')).toBe('error');
+    // ...but a human answer is still owed, so callers must be able to see it.
+    expect(getTaskOpenQuestion('task-1')?.agentId).toBe('agent-2');
+  });
+
+  it('reports the question even when the task is flagged for review', () => {
+    setMockTask('task-1', { agentIds: ['agent-1'], needsReview: true });
+    setMockAgent('agent-1', { status: 'running' });
+
+    markAgentOutput('agent-1', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+
+    expect(getTaskAttentionState('task-1')).toBe('review');
+    expect(getTaskOpenQuestion('task-1')?.agentId).toBe('agent-1');
+  });
+
+  it('returns the newest question when several agents are asking', () => {
+    setMockTask('task-1', { agentIds: ['agent-1', 'agent-2'] });
+    setMockAgent('agent-1', { status: 'running' });
+    setMockAgent('agent-2', { status: 'running' });
+
+    markAgentOutput('agent-1', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+    const first = expectDefined(getTaskOpenQuestion('task-1')).since;
+    vi.advanceTimersByTime(5_000);
+    markAgentOutput('agent-2', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+
+    const newest = expectDefined(getTaskOpenQuestion('task-1'));
+    expect(newest.agentId).toBe('agent-2');
+    expect(newest.since).toBe(first + 5_000);
+  });
+
+  it('reports a question coming from a task shell', () => {
+    setMockTask('task-1', { agentIds: [], shellAgentIds: ['shell-1'] });
+
+    markAgentOutput('shell-1', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+
+    expect(getTaskOpenQuestion('task-1')?.agentId).toBe('shell-1');
+  });
+
+  it('ignores a question left behind by an agent that is no longer running', () => {
+    setMockTask('task-1', { agentIds: ['agent-1'] });
+    setMockAgent('agent-1', { status: 'running' });
+
+    markAgentOutput('agent-1', new TextEncoder().encode('Continue? [Y/n]'), 'task-1');
+    expect(getTaskOpenQuestion('task-1')).not.toBeNull();
+
+    setMockAgent('agent-1', { status: 'exited', exitCode: 0, signal: null });
+
+    expect(getTaskOpenQuestion('task-1')).toBeNull();
   });
 });
 

--- a/src/store/taskStatus.ts
+++ b/src/store/taskStatus.ts
@@ -465,20 +465,38 @@ function updateQuestionState(agentId: string, hasQuestion: boolean): void {
   setQuestionAgents(next);
 }
 
-/** When this task's newest open question appeared (epoch ms), or null when
- *  nothing in the task is asking. Mirrors the agent set `getTaskAttentionState`
- *  reads, so a `needs_input` task always has a timestamp. */
-export function getTaskQuestionSince(taskId: string): number | null {
+export interface TaskOpenQuestion {
+  /** The agent whose terminal is showing the question. */
+  agentId: string;
+  /** When the question appeared (epoch ms). */
+  since: number;
+}
+
+/** This task's newest open question — who is asking and since when — or null
+ *  when nothing in the task is asking.
+ *
+ *  Deliberately independent of `getTaskAttentionState`: that function reports a
+ *  single prioritized status, so an exited-non-zero agent (`error`) or a review
+ *  flag hides a question another agent is still blocked on. The sidebar tray
+ *  reads this instead. The desktop-notification watcher and `remoteStatusSync`
+ *  still classify `needs_input` from the attention state and so inherit that
+ *  masking — knowingly unconverted, since changing when a notification fires is
+ *  a product decision, not a mechanical follow-through. */
+export function getTaskOpenQuestion(taskId: string): TaskOpenQuestion | null {
   const asking = questionAgents(); // reactive read
   const task = store.tasks[taskId];
   if (!task) return null;
 
-  let newest: number | null = null;
+  let newest: TaskOpenQuestion | null = null;
   const runningAgentIds = task.agentIds.filter((id) => store.agents[id]?.status === 'running');
   for (const agentId of [...runningAgentIds, ...task.shellAgentIds]) {
     if (!asking.has(agentId)) continue;
+    // The asking set and the onset map are separate structures kept in step by
+    // `updateQuestionState`, their sole writer. This is the one place they meet,
+    // so it is the one place that has to tolerate them drifting apart.
     const since = questionSinceByAgent.get(agentId);
-    if (since !== undefined && (newest === null || since > newest)) newest = since;
+    if (since === undefined) continue;
+    if (newest === null || since > newest.since) newest = { agentId, since };
   }
   return newest;
 }

--- a/src/store/taskStatus.ts
+++ b/src/store/taskStatus.ts
@@ -1,4 +1,4 @@
-import { createSignal } from 'solid-js';
+import { createSignal, untrack } from 'solid-js';
 import { invoke } from '../lib/ipc';
 import { IPC } from '../../electron/ipc/channels';
 import { store, setStore } from './core';
@@ -446,14 +446,41 @@ export function isAgentBracketedPasteEnabled(agentId: string): boolean {
   return agentStates.get(agentId)?.bracketedPasteEnabled === true;
 }
 
+// When each agent's current question first appeared (epoch ms). Cleared as soon
+// as the question goes away, so an entry only ever describes the open question.
+const questionSinceByAgent = new Map<string, number>();
+
 function updateQuestionState(agentId: string, hasQuestion: boolean): void {
-  setQuestionAgents((prev) => {
-    if (hasQuestion === prev.has(agentId)) return prev;
-    const next = new Set(prev);
-    if (hasQuestion) next.add(agentId);
-    else next.delete(agentId);
-    return next;
-  });
+  const asking = untrack(questionAgents);
+  if (hasQuestion === asking.has(agentId)) return;
+
+  const next = new Set(asking);
+  if (hasQuestion) {
+    next.add(agentId);
+    questionSinceByAgent.set(agentId, Date.now());
+  } else {
+    next.delete(agentId);
+    questionSinceByAgent.delete(agentId);
+  }
+  setQuestionAgents(next);
+}
+
+/** When this task's newest open question appeared (epoch ms), or null when
+ *  nothing in the task is asking. Mirrors the agent set `getTaskAttentionState`
+ *  reads, so a `needs_input` task always has a timestamp. */
+export function getTaskQuestionSince(taskId: string): number | null {
+  const asking = questionAgents(); // reactive read
+  const task = store.tasks[taskId];
+  if (!task) return null;
+
+  let newest: number | null = null;
+  const runningAgentIds = task.agentIds.filter((id) => store.agents[id]?.status === 'running');
+  for (const agentId of [...runningAgentIds, ...task.shellAgentIds]) {
+    if (!asking.has(agentId)) continue;
+    const since = questionSinceByAgent.get(agentId);
+    if (since !== undefined && (newest === null || since > newest)) newest = since;
+  }
+  return newest;
 }
 
 // --- Agent activity tracking ---

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -4,7 +4,7 @@ import { IPC } from '../../electron/ipc/channels';
 import { store, setStore, cleanupPanelEntries } from './core';
 import { effectiveAgentId } from './agent-select';
 import { saveState } from './persistence';
-import { setTaskFocusedPanel } from './focused-panel';
+import { setTaskFocusedPanel, shellPanelId } from './focused-panel';
 import { getProject, getProjectPath, getProjectBranchPrefix, isProjectMissing } from './projects';
 import { setPendingShellCommand } from '../lib/bookmarks';
 import {
@@ -872,7 +872,7 @@ export function runBookmarkInTask(taskId: string, command: string): void {
     if (isAgentIdle(shellId)) {
       // Mark busy immediately so rapid clicks don't reuse the same shell.
       markAgentBusy(shellId);
-      setTaskFocusedPanel(taskId, `shell:${i}`);
+      setTaskFocusedPanel(taskId, shellPanelId(i));
       invoke(IPC.WriteToAgent, { agentId: shellId, data: command + '\r' }).catch((err) => {
         logWarn('tasks.shell', 'WriteToAgent failed; falling back to spawnShell', { err });
         spawnShellForTask(taskId, command);
@@ -906,7 +906,7 @@ export async function closeShell(taskId: string, shellId: string): Promise<void>
       setTaskFocusedPanel(taskId, 'shell-toolbar:0');
     } else {
       const focusIndex = Math.min(closedIndex, remaining - 1);
-      setTaskFocusedPanel(taskId, `shell:${focusIndex}`);
+      setTaskFocusedPanel(taskId, shellPanelId(focusIndex));
     }
   }
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -257,6 +257,7 @@ export interface PersistedState {
   showPlans?: boolean;
   showSidebarTips?: boolean;
   showSidebarProgress?: boolean;
+  sidebarNeedsInputFirst?: boolean;
   projectsCollapsed?: boolean;
   desktopNotificationsEnabled?: boolean;
   inactiveColumnOpacity?: number;
@@ -354,6 +355,9 @@ export interface AppStore {
   showPlans: boolean;
   showSidebarTips: boolean;
   showSidebarProgress: boolean;
+  /** Pin tasks that are waiting on an answer to the top of the sidebar task
+   *  list, newest question first. */
+  sidebarNeedsInputFirst: boolean;
   projectsCollapsed: boolean;
   desktopNotificationsEnabled: boolean;
   inactiveColumnOpacity: number;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -166,6 +166,10 @@ export function setShowSidebarProgress(show: boolean): void {
   setStore('showSidebarProgress', show);
 }
 
+export function setSidebarNeedsInputFirst(enabled: boolean): void {
+  setStore('sidebarNeedsInputFirst', enabled);
+}
+
 export function setProjectsCollapsed(collapsed: boolean): void {
   batch(() => {
     setStore('projectsCollapsed', collapsed);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1033,6 +1033,46 @@ textarea::placeholder {
   color: var(--fg) !important;
 }
 
+/* Task names wrap to two lines rather than being cut mid-word — at sidebar
+   widths, similar names are otherwise indistinguishable. */
+.task-item-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
+.sidebar-attention-tray {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+  max-height: 32vh;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--warning) 32%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--warning) 7%, transparent);
+}
+
+.sidebar-attention-tray-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 0 2px 2px;
+}
+
+.sidebar-attention-row + .sidebar-attention-row {
+  border-top: 1px solid color-mix(in srgb, var(--warning) 16%, transparent);
+}
+
 .sidebar-offscreen-attention-badge {
   display: inline-flex;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1421,15 +1421,15 @@ textarea::placeholder {
   animation: taskAppear 0.24s ease;
 }
 
+/* No max-height here: rows whose name wraps to two lines are taller than any
+   fixed cap, and a cap clips the second line for the length of the animation. */
 @keyframes taskItemAppear {
   from {
     opacity: 0;
-    max-height: 0;
     transform: translateX(-6px);
   }
   to {
     opacity: 1;
-    max-height: 40px;
     transform: translateX(0);
   }
 }


### PR DESCRIPTION
## What

Two changes to the left sidebar task list.

### 1. A "Waiting for you" tray, pinned under + New Task

When several tasks run in parallel, the one that just stopped to ask you something is wherever it happens to sit in the list — easy to miss, and easy to lose again once the list scrolls. This adds a tray between the **+ New Task** button and the scrollable list holding every task blocked on an answer, **newest question first**. It sits outside the scroll container, so it never scrolls away.

Each row shows the status dot, the task name, the project it belongs to (the row is out of its project group, so it needs the label), and how long it has been waiting. Clicking a row opens the task *and* restores its last focused panel, so the question can be answered in one click.

Tasks stay in their project group as well — the tray is a shortcut, not a move. That keeps the `data-task-index` ↔ `taskOrder` mapping drag-reorder depends on intact, and keeps list positions stable.

It's a mode: `sidebarNeedsInputFirst`, persisted, on by default, with an × in the tray header and a **Settings → Behavior** checkbox to turn it back on.

<table>
<tr>
<td width="50%"><b>Pinning on</b> — two tasks asked, most recent on top</td>
<td width="50%"><b>Pinning off</b> — plain grouped list</td>
</tr>
<tr>
<td><img width="330" alt="Sidebar with the Waiting for you tray pinned under New Task, listing two tasks newest-first" src="https://raw.githubusercontent.com/oluies/parallel-code/assets/sidebar-needs-input/docs/screenshots/sidebar-needs-input-on.png"></td>
<td><img width="330" alt="Sidebar with pinning disabled, showing the plain project-grouped task list" src="https://raw.githubusercontent.com/oluies/parallel-code/assets/sidebar-needs-input/docs/screenshots/sidebar-needs-input-off.png"></td>
</tr>
</table>

Ordering by recency needed a question-onset timestamp, which nothing recorded. `taskStatus` now stamps one per agent when a question appears, clears it when the question goes away, and exposes `getTaskQuestionSince(taskId)`.

### 2. Task names you can actually read

Long names were clipped mid-word. Three separate causes, all fixed:

- The name span sat in a flex row with no `min-width: 0`, so `text-overflow: ellipsis` never applied and the text was simply cut by the row's `overflow: hidden`. Names now wrap to at most two lines with the full name as a tooltip.
- Rows are flex children of the scrolling task column, so they were shrunk below their content height — the second line got clipped. Rows now set `flex-shrink: 0`.
- The `task-item` appear animation tweens `max-height` to a fixed **40px**, shorter than any two-line row, and the class stays on the element. The keyframe now animates only opacity and transform.

Both screenshots above show the result — every name renders on two full lines with a proper ellipsis.

Alongside that: the `direct` branch badge moved after the name so the name claims width first (and the badge is capped and ellipsised), project group headers ellipsise while keeping their `(n)` count visible, and row spacing went 1px → 3px.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check` clean; full suite 1683 passed / 24 skipped.

New `src/store/sidebar-attention.test.ts` covers the ordering: newest question first, collapsed tasks included, unknown timestamps sink to the bottom, missing task ids skipped, no task listed twice.

Verified in the running app, not just in tests: launched Electron against a scratch profile seeded with two projects and four tasks, driven by stub agents that print a question and wait, so the real PTY question detector fires. The tray appeared with one entry, then two, with the later question sorted above the earlier one; the × persisted the mode to `state.json`. The two clipping bugs above were found *because* of that run — they were invisible to typecheck, lint, and unit tests.
