### PR TITLE
feat(review): import GitHub Code Quality findings

### DIFF
--- a/electron/ipc/channel-manifest.json
+++ b/electron/ipc/channel-manifest.json
@@ -112,6 +112,7 @@
   "DetectPrForBranch": "detect_pr_for_branch",
   "RefreshPrChecksWatcher": "refresh_pr_checks_watcher",
   "PrChecksUpdate": "pr_checks_update",
+  "GetGithubCodeQualityFindings": "get_github_code_quality_findings",
   "LogFromRenderer": "log_from_renderer",
   "CheckForUpdates": "check_for_updates",
   "DownloadUpdate": "download_update",

--- a/electron/ipc/github-code-quality.test.ts
+++ b/electron/ipc/github-code-quality.test.ts
@@ -1,0 +1,225 @@
+import { execFile } from 'child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', () => {
+  const mockExecFile = vi.fn();
+  (mockExecFile as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
+    (file: unknown, args: unknown, opts: unknown): Promise<{ stdout: string; stderr: string }> =>
+      new Promise((resolve, reject) => {
+        mockExecFile(file, args, opts, (error: Error | null, stdout: string, stderr: string) => {
+          if (error) reject(Object.assign(error, { stderr }));
+          else resolve({ stdout, stderr });
+        });
+      });
+  return { execFile: mockExecFile };
+});
+
+import {
+  classifyGithubCodeQualityError,
+  loadGithubCodeQualityFindings,
+  parseGithubCodeQualityFindings,
+} from './github-code-quality.js';
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+type ExecHandler = (command: string, args: string[], callback: ExecCallback) => void;
+
+function stubExec(handler: ExecHandler): Array<{ command: string; args: string[]; cwd: string }> {
+  const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+  vi.mocked(execFile).mockImplementation(((
+    command: string,
+    args: string[],
+    options: { cwd: string },
+    callback: ExecCallback,
+  ) => {
+    calls.push({ command, args, cwd: options.cwd });
+    handler(command, args, callback);
+  }) as unknown as typeof execFile);
+  return calls;
+}
+
+function apiFinding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 42,
+    state: 'open',
+    rule: {
+      id: 'js/no-floating-promises',
+      title: 'Promise is not handled',
+      description: 'Handle the promise.',
+      severity: 'warning',
+      category: 'reliability',
+    },
+    location: {
+      path: 'src/app.ts',
+      start_line: 9,
+      start_column: 4,
+      end_line: 9,
+      end_column: 18,
+    },
+    message: {
+      text: 'Await this promise or explicitly handle its rejection.',
+      markdown: 'Await **this promise**.',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('parseGithubCodeQualityFindings', () => {
+  it('maps newline-delimited pages into stable provider findings', () => {
+    const first = apiFinding();
+    const second = apiFinding({
+      number: 43,
+      rule: {
+        id: 'js/complexity',
+        title: 'Complex function',
+        severity: 'note',
+        category: 'maintainability',
+      },
+      location: { path: 'src/util.ts', start_line: 4 },
+      message: {},
+    });
+
+    expect(
+      parseGithubCodeQualityFindings(
+        'acme/widgets',
+        `${JSON.stringify(first)}\n${JSON.stringify(second)}\n`,
+      ),
+    ).toEqual([
+      {
+        id: 'github-code-quality:acme/widgets:42',
+        source: 'github-code-quality',
+        ruleId: 'js/no-floating-promises',
+        category: 'reliability',
+        severity: 'warning',
+        location: {
+          filePath: 'src/app.ts',
+          startLine: 9,
+          startColumn: 4,
+          endLine: 9,
+          endColumn: 18,
+        },
+        explanation: 'Await this promise or explicitly handle its rejection.',
+      },
+      {
+        id: 'github-code-quality:acme/widgets:43',
+        source: 'github-code-quality',
+        ruleId: 'js/complexity',
+        category: 'maintainability',
+        severity: 'note',
+        location: { filePath: 'src/util.ts', startLine: 4 },
+        explanation: 'Complex function',
+      },
+    ]);
+  });
+
+  it('deduplicates pages and skips closed or malformed findings', () => {
+    const valid = apiFinding();
+    const output = [
+      valid,
+      valid,
+      apiFinding({ number: 44, state: 'dismissed' }),
+      apiFinding({ number: 45, location: { path: 'src/app.ts', start_line: 0 } }),
+      apiFinding({ number: 46, rule: { id: 'unknown', severity: 'critical' } }),
+    ]
+      .map((finding) => JSON.stringify(finding))
+      .join('\n');
+
+    expect(parseGithubCodeQualityFindings('acme/widgets', output)).toHaveLength(1);
+  });
+
+  it('rejects output that is not newline-delimited JSON', () => {
+    expect(() => parseGithubCodeQualityFindings('acme/widgets', 'not json')).toThrow(
+      'unexpected Code Quality response',
+    );
+  });
+});
+
+describe('classifyGithubCodeQualityError', () => {
+  it('returns actionable missing CLI and authentication messages', () => {
+    expect(
+      classifyGithubCodeQualityError(
+        Object.assign(new Error('spawn gh'), { code: 'ENOENT' }),
+        'repository',
+      ),
+    ).toEqual({
+      status: 'unavailable',
+      message: 'GitHub CLI is not installed. Install gh, then try again.',
+    });
+    expect(
+      classifyGithubCodeQualityError(
+        Object.assign(new Error('failed'), {
+          stderr: 'authentication required; run gh auth login',
+        }),
+        'repository',
+      ),
+    ).toEqual({
+      status: 'unavailable',
+      message: 'GitHub CLI is not authenticated. Run gh auth login, then try again.',
+    });
+  });
+
+  it('treats repositories without a GitHub remote as not applicable', () => {
+    expect(
+      classifyGithubCodeQualityError(
+        Object.assign(new Error('failed'), { stderr: 'no git remotes found' }),
+        'repository',
+      ),
+    ).toEqual({ status: 'not-applicable' });
+  });
+
+  it.each([
+    [
+      403,
+      'GitHub Code Quality is unavailable for this repository or your account lacks read access.',
+    ],
+    [404, 'GitHub Code Quality is not available for this repository.'],
+    [503, 'GitHub Code Quality is temporarily unavailable. Try again later.'],
+  ])('maps HTTP %s without exposing raw command output', (status, message) => {
+    expect(
+      classifyGithubCodeQualityError(
+        Object.assign(new Error('failed'), { stderr: `sensitive details (HTTP ${status})` }),
+        'findings',
+      ),
+    ).toEqual({ status: 'unavailable', message });
+  });
+});
+
+describe('loadGithubCodeQualityFindings', () => {
+  it('uses the current GitHub repository and a read-only paginated API request', async () => {
+    const calls = stubExec((_command, args, callback) => {
+      if (args[0] === 'repo') callback(null, 'acme/widgets\n', '');
+      else callback(null, `${JSON.stringify(apiFinding())}\n`, '');
+    });
+
+    await expect(loadGithubCodeQualityFindings('/repo/worktree')).resolves.toMatchObject({
+      status: 'available',
+      findings: [{ id: 'github-code-quality:acme/widgets:42' }],
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({
+      command: 'gh',
+      args: ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+      cwd: '/repo/worktree',
+    });
+    expect(calls[1].args).toContain('GET');
+    expect(calls[1].args).toContain('repos/acme/widgets/code-quality/findings');
+    expect(calls[1].args).toContain('state=open');
+    expect(calls[1].args).toContain('--paginate');
+  });
+
+  it('returns a non-blocking 403 result from the findings request', async () => {
+    stubExec((_command, args, callback) => {
+      if (args[0] === 'repo') callback(null, 'acme/widgets\n', '');
+      else callback(Object.assign(new Error('failed'), { code: 1 }), '', 'HTTP 403');
+    });
+
+    await expect(loadGithubCodeQualityFindings('/repo/worktree')).resolves.toEqual({
+      status: 'unavailable',
+      message:
+        'GitHub Code Quality is unavailable for this repository or your account lacks read access.',
+    });
+  });
+});

--- a/electron/ipc/github-code-quality.ts
+++ b/electron/ipc/github-code-quality.ts
@@ -1,0 +1,199 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { GithubCodeQualityFinding, GithubCodeQualityResult } from './shared-types.js';
+
+const exec = promisify(execFile);
+const GH_TIMEOUT_MS = 30_000;
+const GH_MAX_BUFFER = 8 * 1024 * 1024;
+const GITHUB_API_VERSION = '2026-03-10';
+
+interface ApiFinding {
+  number?: unknown;
+  state?: unknown;
+  rule?: unknown;
+  location?: unknown;
+  message?: unknown;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : undefined;
+}
+
+function parseFinding(repository: string, value: unknown): GithubCodeQualityFinding | null {
+  const finding = record(value) as ApiFinding | null;
+  const rule = record(finding?.rule);
+  const location = record(finding?.location);
+  const message = record(finding?.message);
+  const number = positiveInteger(finding?.number);
+  const ruleId = nonEmptyString(rule?.['id']);
+  const category = rule?.['category'];
+  const severity = rule?.['severity'];
+  const filePath = nonEmptyString(location?.['path']);
+  const startLine = positiveInteger(location?.['start_line']);
+  const explanation =
+    nonEmptyString(message?.['text']) ??
+    nonEmptyString(rule?.['description']) ??
+    nonEmptyString(rule?.['title']);
+
+  if (
+    !number ||
+    finding?.state !== 'open' ||
+    !ruleId ||
+    (category !== 'reliability' && category !== 'maintainability') ||
+    (severity !== 'error' && severity !== 'warning' && severity !== 'note') ||
+    !filePath ||
+    !startLine ||
+    !explanation
+  ) {
+    return null;
+  }
+
+  const startColumn = positiveInteger(location?.['start_column']);
+  const endLine = positiveInteger(location?.['end_line']);
+  const endColumn = positiveInteger(location?.['end_column']);
+  return {
+    id: `github-code-quality:${repository}:${number}`,
+    source: 'github-code-quality',
+    ruleId,
+    category,
+    severity,
+    location: {
+      filePath,
+      startLine,
+      ...(startColumn ? { startColumn } : {}),
+      ...(endLine ? { endLine } : {}),
+      ...(endColumn ? { endColumn } : {}),
+    },
+    explanation,
+  };
+}
+
+export function parseGithubCodeQualityFindings(
+  repository: string,
+  stdout: string,
+): GithubCodeQualityFinding[] {
+  const findings = new Map<string, GithubCodeQualityFinding>();
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error('GitHub returned an unexpected Code Quality response.');
+    }
+    const finding = parseFinding(repository, parsed);
+    if (finding) findings.set(finding.id, finding);
+  }
+  return [...findings.values()];
+}
+
+function errorText(error: unknown): string {
+  if (!error || typeof error !== 'object') return String(error ?? '');
+  const value = error as { message?: unknown; stderr?: unknown; stdout?: unknown };
+  return [value.message, value.stderr, value.stdout]
+    .filter((part): part is string => typeof part === 'string')
+    .join('\n');
+}
+
+function unavailable(message: string): GithubCodeQualityResult {
+  return { status: 'unavailable', message };
+}
+
+export function classifyGithubCodeQualityError(
+  error: unknown,
+  stage: 'repository' | 'findings',
+): GithubCodeQualityResult {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  const text = errorText(error);
+  if (code === 'ENOENT') {
+    return unavailable('GitHub CLI is not installed. Install gh, then try again.');
+  }
+  if (/not logged into|authentication required|gh auth login/i.test(text)) {
+    return unavailable('GitHub CLI is not authenticated. Run gh auth login, then try again.');
+  }
+  if (
+    stage === 'repository' &&
+    /no git remotes|none of the git remotes|not a git repository|unable to determine.*repository/i.test(
+      text,
+    )
+  ) {
+    return { status: 'not-applicable' };
+  }
+  if (/HTTP 403|not authorized to view code quality/i.test(text)) {
+    return unavailable(
+      'GitHub Code Quality is unavailable for this repository or your account lacks read access.',
+    );
+  }
+  if (/HTTP 404/i.test(text)) {
+    return unavailable('GitHub Code Quality is not available for this repository.');
+  }
+  if (/HTTP 503/i.test(text)) {
+    return unavailable('GitHub Code Quality is temporarily unavailable. Try again later.');
+  }
+  return unavailable('GitHub Code Quality findings could not be loaded. Try again later.');
+}
+
+function parseRepository(stdout: string): string | null {
+  const repository = stdout.trim();
+  const parts = repository.split('/');
+  if (parts.length !== 2 || parts.some((part) => !part || !/^[A-Za-z0-9_.-]+$/.test(part))) {
+    return null;
+  }
+  return repository;
+}
+
+export async function loadGithubCodeQualityFindings(
+  worktreePath: string,
+): Promise<GithubCodeQualityResult> {
+  let repositoryStdout: string;
+  try {
+    ({ stdout: repositoryStdout } = await exec(
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+      { cwd: worktreePath, timeout: GH_TIMEOUT_MS, maxBuffer: GH_MAX_BUFFER },
+    ));
+  } catch (error) {
+    return classifyGithubCodeQualityError(error, 'repository');
+  }
+
+  const repository = parseRepository(repositoryStdout);
+  if (!repository) return { status: 'not-applicable' };
+
+  try {
+    const { stdout } = await exec(
+      'gh',
+      [
+        'api',
+        '--method',
+        'GET',
+        `repos/${repository}/code-quality/findings`,
+        '-f',
+        'state=open',
+        '-f',
+        'per_page=100',
+        '--paginate',
+        '--jq',
+        '.[] | @json',
+        '-H',
+        'Accept: application/vnd.github+json',
+        '-H',
+        `X-GitHub-Api-Version: ${GITHUB_API_VERSION}`,
+      ],
+      { cwd: worktreePath, timeout: GH_TIMEOUT_MS, maxBuffer: GH_MAX_BUFFER },
+    );
+    return {
+      status: 'available',
+      findings: parseGithubCodeQualityFindings(repository, stdout),
+    };
+  } catch (error) {
+    return classifyGithubCodeQualityError(error, 'findings');
+  }
+}

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -37,6 +37,7 @@ import {
   refreshPrChecksWatcher,
   isPrUrl,
 } from './pr-checks.js';
+import { loadGithubCodeQualityFindings } from './github-code-quality.js';
 import { readCoverageSummary } from './coverage.js';
 import { startRemoteServer, getMCPLogs, type RemoteProject } from '../remote/server.js';
 import type { RemoteAttentionState } from '../remote/protocol.js';
@@ -876,6 +877,10 @@ export function registerAllHandlers(win: BrowserWindow): void {
   ipcMain.handle(IPC.RefreshPrChecksWatcher, (_e, args) => {
     assertString(args.taskId, 'taskId');
     refreshPrChecksWatcher(args.taskId);
+  });
+  ipcMain.handle(IPC.GetGithubCodeQualityFindings, (_e, args) => {
+    validatePath(args.worktreePath, 'worktreePath');
+    return loadGithubCodeQualityFindings(args.worktreePath);
   });
 
   // --- Steps content (one-shot read) ---

--- a/electron/ipc/shared-types.ts
+++ b/electron/ipc/shared-types.ts
@@ -136,6 +136,27 @@ export interface BranchPrDetectionResult {
   unavailable?: 'missing' | 'auth';
 }
 
+export interface GithubCodeQualityFinding {
+  id: string;
+  source: 'github-code-quality';
+  ruleId: string;
+  category: 'reliability' | 'maintainability';
+  severity: 'error' | 'warning' | 'note';
+  location: {
+    filePath: string;
+    startLine: number;
+    startColumn?: number;
+    endLine?: number;
+    endColumn?: number;
+  };
+  explanation: string;
+}
+
+export type GithubCodeQualityResult =
+  | { status: 'available'; findings: GithubCodeQualityFinding[] }
+  | { status: 'not-applicable' }
+  | { status: 'unavailable'; message: string };
+
 export interface StepEntry {
   summary: string;
   detail?: string;

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -116,6 +116,7 @@ const ALLOWED_CHANNELS = new Set([
   'detect_pr_for_branch',
   'refresh_pr_checks_watcher',
   'pr_checks_update',
+  'get_github_code_quality_findings',
   'log_from_renderer',
   'check_for_updates',
   'download_update',

--- a/src/components/DiffViewerDialog.tsx
+++ b/src/components/DiffViewerDialog.tsx
@@ -21,7 +21,11 @@ import {
   isCommitHashSelection,
   isUncommittedSelection,
 } from './CommitNavBar';
-import { ReviewCommentsButton, ReviewSidebarPanel } from './ReviewSidebarPanel';
+import {
+  QualityFindingsRefreshButton,
+  ReviewCommentsButton,
+  ReviewSidebarPanel,
+} from './ReviewSidebarPanel';
 import { ReviewProvider, useReview } from './ReviewProvider';
 import { ChangedFilesList } from './ChangedFilesList';
 import { CloseIcon } from './icons';
@@ -386,6 +390,7 @@ function DiffViewerContent(props: DiffViewerDialogProps) {
         </span>
 
         <ReviewCommentsButton />
+        <QualityFindingsRefreshButton />
 
         <span style={{ flex: '1' }} />
 

--- a/src/components/ReviewProvider.client.test.tsx
+++ b/src/components/ReviewProvider.client.test.tsx
@@ -245,6 +245,27 @@ describe('ReviewProvider client lifecycle', () => {
     ]);
   });
 
+  it('reloads the active diff only when an explicit finding refresh is requested', async () => {
+    const loadFindings = vi.fn(async (_context: QualityFindingLoadContext) => [
+      finding('finding-1'),
+    ]);
+    const { review } = mountReview({ loadFindings });
+    review.completeDiffLoad('diff-a', renderedDiff());
+    await flushAsyncWork();
+
+    expect(review.canRefreshFindings()).toBe(true);
+    expect(loadFindings).toHaveBeenCalledOnce();
+
+    review.refreshFindings();
+    await flushAsyncWork();
+
+    expect(loadFindings).toHaveBeenCalledTimes(2);
+    expect(loadFindings.mock.calls[1][0]).toMatchObject({
+      reviewIdentity: 'task-a:/worktree-a',
+      diffIdentity: 'diff-a',
+    });
+  });
+
   it('ignores a completed submission after navigation moves to another diff', async () => {
     let resolveSend: (() => void) | undefined;
     vi.mocked(sendPrompt).mockImplementation(

--- a/src/components/ReviewProvider.tsx
+++ b/src/components/ReviewProvider.tsx
@@ -72,6 +72,8 @@ export interface ReviewContextValue {
   findingsLoading: () => boolean;
   findingsError: () => string;
   clearFindingsError: () => void;
+  canRefreshFindings: () => boolean;
+  refreshFindings: () => void;
 
   beginDiffLoad: () => void;
   completeDiffLoad: (diffIdentity: string, files: FileDiff[]) => void;
@@ -375,6 +377,13 @@ export function ReviewProvider(props: ReviewProviderProps) {
     loadFindingsForDiff(next, files);
   }
 
+  function refreshFindings() {
+    if (!props.findingProvider || !activeReviewDiff || !wasOpen || findingsLoading()) return;
+    findingsLoadedFor = null;
+    findingsLoadedProvider = undefined;
+    loadFindingsForDiff(activeReviewDiff, activeReviewDiff.files);
+  }
+
   function suspendDiffLoad() {
     reviewLifecycleGeneration++;
     invalidateFindingLoad();
@@ -495,6 +504,8 @@ export function ReviewProvider(props: ReviewProviderProps) {
     findingsLoading,
     findingsError,
     clearFindingsError: () => setFindingsError(''),
+    canRefreshFindings: () => Boolean(props.findingProvider && activeReviewDiff && wasOpen),
+    refreshFindings,
     beginDiffLoad,
     completeDiffLoad,
     suspendDiffLoad,

--- a/src/components/ReviewSidebarPanel.tsx
+++ b/src/components/ReviewSidebarPanel.tsx
@@ -3,7 +3,7 @@ import { useReview, type ReviewContextValue } from './ReviewProvider';
 import { ReviewSidebar } from './ReviewSidebar';
 import { theme } from '../lib/theme';
 import { sf } from '../lib/fontScale';
-import { CloseIcon } from './icons';
+import { CloseIcon, RefreshIcon } from './icons';
 
 interface ReviewSidebarState {
   reviewCount: number;
@@ -50,6 +50,41 @@ export function ReviewCommentsButton() {
         }}
       >
         Review ({state().reviewCount})
+      </button>
+    </Show>
+  );
+}
+
+export function QualityFindingsRefreshButton() {
+  const review = useReview();
+
+  return (
+    <Show when={review.canRefreshFindings()}>
+      <button
+        type="button"
+        onClick={review.refreshFindings}
+        disabled={review.findingsLoading()}
+        title={
+          review.findingsLoading() ? 'Refreshing quality findings' : 'Refresh quality findings'
+        }
+        aria-label="Refresh quality findings"
+        style={{
+          width: '26px',
+          height: '26px',
+          display: 'inline-flex',
+          'align-items': 'center',
+          'justify-content': 'center',
+          background: 'transparent',
+          color: theme.fgMuted,
+          border: `1px solid ${theme.border}`,
+          'border-radius': '4px',
+          cursor: review.findingsLoading() ? 'default' : 'pointer',
+          opacity: review.findingsLoading() ? '0.55' : '1',
+          padding: '0',
+          'flex-shrink': '0',
+        }}
+      >
+        <RefreshIcon size={14} />
       </button>
     </Show>
   );

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -43,6 +43,7 @@ import type { CommitInfo } from '../ipc/types';
 import { isLandedTaskState } from '../store/landing';
 import { shouldPollTaskCommits } from './task-commit-polling';
 import { devQualityFindingProvider } from './dev-quality-finding-fixture';
+import { createGithubCodeQualityFindingProvider } from '../lib/github-code-quality';
 
 interface TaskPanelProps {
   task: Task;
@@ -57,6 +58,9 @@ const CHANGED_FILES_PANEL_AUTO_MAX = 'min(300px, 33vh)';
 const NOTES_PANEL_AUTO_MAX = 'min(400px, 33vh)';
 
 export function TaskPanel(props: TaskPanelProps) {
+  const githubCodeQualityFindingProvider = createGithubCodeQualityFindingProvider(
+    () => props.task.worktreePath,
+  );
   const [showCloseConfirm, setShowCloseConfirm] = createSignal(false);
   const [planFullscreen, setPlanFullscreen] = createSignal(false);
 
@@ -657,7 +661,7 @@ export function TaskPanel(props: TaskPanelProps) {
           selectedCommit={selectedCommit()}
           onCommitNavigate={setSelectedCommit}
           gitIsolation={props.task.gitIsolation}
-          findingProvider={devQualityFindingProvider}
+          findingProvider={devQualityFindingProvider ?? githubCodeQualityFindingProvider}
         />
       </Show>
       <EditProjectDialog project={editingProject()} onClose={() => setEditingProjectId(null)} />

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -71,6 +71,14 @@ export function CloseIcon(props: IconProps): JSX.Element {
   );
 }
 
+export function RefreshIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M13.8 4.2V1.75a.75.75 0 0 1 1.5 0V6a.75.75 0 0 1-.75.75H10.3a.75.75 0 0 1 0-1.5h2.4A5 5 0 1 0 13 10a.75.75 0 0 1 1.5 0A6.5 6.5 0 1 1 13.8 4.2Z" />
+    </SvgIcon>
+  );
+}
+
 export function CopyIcon(props: IconProps): JSX.Element {
   return (
     <SvgIcon {...props}>

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -9,6 +9,8 @@ export type {
   CreateTaskResult,
   FileDiffResult,
   GitIgnoredEntry,
+  GithubCodeQualityFinding,
+  GithubCodeQualityResult,
   ImportableWorktree,
   MergeResult,
   MergeStatus,

--- a/src/lib/github-code-quality.test.ts
+++ b/src/lib/github-code-quality.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from './ipc';
+import { createGithubCodeQualityFindingProvider } from './github-code-quality';
+import { IPC } from '../../electron/ipc/channels';
+
+vi.mock('./ipc', () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createGithubCodeQualityFindingProvider', () => {
+  it('maps IPC findings into pending review findings', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'available',
+      findings: [
+        {
+          id: 'github-code-quality:acme/widgets:42',
+          source: 'github-code-quality',
+          ruleId: 'js/no-floating-promises',
+          category: 'reliability',
+          severity: 'warning',
+          location: { filePath: 'src/app.ts', startLine: 9 },
+          explanation: 'Await this promise.',
+        },
+      ],
+    });
+
+    const provider = createGithubCodeQualityFindingProvider(() => '/repo/worktree');
+    await expect(
+      provider.loadFindings({ reviewIdentity: 'task', diffIdentity: 'diff', files: [] }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'github-code-quality:acme/widgets:42',
+        state: 'open',
+        freshness: 'pending',
+      }),
+    ]);
+    expect(invoke).toHaveBeenCalledWith(IPC.GetGithubCodeQualityFindings, {
+      worktreePath: '/repo/worktree',
+    });
+  });
+
+  it('silently ignores repositories that do not map to GitHub', async () => {
+    vi.mocked(invoke).mockResolvedValue({ status: 'not-applicable' });
+    const provider = createGithubCodeQualityFindingProvider(() => '/repo/local');
+
+    await expect(
+      provider.loadFindings({ reviewIdentity: 'task', diffIdentity: 'diff', files: [] }),
+    ).resolves.toEqual([]);
+  });
+
+  it('surfaces an actionable unavailable state through the provider error path', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'unavailable',
+      message: 'GitHub CLI is not authenticated. Run gh auth login, then try again.',
+    });
+    const provider = createGithubCodeQualityFindingProvider(() => '/repo/worktree');
+
+    await expect(
+      provider.loadFindings({ reviewIdentity: 'task', diffIdentity: 'diff', files: [] }),
+    ).rejects.toThrow('Run gh auth login');
+  });
+});

--- a/src/lib/github-code-quality.ts
+++ b/src/lib/github-code-quality.ts
@@ -1,0 +1,26 @@
+import type { GithubCodeQualityResult } from '../ipc/types';
+import { invoke } from './ipc';
+import type { QualityFinding, QualityFindingProvider } from './quality-findings';
+import { IPC } from '../../electron/ipc/channels';
+
+export function createGithubCodeQualityFindingProvider(
+  worktreePath: () => string,
+): QualityFindingProvider {
+  return {
+    async loadFindings() {
+      const result = await invoke<GithubCodeQualityResult>(IPC.GetGithubCodeQualityFindings, {
+        worktreePath: worktreePath(),
+      });
+      if (result.status === 'not-applicable') return [];
+      if (result.status === 'unavailable') throw new Error(result.message);
+      return result.findings.map(
+        (finding): QualityFinding => ({
+          ...finding,
+          location: { ...finding.location },
+          state: 'open',
+          freshness: 'pending',
+        }),
+      );
+    },
+  };
+}


### PR DESCRIPTION
Fixes #238

## Summary
- load open GitHub Code Quality findings through read-only `gh api` requests using the user's existing GitHub CLI authentication
- validate and map API responses into the provider-neutral `QualityFinding` review flow
- surface missing CLI/auth, unsupported repository plans, and API failures as non-blocking actionable states
- add an explicit refresh control while keeping automatic loads tied to diff lifecycle changes

## Validation
- `npm run check`
- `npm run check:static`
- `npm test` (1,817 unit tests and 10 client tests passed)
- `npm run test:security-rules`
- `npm run build:frontend`
- `npm run build:remote`
- `npm run build:mcp`