### PR TITLE
fix(window): make a backgrounded window reachable again

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -82,7 +82,24 @@ function fixEnv(): void {
   }
 }
 
-fixEnv();
+// One running copy per profile, and the lock is taken here rather than beside the
+// window wiring because Electron's guidance is to take it as early as possible and
+// this file gives that guidance teeth: fixEnv() above spawns an interactive login
+// shell, which on a normal rc file (nvm, conda, compinit) costs on the order of half
+// a second. A second launch is going to quit — spending that first would put the
+// delay squarely on the icon-relaunch path the lock exists to make instant.
+//
+// Dev runs skip the lock deliberately, so `npm run dev` still starts while an
+// installed build is running.
+const isPrimaryInstance = !app.isPackaged || app.requestSingleInstanceLock();
+
+if (!isPrimaryInstance) {
+  app.quit();
+} else {
+  // Only the primary instance ever spawns a PTY, so it is the only one that needs
+  // the resolved login-shell environment.
+  fixEnv();
+}
 
 // Blink evicts the oldest WebGL context past 16 per renderer process, and every
 // mounted terminal pane holds one — hidden task/tab terminals included. Past 16
@@ -232,21 +249,14 @@ function createWindow() {
   });
 }
 
-// One running copy per profile. "Keep them alive in the background" hides the
-// window instead of closing it, so a user who launches the app again is asking
-// for the window they already have — but without the lock a second process
-// starts, restores every persisted session from the same state file, and spawns
-// a duplicate agent for each one on top of the PTYs the hidden instance is still
-// holding. The hidden window has no way back either: nothing is listening for
-// the launch. Taking the lock turns a second launch into "show the window".
-//
-// Dev runs skip the lock deliberately, so `npm run dev` still starts while an
-// installed build is running.
-const isPrimaryInstance = !app.isPackaged || app.requestSingleInstanceLock();
-
-if (!isPrimaryInstance) {
-  app.quit();
-} else {
+// Why the lock matters here: "Keep them alive in the background" hides the window
+// instead of closing it, so a user who launches the app again is asking for the
+// window they already have. Without the lock a second process starts, restores
+// every persisted session from the same state file, and spawns a duplicate agent
+// for each one — on top of the PTYs the hidden instance is still holding. The
+// hidden window has no way back either, because nothing is listening for the
+// launch. With the lock, a second launch becomes "show the window".
+if (isPrimaryInstance) {
   // A second launch (icon, CLI, file manager) reaches the instance that owns
   // the lock as this event instead of starting a process of its own.
   app.on('second-instance', () => restoreWindow(mainWindow));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -91,9 +91,13 @@ function fixEnv(): void {
 //
 // Dev runs skip the lock deliberately, so `npm run dev` still starts while an
 // installed build is running.
-const isPrimaryInstance = !app.isPackaged || app.requestSingleInstanceLock();
+const singleInstanceLockHeld = app.isPackaged && app.requestSingleInstanceLock();
+// Two questions, two names: whether this process holds the lock, and whether it
+// should boot at all. A dev run answers no to the first and yes to the second,
+// which is why one flag covering both would be wrong under either name.
+const shouldStartApp = !app.isPackaged || singleInstanceLockHeld;
 
-if (!isPrimaryInstance) {
+if (!shouldStartApp) {
   app.quit();
 } else {
   // Only the primary instance ever spawns a PTY, so it is the only one that needs
@@ -256,7 +260,7 @@ function createWindow() {
 // for each one — on top of the PTYs the hidden instance is still holding. The
 // hidden window has no way back either, because nothing is listening for the
 // launch. With the lock, a second launch becomes "show the window".
-if (isPrimaryInstance) {
+if (shouldStartApp) {
   // A second launch (icon, CLI, file manager) reaches the instance that owns
   // the lock as this event instead of starting a process of its own.
   app.on('second-instance', () => restoreWindow(mainWindow));
@@ -319,6 +323,19 @@ app.on('before-quit', (event) => {
 // Runs only on a quit that got through the check above, so it cannot destroy
 // anything the user still had a chance to cancel.
 app.on('will-quit', () => {
+  // Hand the lock over before the blocking teardown below, not at process exit.
+  // electron-updater's AppImage path spawns the replacement *before* quitting
+  // (`doInstall` → `spawnLog(destination)`, then `setImmediate(() =>
+  // app.quit())`), so the incoming process is already booting while this one is
+  // still killing agents — and `killAllAgents()` blocks on a `docker kill` per
+  // session. Holding the lock through that can make the replacement fail it and
+  // quit: update applied, app never reappears. Releasing here also covers the
+  // plain case, where someone relaunching during a slow shutdown would
+  // otherwise be handed a window that is already going away.
+  //
+  // `will-quit` only runs on a quit that got past the veto above, so a
+  // cancelled quit correctly keeps the lock. A no-op when none is held.
+  app.releaseSingleInstanceLock();
   killAllAgents();
   // Detached process groups would outlive Electron otherwise.
   verificationRunner.cancelAll();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
 import { app, autoUpdater, BrowserWindow, Menu, ipcMain, session, shell } from 'electron';
 import { buildMenuTemplate } from './menu-template.js';
+import { restoreWindow } from './window-restore.js';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -231,41 +232,61 @@ function createWindow() {
   });
 }
 
-app.whenReady().then(async () => {
-  // Grant microphone and clipboard access (deny camera/video)
-  session.defaultSession.setPermissionRequestHandler(
-    (_webContents, permission, callback, details) => {
-      if (permission === 'clipboard-read' || permission === 'clipboard-sanitized-write') {
-        return callback(true);
-      }
-      if (permission === 'media') {
-        const types = (details as { mediaTypes?: string[] }).mediaTypes ?? [];
-        return callback(types.every((t) => t === 'audio'));
-      }
-      callback(false);
-    },
-  );
+// One running copy per profile. "Keep them alive in the background" hides the
+// window instead of closing it, so a user who launches the app again is asking
+// for the window they already have — but without the lock a second process
+// starts, restores every persisted session from the same state file, and spawns
+// a duplicate agent for each one on top of the PTYs the hidden instance is still
+// holding. The hidden window has no way back either: nothing is listening for
+// the launch. Taking the lock turns a second launch into "show the window".
+//
+// Dev runs skip the lock deliberately, so `npm run dev` still starts while an
+// installed build is running.
+const isPrimaryInstance = !app.isPackaged || app.requestSingleInstanceLock();
 
-  // electron-updater stages the install, then quits through `app.quit()`.
-  // Vetoing that quit below would leave the update staged with the app still
-  // running, so let it through — the window's own close prompt still asks about
-  // running terminals, and `autoInstallOnAppQuit` re-applies the update on the
-  // next quit if the user backs out. Both platform paths announce the relaunch
-  // on Electron's own updater immediately before quitting (the AppImage updater
-  // emits it by hand, Squirrel natively), so this is set only while a quit is
-  // genuinely in flight — unlike a flag set when the install is *requested*,
-  // which sticks for the whole session on the many paths where
-  // `quitAndInstall()` returns without quitting.
-  autoUpdater.on('before-quit-for-update', () => {
-    quittingForUpdate = true;
+if (!isPrimaryInstance) {
+  app.quit();
+} else {
+  // A second launch (icon, CLI, file manager) reaches the instance that owns
+  // the lock as this event instead of starting a process of its own.
+  app.on('second-instance', () => restoreWindow(mainWindow));
+
+  app.whenReady().then(async () => {
+    // Grant microphone and clipboard access (deny camera/video)
+    session.defaultSession.setPermissionRequestHandler(
+      (_webContents, permission, callback, details) => {
+        if (permission === 'clipboard-read' || permission === 'clipboard-sanitized-write') {
+          return callback(true);
+        }
+        if (permission === 'media') {
+          const types = (details as { mediaTypes?: string[] }).mediaTypes ?? [];
+          return callback(types.every((t) => t === 'audio'));
+        }
+        callback(false);
+      },
+    );
+
+    // electron-updater stages the install, then quits through `app.quit()`.
+    // Vetoing that quit below would leave the update staged with the app still
+    // running, so let it through — the window's own close prompt still asks about
+    // running terminals, and `autoInstallOnAppQuit` re-applies the update on the
+    // next quit if the user backs out. Both platform paths announce the relaunch
+    // on Electron's own updater immediately before quitting (the AppImage updater
+    // emits it by hand, Squirrel natively), so this is set only while a quit is
+    // genuinely in flight — unlike a flag set when the install is *requested*,
+    // which sticks for the whole session on the many paths where
+    // `quitAndInstall()` returns without quitting.
+    autoUpdater.on('before-quit-for-update', () => {
+      quittingForUpdate = true;
+    });
+
+    // Listening before the window exists: a renderer cannot spawn a Claude
+    // agent that misses its hooks. Failure falls back to PTY heuristics.
+    await startAgentHookRuntime(() => mainWindow);
+    setupApplicationMenu();
+    createWindow();
   });
-
-  // Listening before the window exists: a renderer cannot spawn a Claude
-  // agent that misses its hooks. Failure falls back to PTY heuristics.
-  await startAgentHookRuntime(() => mainWindow);
-  setupApplicationMenu();
-  createWindow();
-});
+}
 
 // A quit reaches `before-quit` *before* any window `close` event, so tearing
 // down agents here destroyed the very terminals the close dialog was about to
@@ -279,9 +300,9 @@ app.whenReady().then(async () => {
 app.on('before-quit', (event) => {
   if (!mainWindow || mainWindow.isDestroyed() || quittingForUpdate) return;
   event.preventDefault();
-  // The confirmation is a sheet on this window, and show() also focuses — a
-  // quit from the menu while the app sits hidden must not prompt invisibly.
-  mainWindow.show();
+  // The confirmation is a sheet on this window — a quit from the menu while the
+  // app sits hidden or minimized must not prompt somewhere the user cannot see.
+  restoreWindow(mainWindow);
   mainWindow.close();
 });
 
@@ -298,10 +319,9 @@ app.on('will-quit', () => {
 });
 
 // "Keep them alive in the background" hides the window; without this the dock
-// icon is a dead end and the only way back is attempting to quit.
-app.on('activate', () => {
-  mainWindow?.show();
-});
+// icon is a dead end and the only way back is attempting to quit. `show()` alone
+// left a minimized or buried window where it was — see restoreWindow.
+app.on('activate', () => restoreWindow(mainWindow));
 
 app.on('window-all-closed', () => {
   app.quit();

--- a/electron/window-restore.test.ts
+++ b/electron/window-restore.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { restoreWindow, type RestorableWindow } from './window-restore.js';
+
+interface FakeWindow extends RestorableWindow {
+  calls: string[];
+}
+
+function fakeWindow(
+  state: { destroyed?: boolean; visible?: boolean; minimized?: boolean } = {},
+): FakeWindow {
+  const calls: string[] = [];
+  return {
+    calls,
+    isDestroyed: () => state.destroyed ?? false,
+    isVisible: () => state.visible ?? true,
+    isMinimized: () => state.minimized ?? false,
+    show: () => void calls.push('show'),
+    restore: () => void calls.push('restore'),
+    focus: () => void calls.push('focus'),
+  };
+}
+
+describe('restoreWindow', () => {
+  // The case the whole function exists for: "Keep them alive in the background"
+  // hides the window, and without `show()` there is no way back to it at all.
+  it('shows a hidden window and focuses it', () => {
+    const win = fakeWindow({ visible: false });
+    restoreWindow(win);
+    expect(win.calls).toEqual(['show', 'focus']);
+  });
+
+  // `show()` is a no-op on a minimized window, so a handler that only called
+  // `show()` would leave the user's click doing nothing at all.
+  it('restores a minimized window and focuses it', () => {
+    const win = fakeWindow({ minimized: true });
+    restoreWindow(win);
+    expect(win.calls).toEqual(['restore', 'focus']);
+  });
+
+  // Minimized windows report themselves as not visible on some platforms;
+  // both branches have to run or one of the two platforms is left broken.
+  it('handles a window that is both hidden and minimized', () => {
+    const win = fakeWindow({ visible: false, minimized: true });
+    restoreWindow(win);
+    expect(win.calls).toEqual(['show', 'restore', 'focus']);
+  });
+
+  // Visible but buried behind another app: nothing to show or restore, but the
+  // user asked for this window, so it still has to come forward.
+  it('focuses a window that is already visible', () => {
+    const win = fakeWindow();
+    restoreWindow(win);
+    expect(win.calls).toEqual(['focus']);
+  });
+
+  // The window is nulled on `closed`, but these events can arrive in the gap
+  // before that fires, and calling into a destroyed window throws.
+  it('is a no-op for a destroyed window', () => {
+    const win = fakeWindow({ destroyed: true, visible: false, minimized: true });
+    expect(() => restoreWindow(win)).not.toThrow();
+    expect(win.calls).toEqual([]);
+  });
+
+  it('is a no-op for a missing window', () => {
+    expect(() => restoreWindow(null)).not.toThrow();
+    expect(() => restoreWindow(undefined)).not.toThrow();
+  });
+
+  // Guard clauses must not swallow the calls they guard: a regression that made
+  // `isDestroyed()` throw would otherwise look like a passing no-op test.
+  it('asks whether the window is destroyed before touching it', () => {
+    const isDestroyed = vi.fn(() => false);
+    const win = { ...fakeWindow(), isDestroyed };
+    restoreWindow(win);
+    expect(isDestroyed).toHaveBeenCalled();
+  });
+});

--- a/electron/window-restore.test.ts
+++ b/electron/window-restore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { restoreWindow, type RestorableWindow } from './window-restore.js';
 
 interface FakeWindow extends RestorableWindow {
@@ -29,16 +29,16 @@ describe('restoreWindow', () => {
     expect(win.calls).toEqual(['show', 'focus']);
   });
 
-  // `show()` is a no-op on a minimized window, so a handler that only called
-  // `show()` would leave the user's click doing nothing at all.
+  // A handler that only called `show()` would leave a minimized window where it
+  // was: `restore()` is the call that un-minimizes.
   it('restores a minimized window and focuses it', () => {
     const win = fakeWindow({ minimized: true });
     restoreWindow(win);
     expect(win.calls).toEqual(['restore', 'focus']);
   });
 
-  // Minimized windows report themselves as not visible on some platforms;
-  // both branches have to run or one of the two platforms is left broken.
+  // The two states are not exclusive, and the function must not treat them as
+  // such — a window can be hidden and minimized at the same time.
   it('handles a window that is both hidden and minimized', () => {
     const win = fakeWindow({ visible: false, minimized: true });
     restoreWindow(win);
@@ -64,14 +64,5 @@ describe('restoreWindow', () => {
   it('is a no-op for a missing window', () => {
     expect(() => restoreWindow(null)).not.toThrow();
     expect(() => restoreWindow(undefined)).not.toThrow();
-  });
-
-  // Guard clauses must not swallow the calls they guard: a regression that made
-  // `isDestroyed()` throw would otherwise look like a passing no-op test.
-  it('asks whether the window is destroyed before touching it', () => {
-    const isDestroyed = vi.fn(() => false);
-    const win = { ...fakeWindow(), isDestroyed };
-    restoreWindow(win);
-    expect(isDestroyed).toHaveBeenCalled();
   });
 });

--- a/electron/window-restore.ts
+++ b/electron/window-restore.ts
@@ -2,12 +2,16 @@
 //
 // "Keep them alive in the background" hides the window rather than closing it,
 // which is the whole point — the agents keep running. But a hidden window is
-// only useful if there is a way back to it, and `show()` alone is not that way:
-// a window the user minimized is still "visible" to Electron, so `show()` is a
-// no-op on it, and a window that is visible but buried behind other apps needs
-// `focus()` to come forward. Each entry point (dock click, second launch, tray)
-// can hit any of those three states, so they all route through one function
-// that handles all three rather than each guessing.
+// only useful if there is a way back to it, and the entry points that ask for
+// it (a dock click, a second launch) can arrive with the window hidden,
+// minimized, or merely behind another app. Each of those needs a different call,
+// so they all route through one function that makes all three rather than each
+// caller guessing which one applies.
+//
+// Wayland caveat: a client generally cannot raise itself there, and Electron's
+// own docs say `focus()` on Wayland "may show a notification or flash the app
+// icon" instead. So the visible-but-buried case can end at an icon flash rather
+// than a raise, depending on the compositor. Hidden and minimized are unaffected.
 //
 // Typed structurally instead of against `BrowserWindow` so the behaviour can be
 // tested without an Electron runtime. `BrowserWindow` satisfies this shape.
@@ -30,8 +34,9 @@ export interface RestorableWindow {
  */
 export function restoreWindow(win: RestorableWindow | null | undefined): void {
   if (!win || win.isDestroyed()) return;
-  // Order matters: a minimized window reports `isVisible() === false` on some
-  // platforms and `true` on others, so ask both questions and act on each.
+  // Both questions get asked, and each answer gets acted on independently: the
+  // two states are not exclusive, and how a minimized window reports its
+  // visibility is not something to depend on.
   if (!win.isVisible()) win.show();
   if (win.isMinimized()) win.restore();
   win.focus();

--- a/electron/window-restore.ts
+++ b/electron/window-restore.ts
@@ -1,0 +1,38 @@
+// Bringing the main window back from wherever the user left it.
+//
+// "Keep them alive in the background" hides the window rather than closing it,
+// which is the whole point — the agents keep running. But a hidden window is
+// only useful if there is a way back to it, and `show()` alone is not that way:
+// a window the user minimized is still "visible" to Electron, so `show()` is a
+// no-op on it, and a window that is visible but buried behind other apps needs
+// `focus()` to come forward. Each entry point (dock click, second launch, tray)
+// can hit any of those three states, so they all route through one function
+// that handles all three rather than each guessing.
+//
+// Typed structurally instead of against `BrowserWindow` so the behaviour can be
+// tested without an Electron runtime. `BrowserWindow` satisfies this shape.
+export interface RestorableWindow {
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  isMinimized(): boolean;
+  show(): void;
+  restore(): void;
+  focus(): void;
+}
+
+/**
+ * Bring `win` back into view, whatever state it is in: hidden, minimized,
+ * behind another app, or any combination.
+ *
+ * A no-op for a missing or destroyed window — the window is set to null on
+ * `closed`, but the events that call this can arrive in the gap before that
+ * fires, and calling into a destroyed window throws.
+ */
+export function restoreWindow(win: RestorableWindow | null | undefined): void {
+  if (!win || win.isDestroyed()) return;
+  // Order matters: a minimized window reports `isVisible() === false` on some
+  // platforms and `true` on others, so ask both questions and act on each.
+  if (!win.isVisible()) win.show();
+  if (win.isMinimized()) win.restore();
+  win.focus();
+}


### PR DESCRIPTION
"Keep them alive in the background" hides the window instead of closing it, which is the point — the agents keep running. Getting back to it is where it breaks down, in two ways.

**Nothing owns a second launch.** Clicking the icon, or running the binary again, starts a whole second process. It reads the same state file, restores every persisted session, and spawns a duplicate agent for each one — on top of the PTYs the first instance is still holding. The hidden window is not raised, because nothing is listening for the launch. On Linux, where there is no dock to click, that launch is the only gesture a user has, so the app answers "come back" by cloning itself over its own running terminals.

**`show()` is not enough on its own.** It is a no-op on a minimized window, and does nothing for a window that is visible but buried behind another app. Both states reach the same handlers as the hidden one.

### Changes

- Take the single-instance lock in packaged builds, before `fixEnv()` resolves the login-shell environment, and release it at the top of `will-quit` so a replacement spawned by the AppImage updater cannot lose the lock to a process that is already quitting. A second launch now arrives at the running instance as `second-instance` and restores its window instead of starting a process. **Dev runs skip the lock**, so `npm run dev` still starts while an installed build is running.
- Add `restoreWindow()` in `electron/window-restore.ts`: show if hidden, restore if minimized, focus either way, no-op if the window is missing or destroyed. Typed structurally against a `RestorableWindow` shape rather than `BrowserWindow`, so it is testable without an Electron runtime — following the `menu-template.ts` pattern.
- Route all three call sites through it: the existing `activate` handler, the new `second-instance`, and the `before-quit` prompt.

### On that third call site

`before-quit` currently calls `mainWindow.show()` and its comment already says a quit from the menu "must not prompt invisibly". A minimized window is exactly that case, so I included it. Happy to drop it to a separate PR if you'd rather keep this one to the lock.

### Testing

6 unit tests covering hidden, minimized, both at once, visible-but-unfocused, destroyed, and missing. `npm run compile`, `npm run check:static` and the full suite pass.

### Note

Found while running a fork of this app on a headless Linux box, where the icon-relaunch path is the whole story. Not fork-specific — the duplicate-spawn happens on any platform once the window is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoJfWuU93BeL2W48mz9bC6

