### PR TITLE
refactor: move bookmark glyph into shared icon

### DIFF
--- a/src/components/TerminalBookmarks.tsx
+++ b/src/components/TerminalBookmarks.tsx
@@ -1,5 +1,6 @@
 import { For, Show, type JSX } from 'solid-js';
 import { theme } from '../lib/theme';
+import { BookmarkIcon } from './icons';
 
 /** Minimal bookmark shape the gutter needs to draw. Position is supplied
  *  separately via `topOf` so it can track live xterm state without re-creating
@@ -31,8 +32,6 @@ export interface TerminalBookmarkGutterProps {
   createTop: number;
   onCreate: () => void;
 }
-
-const BOOKMARK_ICON_PATH = 'M4 2.5A1.5 1.5 0 0 1 5.5 1h5A1.5 1.5 0 0 1 12 2.5V14l-4-2.5L4 14V2.5Z';
 
 /** Left-edge gutter for one terminal pane. Purely presentational — the owning
  *  TerminalView registers xterm markers and feeds positions back in. A bookmark
@@ -89,9 +88,7 @@ export function TerminalBookmarkGutter(props: TerminalBookmarkGutterProps): JSX.
                 filter: 'drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55))',
               }}
             >
-              <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor">
-                <path d={BOOKMARK_ICON_PATH} />
-              </svg>
+              <BookmarkIcon size={15} />
             </button>
           </Show>
         )}
@@ -143,9 +140,7 @@ export function TerminalBookmarkGutter(props: TerminalBookmarkGutterProps): JSX.
             'pointer-events': 'auto',
           }}
         >
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d={BOOKMARK_ICON_PATH} />
-          </svg>
+          <BookmarkIcon size={14} />
         </button>
       </Show>
     </div>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -102,3 +102,11 @@ export function GitGraphIcon(props: IconProps): JSX.Element {
     </SvgIcon>
   );
 }
+
+export function BookmarkIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M4 2.5A1.5 1.5 0 0 1 5.5 1h5A1.5 1.5 0 0 1 12 2.5V14l-4-2.5L4 14V2.5Z" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
## Summary
- add `BookmarkIcon` to the shared icon module
- replace the duplicated inline bookmark SVGs in the terminal bookmark gutter
- keeps the two existing rendered sizes (15px and 14px) while removing the local pasted path

Refs #208

## Tests
- `npm ci --ignore-scripts` (plain `npm ci` failed because `node-pty` native postinstall could not rebuild in this container)
- `npm run typecheck`
- `git diff --check`