### PR TITLE
fix(agent-hooks): keep a dev run's endpoint file out of the installed profile

### DIFF
--- a/electron/agent-hooks/runtime.ts
+++ b/electron/agent-hooks/runtime.ts
@@ -1,6 +1,7 @@
-import { app, type BrowserWindow } from 'electron';
+import { type BrowserWindow } from 'electron';
 import path from 'path';
 import { IPC } from '../ipc/channels.js';
+import { getUserDataDir } from '../user-data-dir.js';
 import { setAgentHookRuntime } from '../ipc/pty.js';
 import { error as logError, info as logInfo } from '../log.js';
 import { emitAgentHookEvent } from './events.js';
@@ -15,7 +16,11 @@ let server: AgentHookServer | null = null;
  * Failure is logged and otherwise ignored: the PTY heuristics keep working.
  */
 export async function startAgentHookRuntime(getWindow: () => BrowserWindow | null): Promise<void> {
-  const dir = path.join(app.getPath('userData'), 'agent-hooks');
+  // Per-instance, not raw userData: this directory holds endpoint.env (loopback
+  // port + bearer token), written only at startup, so sharing it between a dev
+  // run and an installed build hands every agent's hook events to whichever
+  // instance started last.
+  const dir = path.join(getUserDataDir(), 'agent-hooks');
   // Resolved per event: the server starts before the window exists so that no
   // Claude launch can race it, and the window may be recreated later.
   const forward = (event: AgentHookEventPayload): void => {

--- a/electron/ipc/persistence.ts
+++ b/electron/ipc/persistence.ts
@@ -1,19 +1,9 @@
-import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
-
-function getStateDir(): string {
-  let dir = app.getPath('userData');
-  // Use separate dir for dev mode
-  if (!app.isPackaged) {
-    const base = path.basename(dir);
-    dir = path.join(path.dirname(dir), `${base}-dev`);
-  }
-  return dir;
-}
+import { getUserDataDir } from '../user-data-dir.js';
 
 function getStatePath(): string {
-  return path.join(getStateDir(), 'state.json');
+  return path.join(getUserDataDir(), 'state.json');
 }
 
 export function saveAppState(json: string): void {
@@ -52,7 +42,7 @@ export function saveAppState(json: string): void {
 }
 
 function getThemesDir(): string {
-  return path.join(getStateDir(), 'themes');
+  return path.join(getUserDataDir(), 'themes');
 }
 
 const VALID_THEME_ID = /^[a-zA-Z0-9_-]+$/;

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -780,7 +780,7 @@ export function registerAllHandlers(win: BrowserWindow): void {
   ipcMain.handle(IPC.SaveArenaData, (_e, args) => {
     assertString(args.filename, 'filename');
     assertString(args.json, 'json');
-    const filePath = path.join(app.getPath('userData'), args.filename);
+    const filePath = path.join(getUserDataDir(), args.filename);
     const basename = path.basename(filePath);
     if (basename !== args.filename) throw new Error('Invalid filename');
     if (!basename.startsWith('arena-') || !basename.endsWith('.json'))
@@ -792,7 +792,7 @@ export function registerAllHandlers(win: BrowserWindow): void {
 
   ipcMain.handle(IPC.LoadArenaData, (_e, args) => {
     assertString(args.filename, 'filename');
-    const filePath = path.join(app.getPath('userData'), args.filename);
+    const filePath = path.join(getUserDataDir(), args.filename);
     const basename = path.basename(filePath);
     if (basename !== args.filename) throw new Error('Invalid filename');
     if (!basename.startsWith('arena-') || !basename.endsWith('.json'))

--- a/electron/ipc/register.ts
+++ b/electron/ipc/register.ts
@@ -43,6 +43,7 @@ import { buildVerifyEnv, validateVerifyCommand, verificationRunner } from './ver
 import { startRemoteServer, getMCPLogs, type RemoteProject } from '../remote/server.js';
 import type { RemoteAttentionState } from '../remote/protocol.js';
 import { atomicWriteFileSync } from '../mcp/atomic.js';
+import { getUserDataDir } from '../user-data-dir.js';
 import { buildMcpLaunchArgs } from '../mcp/agent-args.js';
 import {
   getSymlinkCandidates,
@@ -766,22 +767,13 @@ export function registerAllHandlers(win: BrowserWindow): void {
   });
 
   // --- Keybindings ---
-  function getKeybindingsDir(): string {
-    let dir = app.getPath('userData');
-    if (!app.isPackaged) {
-      const base = path.basename(dir);
-      dir = path.join(path.dirname(dir), `${base}-dev`);
-    }
-    return dir;
-  }
-
   ipcMain.handle(IPC.LoadKeybindings, () => {
-    return loadKeybindings(getKeybindingsDir());
+    return loadKeybindings(getUserDataDir());
   });
 
   ipcMain.handle(IPC.SaveKeybindings, (_e, args) => {
     assertString(args?.json, 'json');
-    saveKeybindings(getKeybindingsDir(), args.json);
+    saveKeybindings(getUserDataDir(), args.json);
   });
 
   // --- Arena persistence ---

--- a/electron/user-data-dir.test.ts
+++ b/electron/user-data-dir.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { resolveUserDataDir } from './user-data-dir.js';
+
+describe('resolveUserDataDir', () => {
+  const userData = path.join('/home', 'someone', '.config', 'parallel-code');
+
+  it('uses the userData path as-is in a packaged build', () => {
+    expect(resolveUserDataDir(userData, true)).toBe(userData);
+  });
+
+  it('appends -dev to the last segment in a dev run', () => {
+    expect(resolveUserDataDir(userData, false)).toBe(
+      path.join('/home', 'someone', '.config', 'parallel-code-dev'),
+    );
+  });
+
+  // Suffixing the whole path instead of the last segment would put dev's data
+  // in a sibling of the config root rather than beside the packaged profile.
+  it('keeps the parent directory', () => {
+    expect(path.dirname(resolveUserDataDir(userData, false))).toBe(path.dirname(userData));
+  });
+});

--- a/electron/user-data-dir.ts
+++ b/electron/user-data-dir.ts
@@ -1,0 +1,27 @@
+import { app } from 'electron';
+import path from 'path';
+
+/**
+ * Per-instance data directory, given Electron's `userData` path.
+ *
+ * A dev run gets its own `<name>-dev` directory so `npm run dev` does not read
+ * or write the installed build's data. Pure and parameterised so the rule can be
+ * tested without an Electron runtime, and so there is exactly one copy of it.
+ */
+export function resolveUserDataDir(userDataPath: string, isPackaged: boolean): string {
+  if (isPackaged) return userDataPath;
+  const base = path.basename(userDataPath);
+  return path.join(path.dirname(userDataPath), `${base}-dev`);
+}
+
+/**
+ * The per-instance data directory for this process.
+ *
+ * Every file the app keeps under `userData` goes here rather than under
+ * `app.getPath('userData')` directly. The suffix is what keeps a dev run and an
+ * installed build from writing over each other, so a caller that reaches past
+ * this helper silently opts one of its files out of that separation.
+ */
+export function getUserDataDir(): string {
+  return resolveUserDataDir(app.getPath('userData'), app.isPackaged);
+}


### PR DESCRIPTION
The dev-instance cross-wiring you spotted reviewing #270. Your diagnosis was right; two things about it turned out to be worse than the comment said, and the fix wanted to be slightly bigger than one line.

### Why it isn't one line

The suffix rule already exists twice, verbatim in shape: `getStateDir()` in `persistence.ts:5` and `getKeybindingsDir()` in `register.ts:769`. It is missing from three places — `agent-hooks/runtime.ts:18` and both arena handlers. Mirroring it into `runtime.ts` would have made a third copy of a rule that has now been forgotten more often than it has been remembered.

So `electron/user-data-dir.ts` instead: `resolveUserDataDir(userDataPath, isPackaged)` is pure, so the rule is testable without an Electron runtime, and `getUserDataDir()` is what callers use. After this, `app.getPath('userData')` appears exactly once in the tree, which makes "someone reached past the helper" a one-line grep instead of an audit.

Same reasoning you used on #270 for the third call site: leaving the copies in place would leave the next one to drift.

### Worse than the comment said

**The misroute succeeds.** The port *and* the token both come from `endpoint.env`, so an agent launched by instance A posts to instance B and passes `tokenMatches` cleanly. Nothing logs on either side — `coordinator.ts:318` returns early on an unknown agent id, and `applyAgentHookEvent` never checks the agent belongs to this instance, so the wrong instance writes phantom status entries.

**Quitting one instance breaks hooks for the other.** `endpoint.env` is written only inside `startAgentHookServer`, at startup. Close the instance that owns the file and it still names a dead port, so the surviving instance's agents post into nothing and fall back to PTY heuristics until that instance is itself restarted.

### Observed, not just reasoned

Neither CI nor the tests exercise the dev/packaged separation — the unit tests cover the string rule only. Same gap as the lock in #270, so the same treatment: packaged build under Xvfb, dev run started second, both pointed at the same `--user-data-dir`.

**Before** (upstream `runtime.ts`) — the dev run overwrites the packaged instance's file:

```
packaged run  → prof/agent-hooks/endpoint.env      PORT=37127
                prof-dev/agent-hooks/endpoint.env  (absent)
dev run       → prof/agent-hooks/endpoint.env      PORT=41559   ← overwritten
                prof-dev/agent-hooks/endpoint.env  (absent)
```

**After** — the packaged file is untouched:

```
packaged run  → prof/agent-hooks/endpoint.env      PORT=42473
                prof-dev/agent-hooks/endpoint.env  (absent)
dev run       → prof/agent-hooks/endpoint.env      PORT=42473   ← unchanged
                prof-dev/agent-hooks/endpoint.env  PORT=46743
```

### Packaged builds are unchanged

`resolveUserDataDir` returns its input on the first line when `isPackaged`, and `getUserDataDir()` is its only caller. All four converted sites resolve to exactly the same paths they did before in a packaged build. agent-hooks needs no migration either — `endpoint.env`, `hook.sh` and `claude-settings.json` are rewritten every launch.

### The second commit is droppable

`SaveArenaData`/`LoadArenaData` are the same slip without the silent misrouting, found while making the first fix. It is a behavior change for dev runs: `arena-presets.json` and `arena-history.json` stay with the installed build, so a dev run picks this up as an empty arena. Split out so you can drop it and keep this PR to agent-hooks.

### Checks

`npm run compile`, `npm run check:static`, `vitest run` (2216 passed / 25 skipped) and `npm run test:client` (36 passed / 6 skipped) all green.

One note in case it is useful to you beyond this PR: `npm run typecheck` and `npm run check:static` do not type-check `electron/**` — root `tsconfig.json` has `"include": ["src", "electron/ipc/channels.ts"]`, so only `npm run compile` covers the main process. I had a main-process type error passing both of the checks you used to verify #270 before I caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoJfWuU93BeL2W48mz9bC6
