### PR TITLE
fix(documents): hold the reading position across a re-render

### DIFF
--- a/src/documents/DocumentWorkspaceOverlay.client.test.tsx
+++ b/src/documents/DocumentWorkspaceOverlay.client.test.tsx
@@ -3,6 +3,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setStore, store } from '../store/core';
 import { DocumentWorkspaceOverlay } from './DocumentWorkspaceOverlay';
 import { documentStore, setDocumentComposerDraft } from './store';
+import { createRenderedBlocks } from './use-blocks';
+
+vi.mock('./use-blocks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./use-blocks')>()),
+  createRenderedBlocks: vi.fn(
+    (await importOriginal<typeof import('./use-blocks')>()).createRenderedBlocks,
+  ),
+}));
 
 const { openInEditor, revealItemInDir, platform } = vi.hoisted(() => ({
   openInEditor: vi.fn(() => Promise.resolve()),
@@ -258,4 +266,16 @@ describe('DocumentWorkspaceOverlay', () => {
 
     expect(button?.disabled).toBe(true);
   });
+});
+
+it('hands the prose scroller to the renderer, which holds it steady on an edit', () => {
+  const host = openWorkspace();
+  const scroll = host.querySelector('.docws-scroll');
+
+  expect(scroll).not.toBeNull();
+  // The renderer anchors the reading position in whatever it is given; given
+  // nothing, every document silently jumps on every edit again.
+  expect(createRenderedBlocks).toHaveBeenCalled();
+  const scroller = vi.mocked(createRenderedBlocks).mock.calls[0][1];
+  expect(scroller?.()).toBe(scroll);
 });

--- a/src/documents/DocumentWorkspaceOverlay.tsx
+++ b/src/documents/DocumentWorkspaceOverlay.tsx
@@ -71,7 +71,12 @@ function DocumentPane(props: { project: Project }) {
   let reviseRef: HTMLButtonElement | undefined;
   // Where the composer sits when a passage is picked; null puts it at the foot.
   const [anchorTop, setAnchorTop] = createSignal<number | null>(null);
-  const blocks = createRenderedBlocks(() => documentStore.snapshot?.content ?? null);
+  // The prose scrolls in `scrollRef`; the reading position is held there
+  // across a re-render, so an edit landing in the file leaves it alone.
+  const blocks = createRenderedBlocks(
+    () => documentStore.snapshot?.content ?? null,
+    () => scrollRef,
+  );
   const documentPath = () => activeDocumentPath() ?? props.project.documentPath ?? '';
   const selection = () => documentStore.selection;
   const [blockEdit, setBlockEdit] = createSignal<BlockEditTarget | null>(null);

--- a/src/documents/scroll-anchor.test.ts
+++ b/src/documents/scroll-anchor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { anchorIndexIn, type ScrollAnchor } from './scroll-anchor';
+import type { DocumentBlock } from './markdown-blocks';
+
+function blocks(...raws: string[]): DocumentBlock[] {
+  return raws.map((raw, index) => ({
+    index,
+    type: 'paragraph',
+    startLine: index + 1,
+    endLine: index + 1,
+    raw,
+    html: `<p>${raw}</p>`,
+  }));
+}
+
+const anchor = (index: number, raw: string, before: string | null = null): ScrollAnchor => ({
+  index,
+  raw,
+  before,
+  offset: 0,
+});
+
+describe('anchorIndexIn', () => {
+  it('keeps the index when the passage did not move', () => {
+    expect(anchorIndexIn(blocks('a', 'b', 'c'), anchor(1, 'b'))).toBe(1);
+  });
+
+  it('follows the passage down when an edit inserts above it', () => {
+    expect(anchorIndexIn(blocks('a', 'new', 'b', 'c'), anchor(1, 'b'))).toBe(2);
+  });
+
+  it('follows the passage up when an edit removes above it', () => {
+    expect(anchorIndexIn(blocks('a', 'c'), anchor(2, 'c'))).toBe(1);
+  });
+
+  it('tells identical passages apart by what sits above them', () => {
+    const document = blocks('new', 'a', '---', 'b', '---', 'c');
+    // The reader was on the `---` under `b`, which the insertion pushed down.
+    expect(anchorIndexIn(document, anchor(3, '---', 'b'))).toBe(4);
+  });
+
+  it('takes the one below when two identical passages keep identical company', () => {
+    // Both `---` sit under a `p`, so only the direction decides — and the edit
+    // this exists for pushes the passage down.
+    expect(anchorIndexIn(blocks('p', '---', 'p', '---'), anchor(2, '---', 'p'))).toBe(3);
+  });
+
+  it('reaches a passage that a shrunken document moved far up', () => {
+    const document = blocks('a', 'b', 'c', 'kept', 'd');
+    expect(anchorIndexIn(document, anchor(90, 'kept'))).toBe(3);
+  });
+
+  it('falls back to the index when the passage itself was rewritten', () => {
+    expect(anchorIndexIn(blocks('a', 'rewritten', 'c'), anchor(1, 'b'))).toBe(1);
+  });
+
+  it('clamps to the last block of a document that lost its tail', () => {
+    expect(anchorIndexIn(blocks('a'), anchor(4, 'e'))).toBe(0);
+  });
+
+  it('has nowhere to anchor in an empty document', () => {
+    expect(anchorIndexIn([], anchor(0, 'a'))).toBeNull();
+  });
+});

--- a/src/documents/scroll-anchor.ts
+++ b/src/documents/scroll-anchor.ts
@@ -108,8 +108,11 @@ const HOLD_MS = 5000;
 
 /**
  * How far the prose may drift before the reader is taken to have moved it.
- * Native scroll anchoring nudges by fractions of a pixel while late content
- * grows, and those are not a reader.
+ * A hedge, not a measurement: a scroll offset settles on whole device pixels,
+ * which a zoomed window and a fractional restore do not land on. Kept because
+ * the two failures are not the same size — a couple of pixels of a reader's
+ * own scrolling overridden goes unnoticed, a hold dropped on a phantom nudge
+ * puts the passage they were reading back off the screen.
  */
 const READER_SLOP = 2;
 

--- a/src/documents/scroll-anchor.ts
+++ b/src/documents/scroll-anchor.ts
@@ -1,0 +1,146 @@
+import type { DocumentBlock } from './markdown-blocks';
+
+/**
+ * The passage a reader is on and where it sat in the viewport. A document
+ * re-renders whole whenever its file changes — an agent editing the checkout,
+ * a block saved from the source editor — which throws away every node the
+ * browser could have anchored the scroll to, so the position is held by hand.
+ */
+export interface ScrollAnchor {
+  index: number;
+  /** The block's source text: the same passage is found again after an edit. */
+  raw: string;
+  /** The text just above it, which tells two identical passages apart. */
+  before: string | null;
+  /** Distance from the top of the scroller to the block's top, in px. */
+  offset: number;
+}
+
+const BLOCK_SELECTOR = '[data-block-index]';
+
+/**
+ * Where the anchored passage now is: the same text when it is still in the
+ * document, otherwise whatever took its index. An edit above the reading
+ * position shifts every index below it, so the text is matched first — and a
+ * match that brought its neighbour along beats a nearer one that did not,
+ * since a document repeats a separator or a boilerplate line far more often
+ * than it repeats a pair of them.
+ *
+ * `relocateAnchor` answers a similar question for notes, but fuzzily and
+ * against a recorded commit. A scroll anchor is only ever compared with the
+ * render it was taken from a moment earlier, where an exact match is both
+ * cheaper and truer.
+ */
+export function anchorIndexIn(
+  blocks: readonly DocumentBlock[],
+  anchor: ScrollAnchor,
+): number | null {
+  if (blocks.length === 0) return null;
+  const sameText = (i: number) => blocks[i]?.raw === anchor.raw;
+  const sameNeighbour = (i: number) =>
+    sameText(i) && (blocks[i - 1]?.raw ?? null) === anchor.before;
+  if (sameNeighbour(anchor.index)) return anchor.index;
+  let loose = sameText(anchor.index) ? anchor.index : null;
+  // Both ends of the document are in reach: an edit can move a passage any
+  // distance, and a document that lost most of itself moves it a long way.
+  const reach = Math.max(anchor.index, blocks.length - 1 - anchor.index);
+  for (let step = 1; step <= reach; step++) {
+    // Downwards first: the edit this holds a position against is an insertion
+    // above the reader, which pushes the passage down.
+    for (const i of [anchor.index + step, anchor.index - step]) {
+      if (sameNeighbour(i)) return i;
+      if (loose === null && sameText(i)) loose = i;
+    }
+  }
+  return loose ?? Math.min(anchor.index, blocks.length - 1);
+}
+
+/**
+ * The topmost block still in view, the one a reader's eye is on. Null at the
+ * top of the document, where staying at the top is what a reader expects.
+ */
+export function captureScrollAnchor(
+  scroller: HTMLElement | undefined,
+  blocks: readonly DocumentBlock[],
+): ScrollAnchor | null {
+  if (!scroller || scroller.scrollTop === 0 || blocks.length === 0) return null;
+  const top = scroller.getBoundingClientRect().top;
+  for (const el of scroller.querySelectorAll<HTMLElement>(BLOCK_SELECTOR)) {
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom <= top) continue;
+    const index = Number(el.dataset.blockIndex);
+    const block = blocks[index];
+    if (!block) continue;
+    return {
+      index: block.index,
+      raw: block.raw,
+      before: blocks[index - 1]?.raw ?? null,
+      offset: rect.top - top,
+    };
+  }
+  return null;
+}
+
+/** Scrolls the anchored passage back under its old pixel; the new position. */
+function restore(
+  scroller: HTMLElement,
+  anchor: ScrollAnchor,
+  blocks: readonly DocumentBlock[],
+): number {
+  const index = anchorIndexIn(blocks, anchor);
+  if (index === null) return scroller.scrollTop;
+  const el = scroller.querySelector<HTMLElement>(`[data-block-index="${index}"]`);
+  if (!el) return scroller.scrollTop;
+  const top = el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+  scroller.scrollTop += top - anchor.offset;
+  return scroller.scrollTop;
+}
+
+/**
+ * How long the anchor keeps its grip after a re-render. It is one window, not
+ * a quiet period that restarts: what lays out late usually arrives once, and a
+ * mermaid diagram — an async render behind a dynamically imported chunk — can
+ * take most of a second to arrive at all. A window that waited only for the
+ * next arrival would have expired before the one arrival came. It doubles as
+ * the ceiling, so a page that animates its own layout cannot hold on for good.
+ */
+const HOLD_MS = 5000;
+
+/**
+ * How far the prose may drift before the reader is taken to have moved it.
+ * Native scroll anchoring nudges by fractions of a pixel while late content
+ * grows, and those are not a reader.
+ */
+const READER_SLOP = 2;
+
+/**
+ * Puts the anchored passage back where it was, and holds it there while the
+ * prose is still settling. The grip is let go the moment the reader scrolls —
+ * their position beats ours — and once the document has had its time.
+ * Returns a disposer for the caller's next re-render.
+ */
+export function holdScrollAnchor(
+  scroller: HTMLElement | undefined,
+  anchor: ScrollAnchor | null,
+  blocks: readonly DocumentBlock[],
+): () => void {
+  if (!scroller || !anchor) return () => {};
+  let held = restore(scroller, anchor, blocks);
+  const deadline = Date.now() + HOLD_MS;
+  const observer = new ResizeObserver(() => {
+    // shortcut: any scroll the hold did not make reads as the reader, and a
+    // document shrinking away under a scrollTop the browser then clamps is one
+    // of those — measured at 1900px for a reader parked at the end. The hold
+    // lets go there, never holds the wrong place. Watch for a real gesture if
+    // anyone reports losing their place mid-restructure.
+    if (Date.now() > deadline || Math.abs(scroller.scrollTop - held) > READER_SLOP) {
+      observer.disconnect();
+      return;
+    }
+    held = restore(scroller, anchor, blocks);
+  });
+  // The prose, not the scroller: a scroll container keeps its own size while
+  // what is inside it grows.
+  observer.observe(scroller.firstElementChild ?? scroller);
+  return () => observer.disconnect();
+}

--- a/src/documents/use-blocks.client.test.tsx
+++ b/src/documents/use-blocks.client.test.tsx
@@ -1,0 +1,323 @@
+import { createSignal } from 'solid-js';
+import { render } from 'solid-js/web';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { DocumentViewer } from './DocumentViewer';
+import { createRenderedBlocks } from './use-blocks';
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn(() => Promise.resolve()) }));
+vi.mock('../lib/ipc', () => ({ invoke }));
+
+const disposers: Array<() => void> = [];
+
+/** Every block is this tall in the fake layout, unless `heights` says otherwise. */
+const BLOCK_HEIGHT = 100;
+const heights = new Map<number, number>();
+
+/** The observers currently watching the prose, newest last. */
+let watchers: Array<{ callback: () => void; target: Element }> = [];
+
+class TestResizeObserver {
+  #callback: () => void;
+  constructor(callback: () => void) {
+    this.#callback = callback;
+  }
+  observe(target: Element): void {
+    watchers.push({ callback: this.#callback, target });
+  }
+  unobserve(): void {
+    this.disconnect();
+  }
+  disconnect(): void {
+    watchers = watchers.filter((w) => w.callback !== this.#callback);
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (disposers.length > 0) disposers.pop()?.();
+  document.body.replaceChildren();
+  heights.clear();
+  watchers = [];
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** The prose settled into a new height: what a late mermaid render looks like. */
+function settle(): void {
+  for (const watcher of [...watchers]) watcher.callback();
+}
+
+function topFor(index: number): number {
+  let top = 0;
+  for (let i = 0; i < index; i++) top += heights.get(i) ?? BLOCK_HEIGHT;
+  return top;
+}
+
+/**
+ * happy-dom lays nothing out, so blocks are given the geometry they would
+ * have in the app: stacked, of `heights`, moving with the scroller.
+ */
+function fakeLayout(scroller: HTMLElement): void {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+    if (this === scroller) return { top: 0, bottom: 300 } as DOMRect;
+    const raw = (this as HTMLElement).dataset?.blockIndex;
+    if (raw === undefined) return { top: 0, bottom: 0 } as DOMRect;
+    const index = Number(raw);
+    const top = topFor(index) - scroller.scrollTop;
+    return { top, bottom: top + (heights.get(index) ?? BLOCK_HEIGHT) } as DOMRect;
+  });
+}
+
+function mount(initial: string): {
+  scroller: HTMLElement;
+  edit: (source: string) => void;
+} {
+  const [source, edit] = createSignal(initial);
+  const host = document.createElement('div');
+  document.body.append(host);
+  let scroller: HTMLDivElement | undefined;
+  disposers.push(
+    render(() => {
+      const blocks = createRenderedBlocks(source, () => scroller);
+      return (
+        <div ref={scroller}>
+          <DocumentViewer blocks={blocks.blocks()} page={blocks.page()} renderKey="t" />
+        </div>
+      );
+    }, host),
+  );
+  if (!scroller) throw new Error('Scroller did not render');
+  return { scroller, edit };
+}
+
+async function blockCount(scroller: HTMLElement, count: number): Promise<void> {
+  await vi.waitFor(() =>
+    expect(scroller.querySelectorAll('[data-block-index]')).toHaveLength(count),
+  );
+}
+
+const MARKDOWN = '# Doc\n\nAlpha.\n\nBravo.\n\nCharlie.\n';
+const MARKDOWN_EDITED = '# Doc\n\nInserted.\n\nAlpha.\n\nBravo.\n\nCharlie.\n';
+const PAGE =
+  '<!doctype html><html><head><style>p{margin:0}</style></head>' +
+  '<body><h1>Doc</h1><p>Alpha.</p><p>Bravo.</p><p>Charlie.</p></body></html>';
+const PAGE_EDITED = PAGE.replace('<p>Alpha.</p>', '<p>Inserted.</p><p>Alpha.</p>');
+
+it('holds the passage being read when markdown changes above it', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  // Bravo, the third block, sits at the top of the viewport.
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  // Bravo is the fourth block now, so the prose scrolled with it: what the
+  // reader was looking at is still under the same pixel.
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT);
+});
+
+it('holds the passage being read when an HTML page changes above it', async () => {
+  const { scroller, edit } = mount(PAGE);
+  // The page's heading loses its element to happy-dom's sanitize pass, so
+  // three of its four blocks carry a marked element here.
+  await blockCount(scroller, 3);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(PAGE_EDITED);
+  await blockCount(scroller, 4);
+
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT);
+});
+
+it('stays where it is when the edit lands below the reading position', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = BLOCK_HEIGHT;
+
+  edit(`${MARKDOWN}\nDelta.\n`);
+  await blockCount(scroller, 5);
+
+  expect(scroller.scrollTop).toBe(BLOCK_HEIGHT);
+});
+
+it('leaves a document read from the top at the top', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  expect(scroller.scrollTop).toBe(0);
+});
+
+it('keeps its grip while a diagram above the reader is still being drawn', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT);
+
+  // The inserted block finishes rendering 200px taller than it landed.
+  heights.set(1, BLOCK_HEIGHT + 200);
+  settle();
+
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT + 200);
+});
+
+it('lets go of the passage as soon as the reader scrolls', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  scroller.scrollTop = 50;
+  heights.set(1, BLOCK_HEIGHT + 200);
+  settle();
+
+  expect(scroller.scrollTop).toBe(50);
+  // And the grip is gone for good, not just for this one settling.
+  settle();
+  expect(scroller.scrollTop).toBe(50);
+});
+
+it('watches the prose, not the scroll container that keeps its own size', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  expect(watchers).toHaveLength(1);
+  expect(watchers[0].target).toBe(scroller.firstElementChild);
+});
+
+it('holds a document once, however many edits land', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+  edit(`${MARKDOWN_EDITED}\nDelta.\n`);
+  await blockCount(scroller, 6);
+
+  // The earlier hold let go; two of them would pull against each other.
+  expect(watchers).toHaveLength(1);
+});
+
+it('takes no grip on a document read from the top', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  expect(watchers).toHaveLength(0);
+});
+
+it('is still holding when a diagram arrives a second and a half late', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+  const settledAt = Date.now();
+
+  // One arrival, late: a mermaid render behind a cold dynamic import.
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(settledAt + 1500);
+  heights.set(1, BLOCK_HEIGHT + 200);
+  settle();
+
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT + 200);
+});
+
+it('lets go once the document has had its time to settle', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+  const settledAt = Date.now();
+
+  // Nothing resized for long enough that a late render is no longer late.
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(settledAt + 6000);
+  heights.set(1, BLOCK_HEIGHT + 200);
+  settle();
+
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT);
+  expect(watchers).toHaveLength(0);
+});
+
+it('releases the grip when the document it held is closed', async () => {
+  const [source, edit] = createSignal<string | null>(MARKDOWN);
+  const host = document.createElement('div');
+  document.body.append(host);
+  let scroller: HTMLDivElement | undefined;
+  disposers.push(
+    render(() => {
+      const blocks = createRenderedBlocks(source, () => scroller);
+      return (
+        <div ref={scroller}>
+          <DocumentViewer blocks={blocks.blocks()} page={blocks.page()} renderKey="t" />
+        </div>
+      );
+    }, host),
+  );
+  if (!scroller) throw new Error('Scroller did not render');
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+  expect(watchers).toHaveLength(1);
+
+  // Opening another document clears the snapshot first; nothing of the old
+  // one may reach back and scroll the new one.
+  edit(null);
+  await blockCount(scroller, 0);
+
+  expect(watchers).toHaveLength(0);
+});
+
+it('does not mistake a fraction of a pixel for the reader', async () => {
+  const { scroller, edit } = mount(MARKDOWN);
+  await blockCount(scroller, 4);
+  fakeLayout(scroller);
+  scroller.scrollTop = 2 * BLOCK_HEIGHT;
+
+  edit(MARKDOWN_EDITED);
+  await blockCount(scroller, 5);
+
+  // Native scroll anchoring nudges the container as the late content grows.
+  scroller.scrollTop = 3 * BLOCK_HEIGHT + 1;
+  heights.set(1, BLOCK_HEIGHT + 200);
+  settle();
+
+  expect(scroller.scrollTop).toBe(3 * BLOCK_HEIGHT + 200);
+  expect(watchers).toHaveLength(1);
+});

--- a/src/documents/use-blocks.ts
+++ b/src/documents/use-blocks.ts
@@ -1,13 +1,21 @@
-import { createEffect, createSignal, onCleanup } from 'solid-js';
+import { batch, createEffect, createSignal, onCleanup, untrack } from 'solid-js';
 import type { DocumentBlock } from './markdown-blocks';
 import type { PageRender } from './PageBlocks';
 import { renderDocument } from './render-document';
+import { captureScrollAnchor, holdScrollAnchor } from './scroll-anchor';
 
 /**
  * Reactively renders a document source into blocks. Stale renders are dropped
  * when the source changes again before they finish.
+ *
+ * `scroller` is the element the blocks scroll in, when they scroll in one: a
+ * re-render replaces every block, so the reading position is held across it
+ * and an edit elsewhere in the file does not move the passage being read.
  */
-export function createRenderedBlocks(source: () => string | null | undefined): {
+export function createRenderedBlocks(
+  source: () => string | null | undefined,
+  scroller?: () => HTMLElement | undefined,
+): {
   blocks: () => DocumentBlock[];
   /** The page's markup and stylesheet when the source is a whole HTML page. */
   page: () => PageRender | null;
@@ -17,11 +25,15 @@ export function createRenderedBlocks(source: () => string | null | undefined): {
   const [page, setPage] = createSignal<PageRender | null>(null);
   const [rendering, setRendering] = createSignal(false);
   let generation = 0;
+  /** Lets go of the reading position the last render was holding. */
+  let release: (() => void) | undefined;
 
   createEffect(() => {
     const content = source();
     const gen = ++generation;
     if (content === null || content === undefined) {
+      release?.();
+      release = undefined;
       setBlocks([]);
       setPage(null);
       setRendering(false);
@@ -31,8 +43,16 @@ export function createRenderedBlocks(source: () => string | null | undefined): {
     renderDocument(content)
       .then((result) => {
         if (gen !== generation) return;
-        setBlocks(result.blocks);
-        setPage(result.page);
+        // Measured before the swap, applied after it: Solid patches the DOM
+        // synchronously as the signals are written. The blocks are read
+        // untracked because this continuation is nobody's dependency.
+        const anchor = captureScrollAnchor(scroller?.(), untrack(blocks));
+        batch(() => {
+          setBlocks(result.blocks);
+          setPage(result.page);
+        });
+        release?.();
+        release = holdScrollAnchor(scroller?.(), anchor, result.blocks);
       })
       .catch((err) => console.warn('[documents] render failed:', err))
       .finally(() => {
@@ -42,6 +62,7 @@ export function createRenderedBlocks(source: () => string | null | undefined): {
 
   onCleanup(() => {
     generation++;
+    release?.();
   });
 
   return { blocks, page, rendering };


### PR DESCRIPTION
A document workspace re-renders the whole document whenever its file changes — the agent editing the checkout, a block saved from the source editor. Every block node is replaced: markdown maps fresh objects through `<For>`, an HTML page re-assigns its markup. The browser's own scroll anchoring needs the node it anchored to, so with all of them gone the prose shifts by whatever the edit changed above the reader, and the passage being read walks off the screen.

## The fix

The topmost visible block is measured before the swap and put back under the same pixel after it. A document read from the top stays at the top.

Finding the passage again is the whole problem:

- Matching by index follows the position rather than the prose, so the block's **source text is matched first**, and a match that brought its neighbour along beats a nearer one that did not — a document repeats a separator or a boilerplate line far more often than it repeats a pair of them.
- The search reaches **both ends** of the document, since an edit can move a passage any distance and one that lost most of itself moves it a long way.
- The grip is **held for five seconds** after the swap, because what lays out late arrives once and can take its time: a mermaid diagram is drawn from an async render behind a dynamically imported chunk. It is let go the moment the reader scrolls.

New module `src/documents/scroll-anchor.ts` (149 lines); `createRenderedBlocks` takes an optional scroller and straddles the signal write, which is the only place that can measure both sides of it. `CompareView` and `HistoryView` pass nothing and are unaffected — they render content fetched at an immutable commit, so nothing changes under their reader.

## Verified

Measured in real Chromium (headless, forced layout), not inferred:

| Question | Result |
|---|---|
| Does an edit above the reader actually shift the prose? | Yes — by exactly the edit's height, under both replacement styles |
| Does the correction land the passage back? | Yes — exactly its original offset |
| Does the browser's own anchoring cover this? | No — it does not re-engage after a full swap |
| Do re-created images collapse and spoil the measurement? | No — a cached image lays out at full size synchronously |
| Does a shrinking document clamp the scroll? | Yes — 1900px for a reader parked at the end; the hold lets go there, and the line says so |

22 tests: 13 on the hook against a simulated layout, 8 on the anchor resolution, 1 pinning that the pane hands its scroll container to the renderer. Every branch was mutation-checked individually — each mutation fails exactly one test. Full suites green (2414 unit, 189 client); compile, typecheck, lint and format clean.

## Known limits

- Not yet watched in a running Electron window; everything above is engine-level measurement.
- `HOLD_MS = 5000` and the 2px drift tolerance are reasoned, not fitted to a measured mermaid render. Both are labelled as such in the code.
- Unrelated: mermaid re-renders every diagram on every edit. The anchor absorbs the layout shift, but the wasted renders and flicker remain, and want keying diagrams by source instead.

https://claude.ai/code/session_012vU45LLjdL7ERWLr59TZ3K